### PR TITLE
feat: expose all translation service configurations in Settings

### DIFF
--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -140,12 +140,14 @@
                         <PasswordBox x:Name="OpenAIKeyBox" Header="API Key" Width="350" PlaceholderText="sk-..." HorizontalAlignment="Left" />
                         <TextBox x:Name="OpenAIEndpointBox" Header="Endpoint (Optional)" Width="450"
                                  PlaceholderText="https://api.openai.com/v1/chat/completions" HorizontalAlignment="Left" />
-                        <ComboBox x:Name="OpenAIModelCombo" Header="Model" Width="200">
+                        <ComboBox x:Name="OpenAIModelCombo" Header="Model" Width="280" IsEditable="True">
                             <ComboBoxItem Content="gpt-4o-mini" Tag="gpt-4o-mini" />
                             <ComboBoxItem Content="gpt-4o" Tag="gpt-4o" />
                             <ComboBoxItem Content="gpt-4-turbo" Tag="gpt-4-turbo" />
                             <ComboBoxItem Content="gpt-3.5-turbo" Tag="gpt-3.5-turbo" />
                         </ComboBox>
+                        <TextBlock Text="You can type a custom model name directly."
+                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
                 </Expander>
 
@@ -156,12 +158,12 @@
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="0,8">
                         <PasswordBox x:Name="DeepSeekKeyBox" Header="API Key" Width="350" PlaceholderText="sk-..." HorizontalAlignment="Left" />
-                        <ComboBox x:Name="DeepSeekModelCombo" Header="Model" Width="200">
+                        <ComboBox x:Name="DeepSeekModelCombo" Header="Model" Width="280" IsEditable="True">
                             <ComboBoxItem Content="deepseek-chat" Tag="deepseek-chat" />
                             <ComboBoxItem Content="deepseek-reasoner" Tag="deepseek-reasoner" />
                         </ComboBox>
-                        <TextBlock Text="Get your API key from platform.deepseek.com"
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <TextBlock Text="Get your API key from platform.deepseek.com. You can type a custom model name."
+                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>
                 </Expander>
 
@@ -172,14 +174,14 @@
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="0,8">
                         <PasswordBox x:Name="GroqKeyBox" Header="API Key" Width="350" PlaceholderText="gsk_..." HorizontalAlignment="Left" />
-                        <ComboBox x:Name="GroqModelCombo" Header="Model" Width="250">
+                        <ComboBox x:Name="GroqModelCombo" Header="Model" Width="280" IsEditable="True">
                             <ComboBoxItem Content="llama-3.3-70b-versatile" Tag="llama-3.3-70b-versatile" />
                             <ComboBoxItem Content="llama-3.1-8b-instant" Tag="llama-3.1-8b-instant" />
                             <ComboBoxItem Content="gemma2-9b-it" Tag="gemma2-9b-it" />
                             <ComboBoxItem Content="mixtral-8x7b-32768" Tag="mixtral-8x7b-32768" />
                         </ComboBox>
-                        <TextBlock Text="Groq provides fast inference. Get your API key from console.groq.com"
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <TextBlock Text="Groq provides fast inference. Get your API key from console.groq.com. You can type a custom model name."
+                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>
                 </Expander>
 
@@ -190,14 +192,14 @@
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="0,8">
                         <PasswordBox x:Name="ZhipuKeyBox" Header="API Key" Width="350" PlaceholderText="Enter your Zhipu API key" HorizontalAlignment="Left" />
-                        <ComboBox x:Name="ZhipuModelCombo" Header="Model" Width="200">
+                        <ComboBox x:Name="ZhipuModelCombo" Header="Model" Width="280" IsEditable="True">
                             <ComboBoxItem Content="glm-4-flash-250414" Tag="glm-4-flash-250414" />
                             <ComboBoxItem Content="glm-4.5-flash" Tag="glm-4.5-flash" />
                             <ComboBoxItem Content="glm-4.7" Tag="glm-4.7" />
                             <ComboBoxItem Content="glm-4.5-air" Tag="glm-4.5-air" />
                         </ComboBox>
