### PR TITLE
feat: add service filtering support for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,7 +5,36 @@ name: Integration Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      service:
+        description: 'Service to test (all, google, openai, deepl, deepseek, groq, zhipu, github-models, gemini, doubao, caiyun, niutrans, linguee, bing, youdao, phonetic)'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - google
+          - openai
+          - deepl
+          - deepseek
+          - groq
+          - zhipu
+          - github-models
+          - gemini
+          - doubao
+          - caiyun
+          - niutrans
+          - linguee
+          - bing
+          - youdao
+          - phonetic
   workflow_call:
+    inputs:
+      service:
+        description: 'Service to test (default: all)'
+        required: false
+        default: 'all'
+        type: string
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -14,7 +43,7 @@ env:
 
 jobs:
   integration-tests:
-    name: Integration Tests
+    name: Integration Tests (${{ inputs.service || 'all' }})
     runs-on: windows-latest
 
     steps:
@@ -47,7 +76,15 @@ jobs:
           NIUTRANS_API_KEY: ${{ secrets.NIUTRANS_API_KEY }}
           DOUBAO_API_KEY: ${{ secrets.DOUBAO_API_KEY }}
           GITHUB_MODELS_API_KEY: ${{ secrets.GITHUB_MODELS_API_KEY }}
-        run: dotnet test tests/Easydict.TranslationService.Tests/Easydict.TranslationService.Tests.csproj --configuration Release --no-build --verbosity normal --filter "Category=Integration" --logger "trx;LogFileName=integration-test-results.trx"
+        run: |
+          $service = "${{ inputs.service || 'all' }}"
+          if ($service -eq "all") {
+            $filter = "Category=Integration"
+          } else {
+            $filter = "Category=Integration&Service=$service"
+          }
+          Write-Host "Running integration tests with filter: $filter"
+          dotnet test tests/Easydict.TranslationService.Tests/Easydict.TranslationService.Tests.csproj --configuration Release --no-build --verbosity normal --filter "$filter" --logger "trx;LogFileName=integration-test-results.trx"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -3,7 +3,7 @@
 # Optional: WinApp CLI (for MSIX packaging)
 
 .PHONY: all build build-release build-debug test clean restore run help
-.PHONY: test-translation test-winui test-ui test-verbose run-release
+.PHONY: test-translation test-winui test-ui test-integration test-verbose run-release
 .PHONY: publish publish-x64 publish-x86 publish-arm64
 .PHONY: msix msix-x64 msix-x86 msix-arm64 msix-all
 .PHONY: fix-msix-minversion
@@ -55,6 +55,22 @@ test-winui:
 # Run UI automation tests (requires app to be installed or EASYDICT_EXE_PATH set)
 test-ui:
 	dotnet test tests/Easydict.UIAutomation.Tests --logger "console;verbosity=detailed" --filter "Category=UIAutomation"
+
+# Integration test service filter (default: all)
+# Available services: google, openai, deepl, deepseek, groq, zhipu, github-models,
+#                     gemini, doubao, caiyun, niutrans, linguee, bing, youdao, phonetic
+SERVICE ?= all
+
+# Run integration tests (all services by default)
+# Usage: make test-integration
+#        make test-integration SERVICE=google
+#        make test-integration SERVICE=openai
+test-integration:
+ifeq ($(SERVICE),all)
+	dotnet test tests/Easydict.TranslationService.Tests --logger "console;verbosity=detailed" --filter "Category=Integration"
+else
+	dotnet test tests/Easydict.TranslationService.Tests --logger "console;verbosity=detailed" --filter "Category=Integration&Service=$(SERVICE)"
+endif
 
 # Run tests with verbose output
 test-verbose:
@@ -252,6 +268,8 @@ help:
 	@echo "  make test-translation - Run TranslationService tests only"
 	@echo "  make test-winui   - Run WinUI tests only"
 	@echo "  make test-ui      - Run UI automation tests (requires installed app)"
+	@echo "  make test-integration - Run integration tests (all services)"
+	@echo "  make test-integration SERVICE=google - Run integration tests for specific service"
 	@echo "  make test-verbose - Run tests with verbose output"
 	@echo ""
 	@echo "Publishing:"
