### PR TITLE
refactor: extract integration tests into reusable workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,57 @@
+name: Integration Tests
+
+# Reusable workflow for running integration tests against real translation APIs.
+# Can be triggered manually or called from other workflows (e.g., release-publish).
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  integration-tests:
+    name: Integration Tests
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: dotnet/global.json
+
+      - name: Restore dependencies
+        working-directory: dotnet
+        run: dotnet restore tests/Easydict.TranslationService.Tests/Easydict.TranslationService.Tests.csproj
+
+      - name: Build test project
+        working-directory: dotnet
+        run: dotnet build tests/Easydict.TranslationService.Tests/Easydict.TranslationService.Tests.csproj --configuration Release --no-restore
+
+      - name: Run integration tests
+        working-directory: dotnet
+        env:
+          DEEPL_API_KEY: ${{ secrets.DEEPL_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          CAIYUN_API_KEY: ${{ secrets.CAIYUN_API_KEY }}
+          NIUTRANS_API_KEY: ${{ secrets.NIUTRANS_API_KEY }}
+          DOUBAO_API_KEY: ${{ secrets.DOUBAO_API_KEY }}
+          GITHUB_MODELS_API_KEY: ${{ secrets.GITHUB_MODELS_API_KEY }}
+        run: dotnet test tests/Easydict.TranslationService.Tests/Easydict.TranslationService.Tests.csproj --configuration Release --no-build --verbosity normal --filter "Category=Integration" --logger "trx;LogFileName=integration-test-results.trx"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-test-results
+          path: dotnet/**/TestResults/*.trx

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,49 +30,10 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 jobs:
-  # Run integration tests before packaging
+  # Run integration tests before packaging (reusable workflow)
   integration-tests:
-    name: Integration Tests
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: dotnet/global.json
-
-      - name: Restore dependencies
-        working-directory: dotnet
-        run: dotnet restore tests/Easydict.TranslationService.Tests/Easydict.TranslationService.Tests.csproj
-
-      - name: Build test project
-        working-directory: dotnet
-        run: dotnet build tests/Easydict.TranslationService.Tests/Easydict.TranslationService.Tests.csproj --configuration Release --no-restore
-
-      - name: Run integration tests
-        working-directory: dotnet
-        env:
-          DEEPL_API_KEY: ${{ secrets.DEEPL_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
-          CAIYUN_API_KEY: ${{ secrets.CAIYUN_API_KEY }}
-          NIUTRANS_API_KEY: ${{ secrets.NIUTRANS_API_KEY }}
-          DOUBAO_API_KEY: ${{ secrets.DOUBAO_API_KEY }}
-          GITHUB_MODELS_API_KEY: ${{ secrets.GITHUB_MODELS_API_KEY }}
-        run: dotnet test tests/Easydict.TranslationService.Tests/Easydict.TranslationService.Tests.csproj --configuration Release --no-build --verbosity normal --filter "Category=Integration" --logger "trx;LogFileName=integration-test-results.trx"
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: integration-test-results
-          path: dotnet/**/TestResults/*.trx
+    uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit
 
   # Build and package MSIX using winapp CLI
   publish-msix:


### PR DESCRIPTION
- Create standalone integration-tests.yml workflow that can be triggered
  independently via workflow_dispatch
- Update release-publish.yml to call the reusable workflow using
  workflow_call, maintaining the same dependency chain
- Secrets are inherited via `secrets: inherit`

https://claude.ai/code/session_01Gm7rcQ77RRWDbKyea4UmZ9