-                        <TextBlock Text="Get your API key from open.bigmodel.cn"
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <TextBlock Text="Get your API key from open.bigmodel.cn. You can type a custom model name."
+                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>
                 </Expander>
 
@@ -208,7 +210,7 @@
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="0,8">
                         <PasswordBox x:Name="GitHubModelsTokenBox" Header="GitHub Token" Width="350" PlaceholderText="ghp_..." HorizontalAlignment="Left" />
-                        <ComboBox x:Name="GitHubModelsModelCombo" Header="Model" Width="200">
+                        <ComboBox x:Name="GitHubModelsModelCombo" Header="Model" Width="280" IsEditable="True">
                             <ComboBoxItem Content="gpt-4.1" Tag="gpt-4.1" />
                             <ComboBoxItem Content="gpt-4.1-mini" Tag="gpt-4.1-mini" />
                             <ComboBoxItem Content="gpt-4.1-nano" Tag="gpt-4.1-nano" />
@@ -216,7 +218,7 @@
                             <ComboBoxItem Content="gpt-4o-mini" Tag="gpt-4o-mini" />
                             <ComboBoxItem Content="deepseek-v3-0324" Tag="deepseek-v3-0324" />
                         </ComboBox>
-                        <TextBlock Text="Use your GitHub personal access token. Get one from github.com/settings/tokens"
+                        <TextBlock Text="Use your GitHub personal access token. Get one from github.com/settings/tokens. You can type a custom model name."
                                    FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>
                 </Expander>
@@ -228,16 +230,18 @@
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="0,8">
                         <PasswordBox x:Name="GeminiKeyBox" Header="API Key" Width="350" PlaceholderText="Enter your Gemini API key" HorizontalAlignment="Left" />
-                        <ComboBox x:Name="GeminiModelCombo" Header="Model" Width="250">
+                        <ComboBox x:Name="GeminiModelCombo" Header="Model" Width="280" IsEditable="True">
                             <ComboBoxItem Content="gemini-2.5-flash" Tag="gemini-2.5-flash" />
                             <ComboBoxItem Content="gemini-2.5-flash-lite" Tag="gemini-2.5-flash-lite" />
                             <ComboBoxItem Content="gemini-2.5-pro" Tag="gemini-2.5-pro" />
                             <ComboBoxItem Content="gemini-2.0-flash" Tag="gemini-2.0-flash" />
                             <ComboBoxItem Content="gemini-1.5-flash" Tag="gemini-1.5-flash" />
                             <ComboBoxItem Content="gemini-1.5-pro" Tag="gemini-1.5-pro" />
+                            <ComboBoxItem Content="gemini-3-flash-preview" Tag="gemini-3-flash-preview" />
+                            <ComboBoxItem Content="gemini-3-pro-preview" Tag="gemini-3-pro-preview" />
                         </ComboBox>
-                        <TextBlock Text="Get your API key from aistudio.google.com"
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <TextBlock Text="Get your API key from aistudio.google.com. You can type a custom model name."
+                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>
                 </Expander>
 
@@ -281,12 +285,14 @@
                         <TextBlock Text="Built-in AI" FontWeight="SemiBold" />
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="0,8">
-                        <ComboBox x:Name="BuiltInModelCombo" Header="Model" Width="250">
+                        <ComboBox x:Name="BuiltInModelCombo" Header="Model" Width="280" IsEditable="True">
                             <ComboBoxItem Content="llama-3.3-70b-versatile" Tag="llama-3.3-70b-versatile" />
                             <ComboBoxItem Content="llama-3.1-8b-instant" Tag="llama-3.1-8b-instant" />
+                            <ComboBoxItem Content="gemma2-9b-it" Tag="gemma2-9b-it" />
+                            <ComboBoxItem Content="mixtral-8x7b-32768" Tag="mixtral-8x7b-32768" />
                         </ComboBox>