@@ -282,6 +300,10 @@ help:
 	@echo "  VERSION=X.Y.Z.W   - Set version for MSIX package (default: 0.1.0.0)"
 	@echo "  CERT_PASSWORD=... - Certificate password (required for cert/sign targets)"
 	@echo "  CERT_PATH=...     - Certificate file path (default: ./certs/dev.pfx)"
+	@echo "  SERVICE=...       - Integration test service filter (default: all)"
+	@echo "                      Available: google, openai, deepl, deepseek, groq, zhipu,"
+	@echo "                      github-models, gemini, doubao, caiyun, niutrans, linguee,"
+	@echo "                      bing, youdao, phonetic"
 	@echo ""
 	@echo "Cleanup:"
 	@echo "  make clean        - Clean build artifacts"

--- a/dotnet/tests/Easydict.TranslationService.Tests/PhoneticEnrichmentIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/PhoneticEnrichmentIntegrationTests.cs
@@ -15,6 +15,7 @@ namespace Easydict.TranslationService.Tests;
 /// 3. Result lacks target phonetics (US/UK)
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "phonetic")]
 public class PhoneticEnrichmentIntegrationTests : IDisposable
 {
     private readonly TranslationManager _manager;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/BingTranslateServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/BingTranslateServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// No API key required — uses EPT mode (Edge PDF Translator) for relaxed rate limits.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "bing")]
 public class BingTranslateServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/CaiyunServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/CaiyunServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires CAIYUN_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "caiyun")]
 public class CaiyunServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/DeepLServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/DeepLServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Uses web translation by default; optionally uses official API if DEEPL_API_KEY is set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "deepl")]
 public class DeepLServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/DeepSeekServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/DeepSeekServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires DEEPSEEK_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "deepseek")]
 public class DeepSeekServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/DoubaoServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/DoubaoServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires DOUBAO_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "doubao")]
 public class DoubaoServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/GeminiServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/GeminiServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires GEMINI_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "gemini")]
 public class GeminiServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/GitHubModelsServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/GitHubModelsServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires GITHUB_MODELS_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "github-models")]
 public class GitHubModelsServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/GoogleTranslateServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/GoogleTranslateServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// No API key required.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "google")]
 public class GoogleTranslateServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/GroqServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/GroqServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires GROQ_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "groq")]
 public class GroqServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/LingueeServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/LingueeServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// No API key required.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "linguee")]
 public class LingueeServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/NiuTransServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/NiuTransServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires NIUTRANS_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "niutrans")]
 public class NiuTransServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/OpenAIServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/OpenAIServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires OPENAI_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "openai")]
 public class OpenAIServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/YoudaoServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/YoudaoServiceIntegrationTests.cs
@@ -11,6 +11,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// No API key required for web APIs.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "youdao")]
 public class YoudaoServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/ZhipuServiceIntegrationTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/ZhipuServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Easydict.TranslationService.Tests.Services;
 /// Requires ZHIPU_API_KEY environment variable to be set.
 /// </summary>
 [Trait("Category", "Integration")]
+[Trait("Service", "zhipu")]
 public class ZhipuServiceIntegrationTests : IDisposable
 {
     private readonly HttpClient _httpClient;


### PR DESCRIPTION
Add Service trait to all 15 integration test classes to enable filtering
tests by service name. The default is "all" which runs all services.

Changes:
- Add [Trait("Service", "...")] to each integration test class
- Update Makefile with test-integration target and SERVICE variable
- Update integration-tests.yml workflow with service input parameter

Available services: google, openai, deepl, deepseek, groq, zhipu,
github-models, gemini, doubao, caiyun, niutrans, linguee, bing,
youdao, phonetic

Usage:
- make test-integration              # Run all services
- make test-integration SERVICE=google  # Run only Google tests
- dotnet test --filter "Category=Integration&Service=openai"

https://claude.ai/code/session_012bVgerFsE5ggxaQXDMTfvi