### PR TITLE
Improve dark mode with blue-tinted palette and theme-aware colors

### DIFF
--- a/dotnet/src/Easydict.WinUI/App.xaml
+++ b/dotnet/src/Easydict.WinUI/App.xaml
@@ -15,14 +15,7 @@
                 <ResourceDictionary Source="Themes/Colors.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- Accent Colors -->
-            <Color x:Key="AccentColor">#0078D4</Color>
-            <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
-
-            <!-- Status Colors -->
-            <SolidColorBrush x:Key="StatusConnectedBrush" Color="#107C10" />
-            <SolidColorBrush x:Key="StatusDisconnectedBrush" Color="#797775" />
-            <SolidColorBrush x:Key="StatusErrorBrush" Color="#D13438" />
+            <!-- Accent and Status Colors are now theme-aware via Themes/Colors.xaml -->
 
             <!-- Card Style -->
             <Style x:Key="CardStyle" TargetType="Border">

--- a/dotnet/src/Easydict.WinUI/Themes/Colors.xaml
+++ b/dotnet/src/Easydict.WinUI/Themes/Colors.xaml
@@ -18,6 +18,12 @@
             <Color x:Key="BlueAccentColor">#007AFF</Color>
             <Color x:Key="BlueTintColor">#1296DB</Color>
 
+            <!-- Status Colors -->
+            <Color x:Key="StatusConnectedColor">#107C10</Color>
+            <Color x:Key="StatusDisconnectedColor">#797775</Color>
+            <Color x:Key="StatusErrorColor">#D13438</Color>
+            <Color x:Key="AccentColor">#0078D4</Color>
+
             <!-- Settings UI -->
             <Color x:Key="AddMinusBackgroundColor">#EAEAE9</Color>
             <Color x:Key="ListBorderColor">#DEDEDE</Color>
@@ -36,27 +42,39 @@
             <SolidColorBrush x:Key="AddMinusBackgroundBrush" Color="{StaticResource AddMinusBackgroundColor}" />
             <SolidColorBrush x:Key="ListBorderBrush" Color="{StaticResource ListBorderColor}" />
             <SolidColorBrush x:Key="ActionButtonIconBrush" Color="{StaticResource ActionButtonIconColor}" />
+            <SolidColorBrush x:Key="StatusConnectedBrush" Color="{StaticResource StatusConnectedColor}" />
+            <SolidColorBrush x:Key="StatusDisconnectedBrush" Color="{StaticResource StatusDisconnectedColor}" />
+            <SolidColorBrush x:Key="StatusErrorBrush" Color="{StaticResource StatusErrorColor}" />
+            <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
         </ResourceDictionary>
 
         <!-- Dark Theme Colors -->
         <ResourceDictionary x:Key="Dark">
-            <!-- Main Colors -->
-            <Color x:Key="MainViewBackgroundColor">#232325</Color>
-            <Color x:Key="MainBorderColor">#515253</Color>
-            <Color x:Key="QueryViewBackgroundColor">#303132</Color>
-            <Color x:Key="QueryTextColor">#E0E0E0</Color>
-            <Color x:Key="TitleBarBackgroundColor">#2C2D2E</Color>
-            <Color x:Key="ResultViewBackgroundColor">#303132</Color>
-            <Color x:Key="ButtonHoverColor">#515253</Color>
+            <!-- Main Colors — subtle blue-tinted grays for depth and visual warmth -->
+            <Color x:Key="MainViewBackgroundColor">#1C1E26</Color>
+            <Color x:Key="MainBorderColor">#3A3D4A</Color>
+            <Color x:Key="QueryViewBackgroundColor">#252830</Color>
+            <Color x:Key="QueryTextColor">#E2E4E9</Color>
+            <Color x:Key="TitleBarBackgroundColor">#21242C</Color>
+            <Color x:Key="ResultViewBackgroundColor">#252830</Color>
+            <Color x:Key="ButtonHoverColor">#3A3D4A</Color>
 
