### PR TITLE
Add GPL-3.0 badge, source:test LOC ratio, and integration test table to README

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -1,0 +1,64 @@
+name: Update Badges
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'dotnet/src/**/*.cs'
+      - 'dotnet/tests/**/*.cs'
+  workflow_dispatch:
+
+jobs:
+  update-badges:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Calculate source:test LOC ratio
+        id: ratio
+        run: |
+          src_lines=$(find dotnet/src -name '*.cs' -exec cat {} + | wc -l)
+          test_lines=$(find dotnet/tests -name '*.cs' -exec cat {} + | wc -l)
+          ratio=$(awk "BEGIN {printf \"%.1f\", $src_lines / $test_lines}")
+          echo "src_lines=$src_lines" >> $GITHUB_OUTPUT
+          echo "test_lines=$test_lines" >> $GITHUB_OUTPUT
+          echo "ratio=$ratio" >> $GITHUB_OUTPUT
+          echo "Source: $src_lines lines, Test: $test_lines lines, Ratio: ${ratio}:1"
+
+      - name: Update badge data
+        env:
+          RATIO: ${{ steps.ratio.outputs.ratio }}
+        run: |
+          cat > /tmp/source-test-ratio.json << EOF
+          {
+            "schemaVersion": 1,
+            "label": "source:test LOC",
+            "message": "${RATIO}:1",
+            "color": "brightgreen"
+          }
+          EOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin badges 2>/dev/null || true
+          if git show-ref --verify --quiet refs/remotes/origin/badges; then
+            git checkout badges
+          else
+            git checkout --orphan badges
+            git rm -rf .
+          fi
+
+          cp /tmp/source-test-ratio.json source-test-ratio.json
+          git add source-test-ratio.json
+
+          if git diff --cached --quiet; then
+            echo "No changes to badge"
+          else
+            git commit -m "Update source:test LOC badge (${RATIO}:1)"
+            git push origin badges
+          fi

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <a href="./README.md">English</a> &nbsp;&nbsp;|&nbsp;&nbsp; <a href="./README_ZH.md">中文</a>
 </div>
 
-[![CI](https://github.com/xiaocang/easydict_win32/actions/workflows/ci.yml/badge.svg)](https://github.com/xiaocang/easydict_win32/actions/workflows/ci.yml) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![Source:Test LOC](https://img.shields.io/badge/source%3Atest_LOC-1.2%3A1-brightgreen)
+[![CI](https://github.com/xiaocang/easydict_win32/actions/workflows/ci.yml/badge.svg)](https://github.com/xiaocang/easydict_win32/actions/workflows/ci.yml) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![Source:Test LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xiaocang/easydict_win32/badges/source-test-ratio.json)
 
 <a href="https://apps.microsoft.com/detail/9p7nqvxf9dzj">
   <img src="https://get.microsoft.com/images/en-us%20dark.svg" alt="Get it from Microsoft" width="200" />

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -9,7 +9,7 @@
 <a href="./README.md">English</a> &nbsp;&nbsp;|&nbsp;&nbsp; <a href="./README_ZH.md">中文</a>
 </div>
 
-[![CI](https://github.com/xiaocang/easydict_win32/actions/workflows/ci.yml/badge.svg)](https://github.com/xiaocang/easydict_win32/actions/workflows/ci.yml) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![Source:Test LOC](https://img.shields.io/badge/source%3Atest_LOC-1.2%3A1-brightgreen)
+[![CI](https://github.com/xiaocang/easydict_win32/actions/workflows/ci.yml/badge.svg)](https://github.com/xiaocang/easydict_win32/actions/workflows/ci.yml) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![Source:Test LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xiaocang/easydict_win32/badges/source-test-ratio.json)
 
 <a href="https://apps.microsoft.com/detail/9p7nqvxf9dzj">
   <img src="https://get.microsoft.com/images/zh-cn%20dark.svg" alt="从 Microsoft 获取" width="200" />


### PR DESCRIPTION
- Add GPL-3.0 license badge and source:test LOC ratio (1.2:1) on the same
  line as the CI badge
- Add new "Translation Service Integration Tests" section after Tech Stack
  with a table listing all 19 services, their protocol type, test status,
  and notes
- 8 services verified: Google, Bing, Youdao, OpenAI, DeepSeek, Gemini,
  Zhipu AI, Volcano Engine
- Sync both README.md (English) and README_ZH.md (Chinese)

https://claude.ai/code/session_019kCfdZWGXZHKVTP416Ttjx