### PR TITLE
feat: add OCR screenshot hotkey settings to Settings page

### DIFF
--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -319,6 +319,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>إظهار النافذة الثابتة</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>ترجمة لقطة شاشة OCR</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>OCR صامت</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>ملاحظة: أعد تشغيل التطبيق لتطبيق تغييرات الاختصارات. اختصارات التبديل تستخدم نفس المفتاح مع Shift (مثل Ctrl+Alt+Shift+M).</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -117,6 +117,8 @@
   <data name="TranslateSelection" xml:space="preserve"><value>Oversæt markering</value></data>
   <data name="ShowMiniWindow" xml:space="preserve"><value>Vis minivindue</value></data>
   <data name="ShowFixedWindow" xml:space="preserve"><value>Vis fast vindue</value></data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve"><value>OCR-skærmbilledeoversættelse</value></data>
+  <data name="SilentOcr" xml:space="preserve"><value>Lydløs OCR</value></data>
   <data name="HotkeysDescription" xml:space="preserve"><value>Bemærk: Genstart appen for at anvende genvejstastændringer. Skiftetaster bruger samme tast med Shift (f.eks. Ctrl+Alt+Shift+M).</value></data>
   <data name="About" xml:space="preserve"><value>Om</value></data>
   <data name="EasydictForWindows" xml:space="preserve"><value>Easydict til Windows</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -415,6 +415,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>Fixiertes Fenster anzeigen</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>OCR-Screenshot-Übersetzung</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>Stille OCR</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>Hinweis: Starten Sie die App neu, um Tastenkürzel-Änderungen anzuwenden. Umschalt-Tastenkürzel verwenden dieselbe Taste mit zusätzlicher Umschalttaste (z.B. Strg+Alt+Umschalt+M).</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -430,6 +430,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>Show Fixed Window</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>OCR Screenshot Translate</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>Silent OCR</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>Note: Restart app to apply hotkey changes. Toggle hotkeys use the same key with Shift added (e.g., Ctrl+Alt+Shift+M).</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -415,6 +415,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>Afficher la fenêtre fixe</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>Traduction OCR par capture d'écran</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>OCR silencieux</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>Note : Redémarrez l'application pour appliquer les changements de raccourcis. Les raccourcis de bascule utilisent la même touche avec Shift ajouté (ex : Ctrl+Alt+Shift+M).</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -117,6 +117,8 @@
   <data name="TranslateSelection" xml:space="preserve"><value>चयन का अनुवाद करें</value></data>
   <data name="ShowMiniWindow" xml:space="preserve"><value>मिनी विंडो दिखाएँ</value></data>
   <data name="ShowFixedWindow" xml:space="preserve"><value>स्थिर विंडो दिखाएँ</value></data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve"><value>OCR स्क्रीनशॉट अनुवाद</value></data>
+  <data name="SilentOcr" xml:space="preserve"><value>मूक OCR</value></data>
   <data name="HotkeysDescription" xml:space="preserve"><value>नोट: शॉर्टकट कुंजी परिवर्तन लागू करने के लिए ऐप पुनः आरंभ करें। टॉगल शॉर्टकट कुंजियाँ Shift के साथ समान कुंजी का उपयोग करती हैं (जैसे Ctrl+Alt+Shift+M)।</value></data>
   <data name="About" xml:space="preserve"><value>के बारे में</value></data>
   <data name="EasydictForWindows" xml:space="preserve"><value>Windows के लिए Easydict</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -289,6 +289,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>Tampilkan Jendela Tetap</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>Terjemahan Tangkapan Layar OCR</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>OCR Diam</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>Catatan: Mulai ulang aplikasi untuk menerapkan perubahan pintasan. Pintasan toggle menggunakan tombol yang sama dengan Shift (mis. Ctrl+Alt+Shift+M).</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -311,6 +311,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>Mostra finestra fissa</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>Traduzione screenshot OCR</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>OCR silenzioso</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>Nota: Riavvia l'app per applicare le modifiche ai tasti rapidi. I tasti di commutazione usano lo stesso tasto con Shift (ad es. Ctrl+Alt+Shift+M).</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -415,6 +415,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>固定ウィンドウを表示</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>OCR スクリーンショット翻訳</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>サイレント OCR</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>注意：ホットキーの変更を適用するにはアプリを再起動してください。切り替えホットキーは同じキーにShiftを追加します（例：Ctrl+Alt+Shift+M）。</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -415,6 +415,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>고정 창 표시</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>OCR 스크린샷 번역</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>무음 OCR</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>참고: 단축키 변경을 적용하려면 앱을 다시 시작하세요. 토글 단축키는 같은 키에 Shift를 추가합니다 (예: Ctrl+Alt+Shift+M).</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -117,6 +117,8 @@
   <data name="TranslateSelection" xml:space="preserve"><value>Terjemah Pilihan</value></data>
   <data name="ShowMiniWindow" xml:space="preserve"><value>Papar Tetingkap Mini</value></data>
   <data name="ShowFixedWindow" xml:space="preserve"><value>Papar Tetingkap Tetap</value></data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve"><value>Terjemahan Tangkapan Skrin OCR</value></data>
