### PR TITLE
i18n: localize ToggleSwitch On/Off content in settings page

### DIFF
--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -660,4 +660,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>&#1601;&#1593;&#1617;&#1604; &#1575;&#1604;&#1582;&#1583;&#1605;&#1575;&#1578; &#1601;&#1610; '&#1575;&#1604;&#1582;&#1583;&#1605;&#1575;&#1578; &#1575;&#1604;&#1605;&#1601;&#1593;&#1617;&#1604;&#1577;' &#1571;&#1593;&#1604;&#1575;&#1607; &#1571;&#1608;&#1604;&#1575;&#1611;</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>&#1578;&#1588;&#1594;&#1610;&#1604;</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>&#1573;&#1610;&#1602;&#1575;&#1601;</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>API &#1585;&#1587;&#1605;&#1610;</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>&#1608;&#1610;&#1576; (&#1605;&#1580;&#1575;&#1606;&#1610;)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -234,4 +234,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>Aktiver tjenester under 'Aktiverede tjenester' ovenfor f&#248;rst</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>Til</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>Fra</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>Officiel API</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web (gratis)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -777,4 +777,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>Zuerst Dienste unter &#8222;Aktivierte Dienste&#8220; oben aktivieren</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>Ein</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>Aus</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>Offizielle API</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web (kostenlos)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -809,4 +809,20 @@
   <data name="TestNotConfigured" xml:space="preserve">
     <value>Please configure the service first (API key, endpoint, etc.).</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>Off</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>Official API</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web (free)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -777,4 +777,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>Activer d&#8217;abord les services dans &#171; Services activ&#233;s &#187; ci-dessus</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>Activé</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>API officielle</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web (gratuit)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -234,4 +234,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>&#2346;&#2361;&#2354;&#2375; &#2314;&#2346;&#2352; '&#2360;&#2325;&#2381;&#2352;&#2367;&#2351; &#2360;&#2375;&#2357;&#2366;&#2319;&#2305;' &#2350;&#2375;&#2306; &#2360;&#2375;&#2357;&#2366;&#2319;&#2305; &#2360;&#2325;&#2381;&#2359;&#2350; &#2325;&#2352;&#2375;&#2306;</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>&#2330;&#2366;&#2354;&#2370;</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>&#2348;&#2306;&#2342;</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>&#2310;&#2343;&#2367;&#2325;&#2366;&#2352;&#2367;&#2325; API</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>&#2357;&#2375;&#2348; (&#2350;&#2369;&#2347;&#2364;&#2381;&#2340;)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -606,4 +606,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>Aktifkan layanan di 'Layanan Aktif' di atas terlebih dahulu</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>Aktif</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>Nonaktif</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>API Resmi</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web (gratis)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -652,4 +652,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>Attiva prima i servizi in 'Servizi attivati' sopra</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>Attivato</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>Disattivato</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>API ufficiale</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web (gratuito)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -777,4 +777,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>先に上の「有効なサービス」で有効にしてください</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>オン</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>オフ</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>公式 API</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web（無料）</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -777,4 +777,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>먼저 위의 '활성화된 서비스'에서 활성화하세요</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>켜짐</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>꺼짐</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>공식 API</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>웹 (무료)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -234,4 +234,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>Aktifkan perkhidmatan dalam 'Perkhidmatan Aktif' di atas dahulu</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>Hidup</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>Mati</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>API Rasmi</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web (percuma)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -614,4 +614,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>&#3648;&#3611;&#3636;&#3604;&#3651;&#3594;&#3657;&#3610;&#3619;&#3636;&#3585;&#3634;&#3619;&#3651;&#3609; '&#3610;&#3619;&#3636;&#3585;&#3634;&#3619;&#3607;&#3637;&#3656;&#3648;&#3611;&#3636;&#3604;&#3651;&#3594;&#3657;' &#3604;&#3657;&#3634;&#3609;&#3610;&#3609;&#3585;&#3656;&#3629;&#3609;</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>&#3648;&#3611;&#3636;&#3604;</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>&#3611;&#3636;&#3604;</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>API &#3607;&#3634;&#3591;&#3585;&#3634;&#3619;</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>&#3648;&#3623;&#3655;&#3610; (&#3615;&#3619;&#3637;)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -660,4 +660,20 @@
   <data name="ServiceConfigHelpTip" xml:space="preserve">
     <value>B&#7853;t d&#7883;ch v&#7909; trong 'D&#7883;ch v&#7909; &#273;&#227; b&#7853;t' &#7903; tr&#234;n tr&#432;&#7899;c</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>B&#7853;t</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>T&#7855;t</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>API ch&#237;nh th&#7913;c</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>Web (mi&#7877;n ph&#237;)</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -809,4 +809,20 @@
   <data name="TestNotConfigured" xml:space="preserve">
     <value>请先配置服务（API 密钥、端点等）。</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>开</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>关</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>官方 API</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>网页版（免费）</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -777,4 +777,20 @@
   <data name="CannotConnectToOllamaMessage" xml:space="preserve">
     <value>無法從 Ollama 取得模型。請確認 Ollama 正在執行且可以存取。</value>
   </data>