-            <!-- Accent Colors -->
-            <Color x:Key="BlueAccentColor">#007AFF</Color>
-            <Color x:Key="BlueTintColor">#1296DB</Color>
+            <!-- Accent Colors — desaturated for dark backgrounds to reduce eye strain -->
+            <Color x:Key="BlueAccentColor">#5EB5FF</Color>
+            <Color x:Key="BlueTintColor">#4DB8E8</Color>
+
+            <!-- Status Colors — softer pastel tones for dark mode -->
+            <Color x:Key="StatusConnectedColor">#6CCB5F</Color>
+            <Color x:Key="StatusDisconnectedColor">#8A8D93</Color>
+            <Color x:Key="StatusErrorColor">#FF99A4</Color>
+
+            <!-- Button accent — medium blue that supports white text on top -->
+            <Color x:Key="AccentColor">#2B88D8</Color>
 
             <!-- Settings UI -->
-            <Color x:Key="AddMinusBackgroundColor">#3B3A3A</Color>
-            <Color x:Key="ListBorderColor">#505050</Color>
-            <Color x:Key="ActionButtonIconColor">#707070</Color>
+            <Color x:Key="AddMinusBackgroundColor">#2E3140</Color>
+            <Color x:Key="ListBorderColor">#3A3D4A</Color>
+            <Color x:Key="ActionButtonIconColor">#9096A3</Color>
 
             <!-- Brushes -->
             <SolidColorBrush x:Key="MainViewBackgroundBrush" Color="{StaticResource MainViewBackgroundColor}" />
@@ -71,6 +89,10 @@
             <SolidColorBrush x:Key="AddMinusBackgroundBrush" Color="{StaticResource AddMinusBackgroundColor}" />
             <SolidColorBrush x:Key="ListBorderBrush" Color="{StaticResource ListBorderColor}" />
             <SolidColorBrush x:Key="ActionButtonIconBrush" Color="{StaticResource ActionButtonIconColor}" />
+            <SolidColorBrush x:Key="StatusConnectedBrush" Color="{StaticResource StatusConnectedColor}" />
+            <SolidColorBrush x:Key="StatusDisconnectedBrush" Color="{StaticResource StatusDisconnectedColor}" />
+            <SolidColorBrush x:Key="StatusErrorBrush" Color="{StaticResource StatusErrorColor}" />
+            <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
         </ResourceDictionary>
 
         <!-- HighContrast Theme (fallback to Light theme values) -->
@@ -84,6 +106,10 @@
             <Color x:Key="ButtonHoverColor">#E0E0E0</Color>
             <Color x:Key="BlueAccentColor">#0000FF</Color>
             <Color x:Key="BlueTintColor">#0000FF</Color>
+            <Color x:Key="StatusConnectedColor">#107C10</Color>
+            <Color x:Key="StatusDisconnectedColor">#797775</Color>
+            <Color x:Key="StatusErrorColor">#D13438</Color>
+            <Color x:Key="AccentColor">#0078D4</Color>
             <Color x:Key="AddMinusBackgroundColor">#E0E0E0</Color>
             <Color x:Key="ListBorderColor">#000000</Color>
             <Color x:Key="ActionButtonIconColor">#999999</Color>
@@ -100,6 +126,10 @@
             <SolidColorBrush x:Key="AddMinusBackgroundBrush" Color="{StaticResource AddMinusBackgroundColor}" />
             <SolidColorBrush x:Key="ListBorderBrush" Color="{StaticResource ListBorderColor}" />
             <SolidColorBrush x:Key="ActionButtonIconBrush" Color="{StaticResource ActionButtonIconColor}" />
+            <SolidColorBrush x:Key="StatusConnectedBrush" Color="{StaticResource StatusConnectedColor}" />
+            <SolidColorBrush x:Key="StatusDisconnectedBrush" Color="{StaticResource StatusDisconnectedColor}" />
+            <SolidColorBrush x:Key="StatusErrorBrush" Color="{StaticResource StatusErrorColor}" />
+            <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
@@ -133,7 +133,7 @@
                 Height="32"
                 Padding="0"
                 CornerRadius="16"