+  <data name="SilentOcr" xml:space="preserve"><value>OCR Senyap</value></data>
   <data name="HotkeysDescription" xml:space="preserve"><value>Nota: Mulakan semula aplikasi untuk menerapkan perubahan kekunci pintas. Kekunci pintas togol menggunakan kekunci yang sama dengan Shift (cth. Ctrl+Alt+Shift+M).</value></data>
   <data name="About" xml:space="preserve"><value>Perihal</value></data>
   <data name="EasydictForWindows" xml:space="preserve"><value>Easydict untuk Windows</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -297,6 +297,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>&#xE41;&#xE2A;&#xE14;&#xE07;&#xE2B;&#xE19;&#xE49;&#xE32;&#xE15;&#xE48;&#xE32;&#xE07;&#xE04;&#xE07;&#xE17;&#xE35;&#xE48;</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>&#xE41;&#xE1B;&#xE25;&#xE20;&#xE32;&#xE1E;&#xE2B;&#xE19;&#xE49;&#xE32;&#xE08;&#xE2D; OCR</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>OCR &#xE40;&#xE07;&#xE35;&#xE22;&#xE1A;</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>&#xE2B;&#xE21;&#xE32;&#xE22;&#xE40;&#xE2B;&#xE15;&#xE38;: &#xE23;&#xE35;&#xE2A;&#xE15;&#xE32;&#xE23;&#xE4C;&#xE17;&#xE41;&#xE2D;&#xE1B;&#xE40;&#xE1E;&#xE37;&#xE48;&#xE2D;&#xE43;&#xE0A;&#xE49;&#xE01;&#xE32;&#xE23;&#xE40;&#xE1B;&#xE25;&#xE35;&#xE48;&#xE22;&#xE19;&#xE41;&#xE1B;&#xE25;&#xE07;&#xE04;&#xE35;&#xE22;&#xE4C;&#xE25;&#xE31;&#xE14; &#xE04;&#xE35;&#xE22;&#xE4C;&#xE25;&#xE31;&#xE14;&#xE2A;&#xE25;&#xE31;&#xE1A;&#xE43;&#xE0A;&#xE49;&#xE1B;&#xE38;&#xE48;&#xE21;&#xE40;&#xE14;&#xE35;&#xE22;&#xE27;&#xE01;&#xE31;&#xE19;&#xE1E;&#xE23;&#xE49;&#xE2D;&#xE21; Shift (&#xE40;&#xE0A;&#xE48;&#xE19; Ctrl+Alt+Shift+M)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -319,6 +319,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>Hi&#x1EC3;n th&#x1ECB; c&#x1EED;a s&#x1ED5; c&#x1ED1; &#x111;&#x1ECB;nh</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>D&#x1ECB;ch &#x1EA3;nh ch&#x1EE5;p m&#xE0;n h&#xEC;nh OCR</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>OCR im l&#x1EB7;ng</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>L&#x1B0;u &#xFD;: Kh&#x1EDF;i &#x111;&#x1ED9;ng l&#x1EA1;i &#x1EE9;ng d&#x1EE5;ng &#x111;&#x1EC3; &#xE1;p d&#x1EE5;ng thay &#x111;&#x1ED5;i ph&#xED;m t&#x1EAF;t. Ph&#xED;m t&#x1EAF;t chuy&#x1EC3;n &#x111;&#x1ED5;i s&#x1EED; d&#x1EE5;ng c&#xF9;ng ph&#xED;m v&#x1EDB;i Shift (v&#xED; d&#x1EE5;: Ctrl+Alt+Shift+M).</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -430,6 +430,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>显示固定窗口</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>OCR 截图翻译</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>静默 OCR</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>注意：重启应用以应用快捷键更改。切换快捷键使用相同的键加 Shift（例如 Ctrl+Alt+Shift+M）。</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -415,6 +415,12 @@
   <data name="ShowFixedWindow" xml:space="preserve">
     <value>顯示固定視窗</value>
   </data>