+
+  <!-- Toggle Switch On/Off -->
+  <data name="ToggleOn" xml:space="preserve">
+    <value>開</value>
+  </data>
+  <data name="ToggleOff" xml:space="preserve">
+    <value>關</value>
+  </data>
+
+  <!-- Youdao Toggle Content -->
+  <data name="OfficialApi" xml:space="preserve">
+    <value>官方 API</value>
+  </data>
+  <data name="WebFree" xml:space="preserve">
+    <value>網頁版（免費）</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -152,8 +152,7 @@
                                         <ToggleSwitch
                                             Grid.Column="1"
                                             IsOn="{Binding EnabledQuery, Mode=TwoWay}"
-                                            OnContent="Auto"
-                                            OffContent="Manual"
+                                            Loaded="OnServiceToggleSwitchLoaded"
                                             Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
                                             IsEnabled="{Binding IsAvailable}"
                                             MinWidth="0"
@@ -186,8 +185,7 @@
                                         <ToggleSwitch
                                             Grid.Column="1"
                                             IsOn="{Binding EnabledQuery, Mode=TwoWay}"
-                                            OnContent="Auto"
-                                            OffContent="Manual"
+                                            Loaded="OnServiceToggleSwitchLoaded"
                                             Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
                                             IsEnabled="{Binding IsAvailable}"
                                             MinWidth="0"
@@ -220,8 +218,7 @@
                                         <ToggleSwitch
                                             Grid.Column="1"
                                             IsOn="{Binding EnabledQuery, Mode=TwoWay}"
-                                            OnContent="Auto"
-                                            OffContent="Manual"
+                                            Loaded="OnServiceToggleSwitchLoaded"
                                             Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
                                             IsEnabled="{Binding IsAvailable}"
                                             MinWidth="0"
@@ -549,7 +546,7 @@
                     <StackPanel Spacing="12" Padding="0,8">
                         <PasswordBox x:Name="YoudaoAppKeyBox" Header="App Key" Width="350" PlaceholderText="Enter your Youdao App Key" HorizontalAlignment="Left" />
                         <PasswordBox x:Name="YoudaoAppSecretBox" Header="App Secret" Width="350" PlaceholderText="Enter your Youdao App Secret" HorizontalAlignment="Left" />
-                        <ToggleSwitch x:Name="YoudaoUseOfficialApiToggle" Header="Use Official API" OffContent="Web (free)" OnContent="Official API" />
+                        <ToggleSwitch x:Name="YoudaoUseOfficialApiToggle" Header="Use Official API" />
                         <TextBlock Text="Youdao provides phonetic transcriptions for English words. Without API keys, uses free web dictionary. With API keys, enables official API for higher limits. Get API keys from ai.youdao.com"
                                    FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -138,6 +138,8 @@ public sealed partial class SettingsPage : Page
         YoudaoAppKeyBox.Header = loc.GetString("AppKey");
         YoudaoAppSecretBox.Header = loc.GetString("AppSecret");
         YoudaoUseOfficialApiToggle.Header = loc.GetString("UseOfficialApi");
