### PR TITLE
fix: use GetKeyStateForCurrentThread for Shift+Enter newline detection

### DIFF
--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -987,24 +987,14 @@ public sealed partial class FixedWindow : Window
             return;
         }
 
-        try
-        {
-            if (this.Content is FrameworkElement fe && fe.XamlRoot?.ContentIsland != null)
-            {
-                var keyboardSource = InputKeyboardSource.GetForIsland(fe.XamlRoot.ContentIsland);
-                var shiftState = keyboardSource.GetKeyState(VirtualKey.Shift);
-                var ctrlState = keyboardSource.GetKeyState(VirtualKey.Control);
+        // Check if Shift or Ctrl is held — allow newline insertion
+        var shiftState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift);
+        var ctrlState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
 
-                if (shiftState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down) ||
-                    ctrlState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down))
-                {
-                    return; // Allow newline
-                }
-            }
-        }
-        catch
+        if (shiftState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down) ||
+            ctrlState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down))
         {
-            // Fallback: trigger translation
+            return; // Allow newline
         }
 
         e.Handled = true;

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -544,41 +544,19 @@ namespace Easydict.WinUI.Views
                 return;
             }
 
-            try
+            // Check if Shift or Ctrl is held — allow newline insertion
+            var shiftState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift);
+            var ctrlState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
+
+            if (shiftState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down) ||
+                ctrlState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down))
             {
-                // Check if XamlRoot and ContentIsland are available
-                if (this.XamlRoot?.ContentIsland == null)
-                {
-                    // Fallback: trigger translation if we can't check modifiers
-                    e.Handled = true;
-                    await StartQueryTrackedAsync();
-                    return;
-                }
-
-                // Check if Shift or Ctrl is held down using InputKeyboardSource
-                var keyboardSource = InputKeyboardSource.GetForIsland(this.XamlRoot.ContentIsland);
-                var shiftState = keyboardSource.GetKeyState(VirtualKey.Shift);
-                var ctrlState = keyboardSource.GetKeyState(VirtualKey.Control);
-
-                bool isShiftPressed = shiftState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
-                bool isCtrlPressed = ctrlState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
-
-                // If Shift or Ctrl is held, allow newline (don't handle the event)
-                if (isShiftPressed || isCtrlPressed)
-                {
-                    return; // Let the TextBox handle it normally (insert newline)
-                }
-
-                // Plain Enter: trigger translation
-                e.Handled = true; // Prevent default behavior (inserting newline)
-                await StartQueryTrackedAsync();
+                return; // Let the TextBox handle it normally (insert newline)
             }
-            catch
-            {
-                // Fallback: trigger translation on plain Enter if modifier detection fails
-                e.Handled = true;
-                await StartQueryTrackedAsync();
-            }
+
+            // Plain Enter: trigger translation
+            e.Handled = true;
+            await StartQueryTrackedAsync();
         }
 
         /// <summary>

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -1145,24 +1145,14 @@ public sealed partial class MiniWindow : Window
             return;
         }
 
-        try
-        {
-            if (this.Content is FrameworkElement fe && fe.XamlRoot?.ContentIsland != null)
-            {
-                var keyboardSource = InputKeyboardSource.GetForIsland(fe.XamlRoot.ContentIsland);
-                var shiftState = keyboardSource.GetKeyState(VirtualKey.Shift);
-                var ctrlState = keyboardSource.GetKeyState(VirtualKey.Control);
+        // Check if Shift or Ctrl is held — allow newline insertion
+        var shiftState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift);
+        var ctrlState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
 
-                if (shiftState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down) ||
-                    ctrlState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down))
-                {
-                    return; // Allow newline
-                }
-            }
-        }
-        catch
+        if (shiftState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down) ||
+            ctrlState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down))
         {
-            // Fallback: trigger translation
+            return; // Allow newline
         }
 
         e.Handled = true;


### PR DESCRIPTION
The previous implementation used InputKeyboardSource.GetForIsland() which
requires a non-null ContentIsland. When ContentIsland was null, the fallback
path triggered translation instead of allowing newline insertion. Switch to
the static GetKeyStateForCurrentThread() method which reliably detects
modifier keys without needing a ContentIsland.

https://claude.ai/code/session_01PKmuLqvzCoEVpKvVbqG1n4