+  <data name="OcrScreenshotTranslate" xml:space="preserve">
+    <value>OCR 截圖翻譯</value>
+  </data>
+  <data name="SilentOcr" xml:space="preserve">
+    <value>靜默 OCR</value>
+  </data>
   <data name="HotkeysDescription" xml:space="preserve">
     <value>注意：重新啟動應用程式以套用快速鍵變更。切換快速鍵使用相同的鍵加 Shift（例如 Ctrl+Alt+Shift+M）。</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -658,6 +658,8 @@
                         <TextBox x:Name="TranslateHotkeyBox" Header="Translate Selection" Width="200" PlaceholderText="Ctrl+Alt+D" />
                         <TextBox x:Name="ShowMiniHotkeyBox" Header="Show Mini Window" Width="200" PlaceholderText="Ctrl+Alt+M" />
                         <TextBox x:Name="ShowFixedHotkeyBox" Header="Show Fixed Window" Width="200" PlaceholderText="Ctrl+Alt+F" />
+                        <TextBox x:Name="OcrTranslateHotkeyBox" Header="OCR Screenshot Translate" Width="200" PlaceholderText="Ctrl+Alt+S" />
+                        <TextBox x:Name="SilentOcrHotkeyBox" Header="Silent OCR" Width="200" PlaceholderText="Ctrl+Alt+Shift+S" />
                         <TextBlock x:Name="HotkeysDescriptionText" Text="Note: Restart app to apply hotkey changes. Toggle hotkeys use the same key with Shift added (e.g., Ctrl+Alt+Shift+M)."
                                    FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -212,6 +212,8 @@ public sealed partial class SettingsPage : Page
         TranslateHotkeyBox.Header = loc.GetString("TranslateSelection");
         ShowMiniHotkeyBox.Header = loc.GetString("ShowMiniWindow");
         ShowFixedHotkeyBox.Header = loc.GetString("ShowFixedWindow");
+        OcrTranslateHotkeyBox.Header = loc.GetString("OcrScreenshotTranslate");
+        SilentOcrHotkeyBox.Header = loc.GetString("SilentOcr");
 
         // About section
         if (AboutHeaderText != null)
@@ -317,6 +319,8 @@ public sealed partial class SettingsPage : Page
         TranslateHotkeyBox.TextChanged += OnSettingChanged;
         ShowMiniHotkeyBox.TextChanged += OnSettingChanged;
         ShowFixedHotkeyBox.TextChanged += OnSettingChanged;
+        OcrTranslateHotkeyBox.TextChanged += OnSettingChanged;
+        SilentOcrHotkeyBox.TextChanged += OnSettingChanged;
 
         // TextBox/PasswordBox changes - new services
         DeepSeekKeyBox.PasswordChanged += OnSettingChanged;
@@ -475,6 +479,8 @@ public sealed partial class SettingsPage : Page
         TranslateHotkeyBox.Text = _settings.TranslateSelectionHotkey;
         ShowMiniHotkeyBox.Text = _settings.ShowMiniWindowHotkey;
         ShowFixedHotkeyBox.Text = _settings.ShowFixedWindowHotkey;
+        OcrTranslateHotkeyBox.Text = _settings.OcrTranslateHotkey;
+        SilentOcrHotkeyBox.Text = _settings.SilentOcrHotkey;
 
         // Enabled services for each window (populate from TranslationManager.Services)
         PopulateServiceCollection(_mainWindowServices, _settings.MainWindowEnabledServices, _settings.MainWindowServiceEnabledQuery);
@@ -865,6 +871,8 @@ public sealed partial class SettingsPage : Page
         _settings.TranslateSelectionHotkey = TranslateHotkeyBox.Text;
         _settings.ShowMiniWindowHotkey = ShowMiniHotkeyBox.Text;
         _settings.ShowFixedWindowHotkey = ShowFixedHotkeyBox.Text;
+        _settings.OcrTranslateHotkey = OcrTranslateHotkeyBox.Text;
+        _settings.SilentOcrHotkey = SilentOcrHotkeyBox.Text;
 
         // Save enabled services for each window (from collections)
         _settings.MainWindowEnabledServices = GetEnabledServicesFromCollection(_mainWindowServices);


### PR DESCRIPTION
Add configurable hotkey TextBoxes for "OCR Screenshot Translate" and
"Silent OCR" in the Hotkeys section of Settings, matching the existing
pattern for other hotkey settings. Includes localization strings for
all 15 supported languages.

https://claude.ai/code/session_01GK3DDd8sAJbWrafFGm8AaV