### PR TITLE
fix: enable window dragging for MiniWindow and FixedWindow

### DIFF
--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
@@ -19,8 +19,8 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <!-- Header with Close button (no Pin - always on top) -->
-        <Grid Grid.Row="0" Margin="0,0,0,4">
+        <!-- Header with Close button (no Pin - always on top) - also serves as drag region -->
+        <Grid x:Name="TitleBarRegion" Grid.Row="0" Margin="0,0,0,4" Background="Transparent">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -102,6 +102,9 @@ public sealed partial class FixedWindow : Window
         _appWindow.TitleBar.ExtendsContentIntoTitleBar = true;
         _appWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
 
+        // Set the header grid as the draggable title bar region
+        this.SetTitleBar(TitleBarRegion);
+
         // Set window size from Fixed Window settings
         var scale = DpiHelper.GetScaleFactorForWindow(WindowNative.GetWindowHandle(this));
         var widthPx = DpiHelper.DipsToPhysicalPixels(_settings.FixedWindowWidthDips, scale);

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -19,8 +19,8 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <!-- Header with Pin and Close buttons -->
-        <Grid Grid.Row="0" Margin="0,0,0,4">
+        <!-- Header with Pin and Close buttons - also serves as drag region -->
+        <Grid x:Name="TitleBarRegion" Grid.Row="0" Margin="0,0,0,4" Background="Transparent">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -103,6 +103,9 @@ public sealed partial class MiniWindow : Window
         _appWindow.TitleBar.ExtendsContentIntoTitleBar = true;
         _appWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
 
+        // Set the header grid as the draggable title bar region
+        this.SetTitleBar(TitleBarRegion);
+
         // Set window size
         var scale = DpiHelper.GetScaleFactorForWindow(WindowNative.GetWindowHandle(this));
         var widthPx = DpiHelper.DipsToPhysicalPixels(_settings.MiniWindowWidthDips, scale);


### PR DESCRIPTION
Both windows had extended content into the title bar area but were missing the SetTitleBar() call to designate the header grid as the draggable region. This adds x:Name="TitleBarRegion" to the header grids and calls SetTitleBar() to enable mouse dragging.