-                        <TextBlock Text="Built-in AI uses Groq cloud service. No API key required."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <TextBlock Text="Built-in AI uses Groq cloud service. No API key required. You can type a custom model name."
+                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>
                 </Expander>
 

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -110,27 +110,27 @@ public sealed partial class SettingsPage : Page
         // OpenAI settings
         OpenAIKeyBox.Password = _settings.OpenAIApiKey ?? string.Empty;
         OpenAIEndpointBox.Text = _settings.OpenAIEndpoint;
-        SelectComboByTag(OpenAIModelCombo, _settings.OpenAIModel);
+        SetEditableComboValue(OpenAIModelCombo, _settings.OpenAIModel);
 
         // DeepSeek settings
         DeepSeekKeyBox.Password = _settings.DeepSeekApiKey ?? string.Empty;
-        SelectComboByTag(DeepSeekModelCombo, _settings.DeepSeekModel);
+        SetEditableComboValue(DeepSeekModelCombo, _settings.DeepSeekModel);
 
         // Groq settings
         GroqKeyBox.Password = _settings.GroqApiKey ?? string.Empty;
-        SelectComboByTag(GroqModelCombo, _settings.GroqModel);
+        SetEditableComboValue(GroqModelCombo, _settings.GroqModel);
 
         // Zhipu settings
         ZhipuKeyBox.Password = _settings.ZhipuApiKey ?? string.Empty;
-        SelectComboByTag(ZhipuModelCombo, _settings.ZhipuModel);
+        SetEditableComboValue(ZhipuModelCombo, _settings.ZhipuModel);
 
         // GitHub Models settings
         GitHubModelsTokenBox.Password = _settings.GitHubModelsToken ?? string.Empty;
-        SelectComboByTag(GitHubModelsModelCombo, _settings.GitHubModelsModel);
+        SetEditableComboValue(GitHubModelsModelCombo, _settings.GitHubModelsModel);
 
         // Gemini settings
         GeminiKeyBox.Password = _settings.GeminiApiKey ?? string.Empty;
-        SelectComboByTag(GeminiModelCombo, _settings.GeminiModel);
+        SetEditableComboValue(GeminiModelCombo, _settings.GeminiModel);
 
         // Custom OpenAI settings
         CustomOpenAIEndpointBox.Text = _settings.CustomOpenAIEndpoint;
@@ -142,7 +142,7 @@ public sealed partial class SettingsPage : Page
         OllamaModelCombo.Text = _settings.OllamaModel;
 
         // Built-in AI settings
-        SelectComboByTag(BuiltInModelCombo, _settings.BuiltInAIModel);
+        SetEditableComboValue(BuiltInModelCombo, _settings.BuiltInAIModel);
 
         // Doubao settings
         DoubaoKeyBox.Password = _settings.DoubaoApiKey ?? string.Empty;
@@ -192,6 +192,45 @@ public sealed partial class SettingsPage : Page
             return item.Tag?.ToString();
         }
         return null;