-                Background="{StaticResource AccentBrush}"
+                Background="{ThemeResource AccentBrush}"
                 ToolTipService.ToolTip="Translate"
                 Margin="4,0,0,0">
                 <Grid>
@@ -158,7 +158,7 @@
             Grid.Row="3"
             Text=""
             FontSize="10"
-            Foreground="{ThemeResource AccentBrush}"
+            Foreground="{ThemeResource BlueAccentBrush}"
             Margin="0,0,0,2"
             Visibility="Collapsed" />
 

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
@@ -54,7 +54,7 @@
             </Grid.ColumnDefinitions>
 
             <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                <FontIcon Glyph="&#xE774;" FontSize="28" Foreground="{StaticResource AccentBrush}" />
+                <FontIcon Glyph="&#xE774;" FontSize="28" Foreground="{ThemeResource BlueAccentBrush}" />
                 <TextBlock
                     Text="Easydict"
                     FontSize="22"
@@ -66,7 +66,7 @@
             <Border
                 x:Name="StatusIndicator"
                 Grid.Column="1"
-                Background="{StaticResource StatusDisconnectedBrush}"
+                Background="{ThemeResource StatusDisconnectedBrush}"
                 CornerRadius="12"
                 Padding="12,6"
                 VerticalAlignment="Center"
@@ -177,7 +177,7 @@
                 CornerRadius="20"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
-                Background="{StaticResource AccentBrush}"
+                Background="{ThemeResource AccentBrush}"
                 ToolTipService.ToolTip="Translate">
                 <Grid>
                     <ProgressRing
@@ -266,7 +266,7 @@
                 Padding="0"
                 CornerRadius="20"
                 HorizontalAlignment="Center"
-                Background="{StaticResource AccentBrush}"
+                Background="{ThemeResource AccentBrush}"
                 ToolTipService.ToolTip="Translate">
                 <Grid>
                     <ProgressRing
@@ -329,7 +329,7 @@
                     Grid.Row="1"
                     Text=""
                     FontSize="11"
-                    Foreground="{ThemeResource AccentBrush}"
+                    Foreground="{ThemeResource BlueAccentBrush}"
                     Margin="4,0,0,0"
                     VerticalAlignment="Top"
                     Visibility="Collapsed" />

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -147,7 +147,7 @@
                 Height="32"
                 Padding="0"
                 CornerRadius="16"
-                Background="{StaticResource AccentBrush}"
+                Background="{ThemeResource AccentBrush}"
                 ToolTipService.ToolTip="Translate"
                 Margin="4,0,0,0">
                 <Grid>
@@ -172,7 +172,7 @@
             Grid.Row="3"
             Text=""
             FontSize="10"
-            Foreground="{ThemeResource AccentBrush}"
+            Foreground="{ThemeResource BlueAccentBrush}"
             Margin="0,0,0,2"
             Visibility="Collapsed" />
 


### PR DESCRIPTION
- Replace neutral gray dark backgrounds (#232325) with subtle blue-tinted
  grays (#1C1E26, #21242C, #252830) for visual depth and warmth
- Desaturate accent colors for dark mode: BlueAccent #007AFF → #5EB5FF,
  BlueTint #1296DB → #4DB8E8 to reduce eye strain
- Add theme-aware status colors: green #6CCB5F, red #FF99A4 (softer
  pastel tones appropriate for dark backgrounds)
- Use medium blue #2B88D8 for button accent in dark mode (supports white
  text foreground while being lighter than light-mode #0078D4)
- Brighten action button icons #707070 → #9096A3 for better visibility
- Move AccentBrush and StatusBrushes from static App.xaml into
  Colors.xaml ThemeDictionaries so they adapt per-theme
- Switch XAML references from StaticResource to ThemeResource for
  accent/status brushes to enable runtime theme switching
- Use BlueAccentBrush (lighter) for text foreground, AccentBrush
  (medium) for button backgrounds in dark mode

https://claude.ai/code/session_01Y5NaQNptbe4qxwd5yDxCGj