### PR TITLE
Deduplicate phonetics across multiple translation services

### DIFF
--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -368,6 +368,7 @@ public sealed partial class FixedWindow : Window
                 serviceResult.Result = result;
                 serviceResult.IsLoading = false;
                 serviceResult.ApplyAutoCollapseLogic();
+                UpdatePhoneticDeduplication();
                 RequestResize();
             }
         }
@@ -667,6 +668,7 @@ public sealed partial class FixedWindow : Window
                             serviceResult.Result = result;
                             serviceResult.IsLoading = false;
                             serviceResult.ApplyAutoCollapseLogic();
+                            UpdatePhoneticDeduplication();
                             // Coalesced resize so ServiceResultItem.UpdateUI() completes first
                             RequestResize();
                         });
@@ -842,6 +844,7 @@ public sealed partial class FixedWindow : Window
             serviceResult.StreamingText = "";
             serviceResult.Result = result;
             serviceResult.ApplyAutoCollapseLogic();
+            UpdatePhoneticDeduplication();
             // Delay resize to next tick so ServiceResultItem.UpdateUI() completes first
             DispatcherQueue.TryEnqueue(() => ResizeWindowToContent());
         });
@@ -1113,6 +1116,30 @@ public sealed partial class FixedWindow : Window
         if (this.Content is FrameworkElement root)
         {
             root.RequestedTheme = theme;
+        }
+    }
+
+    /// <summary>
+    /// Updates phonetic deduplication across all service result controls.
+    /// The first service showing a phonetic displays it; subsequent services with
+    /// the same phonetic will have it hidden to avoid duplication.
+    /// </summary>
+    private void UpdatePhoneticDeduplication()
+    {
+        var shownPhonetics = new HashSet<string>();
+
+        foreach (var control in _resultControls)
+        {
+            // Set which phonetics have already been shown (before this control)
+            control.AlreadyShownPhonetics = shownPhonetics.Count > 0
+                ? new HashSet<string>(shownPhonetics)
+                : null;
+
+            // Collect phonetics displayed by this control for subsequent controls
+            foreach (var key in control.GetDisplayedPhoneticKeys())
+            {
+                shownPhonetics.Add(key);
+            }
         }
     }
 }

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -411,6 +411,7 @@ public sealed partial class MiniWindow : Window
                 serviceResult.Result = result;
                 serviceResult.IsLoading = false;
                 serviceResult.ApplyAutoCollapseLogic();
+                UpdatePhoneticDeduplication();
                 RequestResize();
             }
         }
@@ -786,6 +787,7 @@ public sealed partial class MiniWindow : Window
                             serviceResult.Result = result;
                             serviceResult.IsLoading = false;
                             serviceResult.ApplyAutoCollapseLogic();
+                            UpdatePhoneticDeduplication();
                             // Coalesced resize so ServiceResultItem.UpdateUI() completes first
                             RequestResize();
                         });
@@ -961,6 +963,7 @@ public sealed partial class MiniWindow : Window
             serviceResult.StreamingText = "";
             serviceResult.Result = result;
             serviceResult.ApplyAutoCollapseLogic();
+            UpdatePhoneticDeduplication();
             // Delay resize to next tick so ServiceResultItem.UpdateUI() completes first
             DispatcherQueue.TryEnqueue(() => ResizeWindowToContent());
         });
@@ -1251,6 +1254,30 @@ public sealed partial class MiniWindow : Window
         if (this.Content is FrameworkElement root)
         {
             root.RequestedTheme = theme;
+        }
+    }
+
+    /// <summary>
+    /// Updates phonetic deduplication across all service result controls.
+    /// The first service showing a phonetic displays it; subsequent services with
+    /// the same phonetic will have it hidden to avoid duplication.
+    /// </summary>
+    private void UpdatePhoneticDeduplication()
+    {
+        var shownPhonetics = new HashSet<string>();
+
+        foreach (var control in _resultControls)
+        {
+            // Set which phonetics have already been shown (before this control)
+            control.AlreadyShownPhonetics = shownPhonetics.Count > 0
+                ? new HashSet<string>(shownPhonetics)
+                : null;
+
+            // Collect phonetics displayed by this control for subsequent controls
+            foreach (var key in control.GetDisplayedPhoneticKeys())
+            {
+                shownPhonetics.Add(key);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR implements phonetic deduplication across multiple translation service results. When multiple services display the same phonetic pronunciation (e.g., "US:/həˈloʊ/"), only the first service shows it while subsequent services hide duplicates to reduce visual clutter.

## Key Changes

- **ServiceResultItem.xaml.cs**
  - Added `AlreadyShownPhonetics` property to track phonetics already displayed by previous services
  - Added `GetDisplayedPhoneticKeys()` method to expose which phonetics this control is currently displaying
  - Updated `UpdatePhonetics()` to filter out phonetics that have already been shown
  - Reduced phonetic badge font sizes from 11 to 10 for better visual balance
  - Added null-check filter for empty phonetic text

- **MainPage.xaml.cs, FixedWindow.xaml.cs, MiniWindow.xaml.cs**
  - Added `_resultControls` list to track all ServiceResultItem controls
  - Implemented `UpdatePhoneticDeduplication()` method that:
    - Iterates through service results in order
    - Passes the set of already-shown phonetics to each control
    - Collects newly displayed phonetics for subsequent controls
  - Called `UpdatePhoneticDeduplication()` after each translation result is received

## Implementation Details

The deduplication works by maintaining a running set of phonetic keys (format: `"ACCENT:TEXT"`) as we iterate through service results. Each control receives the set of phonetics shown by previous services and filters them out during rendering. This ensures:
- First service showing a phonetic displays it
- Subsequent services with the same phonetic hide it
- No duplicate phonetic badges across multiple service results
- Minimal performance impact with O(n) complexity where n is the number of services

https://claude.ai/code/session_01AvTd7bHDTiW964CXC3tWZq