### PR TITLE
Support dynamic content rendering for sections and pages

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,14 +1,15 @@
 {% extends "base.html" %}
 
 {% block content %}
+{% if section %}{% set data = section %}{% else %}{% set data = page %}{% endif %}
 <!-- Hero -->
 <section class="hero">
   <div class="container">
     <span class="hero-badge">Open Source &middot; Free</span>
     <h1>
-      {{ page.title }}
+      {{ data.title }}
     </h1>
-    <p class="hero-desc">{{ page.description }}</p>
+    <p class="hero-desc">{{ data.description }}</p>
     <div class="hero-actions">
       <a href="{{ config.extra.store_url }}" target="_blank" class="btn btn-primary">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="8" height="8" rx="1"/><rect x="13" y="3" width="8" height="8" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="13" y="13" width="8" height="8" rx="1"/></svg>
@@ -26,11 +27,11 @@
 </section>
 
 <!-- Screenshot -->
-{% if page.extra.screenshot %}
+{% if data.extra.screenshot %}
 <section class="screenshot-section">
   <div class="container">
     <div class="screenshot-wrapper">
-      <img src="{{ get_url(path=page.extra.screenshot) }}" alt="Easydict Screenshot">
+      <img src="{{ get_url(path=data.extra.screenshot) }}" alt="Easydict Screenshot">
     </div>
   </div>
 </section>
@@ -40,7 +41,7 @@
 <section class="readme-content" id="features">
   <div class="container">
     <div class="content-body">
-      {{ page.content | safe }}
+      {{ data.content | safe }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
Updated the index template to support rendering content from either a `section` or `page` object, enabling flexible content display across different page types.

## Changes
- Added conditional logic to use `section` data when available, falling back to `page` data otherwise
- Replaced all hardcoded `page` references with a dynamic `data` variable throughout the template
- Updated references in:
  - Hero section (title and description)
  - Screenshot section (conditional rendering and image path)
  - README content section

## Implementation Details
The template now uses a Jinja2 conditional assignment at the top of the content block:
```jinja2
{% if section %}{% set data = section %}{% else %}{% set data = page %}{% endif %}
```

This allows the same template to work with both page and section contexts without duplicating markup, improving maintainability and reducing code duplication.

https://claude.ai/code/session_01VUVcFxjtfjYMHcFYsg6qn6