+        YoudaoUseOfficialApiToggle.OnContent = loc.GetString("OfficialApi");
+        YoudaoUseOfficialApiToggle.OffContent = loc.GetString("WebFree");
 
         // Refresh button for Ollama
         RefreshOllamaButton.Content = loc.GetString("Refresh");
@@ -171,6 +173,30 @@ public sealed partial class SettingsPage : Page
         ProxyEnabledToggle.Header = loc.GetString("UseHttpProxy");
         ProxyUriBox.Header = loc.GetString("ProxyUrl");
         ProxyBypassLocalToggle.Header = loc.GetString("BypassProxyForLocalhost");
+
+        // Toggle switch On/Off content (override system locale defaults)
+        var toggleOn = loc.GetString("ToggleOn");
+        var toggleOff = loc.GetString("ToggleOff");
+        AutoSelectTargetToggle.OnContent = toggleOn;
+        AutoSelectTargetToggle.OffContent = toggleOff;
+        EnableInternationalServicesToggle.OnContent = toggleOn;
+        EnableInternationalServicesToggle.OffContent = toggleOff;
+        ProxyEnabledToggle.OnContent = toggleOn;
+        ProxyEnabledToggle.OffContent = toggleOff;
+        ProxyBypassLocalToggle.OnContent = toggleOn;
+        ProxyBypassLocalToggle.OffContent = toggleOff;
+        MinimizeToTrayToggle.OnContent = toggleOn;
+        MinimizeToTrayToggle.OffContent = toggleOff;
+        MinimizeToTrayOnStartupToggle.OnContent = toggleOn;
+        MinimizeToTrayOnStartupToggle.OffContent = toggleOff;
+        ClipboardMonitorToggle.OnContent = toggleOn;
+        ClipboardMonitorToggle.OffContent = toggleOff;
+        MouseSelectionTranslateToggle.OnContent = toggleOn;
+        MouseSelectionTranslateToggle.OffContent = toggleOff;
+        AlwaysOnTopToggle.OnContent = toggleOn;
+        AlwaysOnTopToggle.OffContent = toggleOff;
+        LaunchAtStartupToggle.OnContent = toggleOn;
+        LaunchAtStartupToggle.OffContent = toggleOff;
 
         // Hotkeys section
         if (HotkeysHeaderText != null)
@@ -324,6 +350,20 @@ public sealed partial class SettingsPage : Page
         foreach (var item in collection)
         {
             item.PropertyChanged += (_, _) => OnSettingChanged(null!, null!);
+        }
+    }
+
+    /// <summary>
+    /// Apply localized On/Off content to service ToggleSwitches in DataTemplates.
+    /// Called when each ToggleSwitch is loaded.
+    /// </summary>
+    private void OnServiceToggleSwitchLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is ToggleSwitch toggle)
+        {
+            var loc = LocalizationService.Instance;
+            toggle.OnContent = loc.GetString("Auto");
+            toggle.OffContent = loc.GetString("Manual");
         }
     }
 


### PR DESCRIPTION
ToggleSwitch controls were showing system-locale "开/关" regardless of
the app's selected UI language. This adds explicit OnContent/OffContent
localization for all 15 supported languages:

- Add ToggleOn/ToggleOff strings to all resource files
- Add OfficialApi/WebFree strings for Youdao toggle
- Set OnContent/OffContent on all named toggles in ApplyLocalization()
- Replace hardcoded "Auto"/"Manual" in DataTemplate with Loaded event
  handler that applies localized strings
- Remove hardcoded "Official API"/"Web (free)" from Youdao toggle XAML

https://claude.ai/code/session_01KEthj1JYS4XQGVAKXzjDWR