### PR TITLE
feat: add Debug.Assert UI thread checks to MiniWindowService and FixedWindowService

### DIFF
--- a/dotnet/src/Easydict.WinUI/Services/FixedWindowService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/FixedWindowService.cs
@@ -24,10 +24,23 @@ public sealed class FixedWindowService : IDisposable
     {
         get
         {
+            AssertUIThread();
+            return _instance ??= new FixedWindowService();
+        }
+    }
+
+    [Conditional("DEBUG")]
+    private static void AssertUIThread()
+    {
+        try
+        {
             Debug.Assert(
                 DispatcherQueue.GetForCurrentThread() != null,
                 "FixedWindowService.Instance must be accessed from the UI thread");
-            return _instance ??= new FixedWindowService();
+        }
+        catch
+        {
+            // DispatcherQueue unavailable (e.g., unit tests without Windows App SDK).
         }
     }
 

--- a/dotnet/src/Easydict.WinUI/Services/MiniWindowService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/MiniWindowService.cs
@@ -23,10 +23,23 @@ public sealed class MiniWindowService : IDisposable
     {
         get
         {
+            AssertUIThread();
+            return _instance ??= new MiniWindowService();
+        }
+    }
+
+    [Conditional("DEBUG")]
+    private static void AssertUIThread()
+    {
+        try
+        {
             Debug.Assert(
                 DispatcherQueue.GetForCurrentThread() != null,
                 "MiniWindowService.Instance must be accessed from the UI thread");
-            return _instance ??= new MiniWindowService();
+        }
+        catch
+        {
+            // DispatcherQueue unavailable (e.g., unit tests without Windows App SDK).
         }
     }
 


### PR DESCRIPTION
These singleton services are inherently bound to the UI thread (they
create WinUI 3 Windows). Adding Debug.Assert in the Instance getter
catches accidental background-thread access at dev time, before it
causes a hard-to-diagnose crash later during UI operations.

Changes:
- Instance getter: ??= kept, Debug.Assert(DispatcherQueue.GetForCurrentThread() != null) added
- _isDisposed: marked volatile (consistent with MouseHookService)

https://claude.ai/code/session_01AJPQmMvNk8UQ6H4DB4QQVz