+    }
+
+    /// <summary>
+    /// Gets the value from an editable ComboBox. Returns the typed text if available,
+    /// otherwise returns the selected item's tag.
+    /// </summary>
+    private static string GetEditableComboValue(ComboBox combo, string defaultValue)
+    {
+        // For editable ComboBox, prefer Text (user-typed value)
+        var text = combo.Text?.Trim();
+        if (!string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+        // Fall back to selected item's tag
+        if (combo.SelectedItem is ComboBoxItem item && item.Tag != null)
+        {
+            return item.Tag.ToString() ?? defaultValue;
+        }
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Sets the value for an editable ComboBox. If the value matches a dropdown item,
+    /// selects it. Otherwise, sets the Text property for custom values.
+    /// </summary>
+    private static void SetEditableComboValue(ComboBox combo, string value)
+    {
+        // Try to find matching item in dropdown
+        for (int i = 0; i < combo.Items.Count; i++)
+        {
+            if (combo.Items[i] is ComboBoxItem item && item.Tag?.ToString() == value)
+            {
+                combo.SelectedIndex = i;
+                return;
+            }
+        }
+        // Custom value - set Text directly
+        combo.Text = value;
     }
 
     private void OnBackClick(object sender, RoutedEventArgs e)
@@ -247,32 +286,32 @@ public sealed partial class SettingsPage : Page
         _settings.OpenAIEndpoint = string.IsNullOrWhiteSpace(openAIEndpoint)
             ? "https://api.openai.com/v1/chat/completions"
             : openAIEndpoint;
-        _settings.OpenAIModel = GetSelectedTag(OpenAIModelCombo) ?? "gpt-4o-mini";
+        _settings.OpenAIModel = GetEditableComboValue(OpenAIModelCombo, "gpt-4o-mini");
 
         // Save DeepSeek settings
         var deepSeekKey = DeepSeekKeyBox.Password;
         _settings.DeepSeekApiKey = string.IsNullOrWhiteSpace(deepSeekKey) ? null : deepSeekKey;
-        _settings.DeepSeekModel = GetSelectedTag(DeepSeekModelCombo) ?? "deepseek-chat";
+        _settings.DeepSeekModel = GetEditableComboValue(DeepSeekModelCombo, "deepseek-chat");
 
         // Save Groq settings
         var groqKey = GroqKeyBox.Password;
         _settings.GroqApiKey = string.IsNullOrWhiteSpace(groqKey) ? null : groqKey;
-        _settings.GroqModel = GetSelectedTag(GroqModelCombo) ?? "llama-3.3-70b-versatile";
+        _settings.GroqModel = GetEditableComboValue(GroqModelCombo, "llama-3.3-70b-versatile");
 
         // Save Zhipu settings
         var zhipuKey = ZhipuKeyBox.Password;
         _settings.ZhipuApiKey = string.IsNullOrWhiteSpace(zhipuKey) ? null : zhipuKey;
-        _settings.ZhipuModel = GetSelectedTag(ZhipuModelCombo) ?? "glm-4-flash-250414";
+        _settings.ZhipuModel = GetEditableComboValue(ZhipuModelCombo, "glm-4-flash-250414");
 
         // Save GitHub Models settings
         var githubToken = GitHubModelsTokenBox.Password;
         _settings.GitHubModelsToken = string.IsNullOrWhiteSpace(githubToken) ? null : githubToken;
-        _settings.GitHubModelsModel = GetSelectedTag(GitHubModelsModelCombo) ?? "gpt-4.1";
+        _settings.GitHubModelsModel = GetEditableComboValue(GitHubModelsModelCombo, "gpt-4.1");
 
         // Save Gemini settings
         var geminiKey = GeminiKeyBox.Password;
         _settings.GeminiApiKey = string.IsNullOrWhiteSpace(geminiKey) ? null : geminiKey;
-        _settings.GeminiModel = GetSelectedTag(GeminiModelCombo) ?? "gemini-2.5-flash";
+        _settings.GeminiModel = GetEditableComboValue(GeminiModelCombo, "gemini-2.5-flash");
 
         // Save Custom OpenAI settings
         var customEndpoint = CustomOpenAIEndpointBox.Text?.Trim() ?? "";
@@ -290,7 +329,7 @@ public sealed partial class SettingsPage : Page
         _settings.OllamaModel = OllamaModelCombo.Text?.Trim() ?? "llama3.2";
 
         // Save Built-in AI settings
-        _settings.BuiltInAIModel = GetSelectedTag(BuiltInModelCombo) ?? "llama-3.3-70b-versatile";
+        _settings.BuiltInAIModel = GetEditableComboValue(BuiltInModelCombo, "llama-3.3-70b-versatile");
 
         // Save Doubao settings
         var doubaoKey = DoubaoKeyBox.Password;


### PR DESCRIPTION
- Add all 15 translation services to Default Service dropdown
- Create Service Configuration section with Expander controls
- Expose settings for: DeepSeek, Groq, Zhipu, GitHub Models, Gemini,
  Custom OpenAI, Doubao, Caiyun, NiuTrans
- Each service shows API key, model selection, and endpoint where applicable
- Add helpful hints with links to get API keys
- Organize services using collapsible Expander controls for cleaner UI
- Free services (Google, Linguee) noted as requiring no configuration