### PR TITLE
Add hash-based dedup index for long-text translation tasks

### DIFF
--- a/dotnet/src/Easydict.WinUI/Services/LongTextTaskIndexService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/LongTextTaskIndexService.cs
@@ -1,0 +1,185 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Easydict.WinUI.Services;
+
+public enum LongTextTaskStatus
+{
+    InProgress,
+    Partial,
+    Completed,
+    Failed
+}
+
+public enum LongTextEnqueueAction
+{
+    EnqueueNew,
+    ReuseCompletedOutput,
+    ResumeFromCheckpoint,
+    ForceRetranslate
+}
+
+public sealed record LongTextTaskEntry
+{
+    public required string DedupKey { get; init; }
+    public required string FileHash { get; init; }
+    public required string ServiceId { get; init; }
+    public required string FromLang { get; init; }
+    public required string ToLang { get; init; }
+    public required string PipelineVersion { get; init; }
+    public required string OutputPath { get; init; }
+    public string? CheckpointPath { get; init; }
+    public LongTextTaskStatus Status { get; init; }
+    public string? LastError { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record LongTextEnqueueDecision(LongTextEnqueueAction Action, string Prompt, LongTextTaskEntry? ExistingEntry);
+
+public sealed class LongTextTaskIndexService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly string _indexPath;
+    private readonly object _gate = new();
+    private readonly ConcurrentDictionary<string, LongTextTaskEntry> _entries;
+
+    public LongTextTaskIndexService(string indexPath)
+    {
+        if (string.IsNullOrWhiteSpace(indexPath))
+        {
+            throw new ArgumentException("Index path cannot be null or empty.", nameof(indexPath));
+        }
+
+        _indexPath = indexPath;
+        _entries = new ConcurrentDictionary<string, LongTextTaskEntry>(LoadEntries(indexPath));
+    }
+
+    public static async Task<string> ComputeFileHashAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        const int bufferSize = 1024 * 1024;
+        using var sha256 = SHA256.Create();
+        await using var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize,
+            useAsync: true);
+
+        var buffer = new byte[bufferSize];
+        int bytesRead;
+
+        while ((bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)) > 0)
+        {
+            sha256.TransformBlock(buffer, 0, bytesRead, null, 0);
+        }
+
+        sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+
+        return Convert.ToHexString(sha256.Hash!).ToLowerInvariant();
+    }
+
+    public static string BuildDedupKey(string fileHash, string serviceId, string fromLang, string toLang, string pipelineVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileHash);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fromLang);
+        ArgumentException.ThrowIfNullOrWhiteSpace(toLang);
+        ArgumentException.ThrowIfNullOrWhiteSpace(pipelineVersion);
+
+        return string.Join('|', fileHash, serviceId, fromLang, toLang, pipelineVersion);
+    }
+
+    public LongTextEnqueueDecision GetEnqueueDecision(string dedupKey, bool forceRetranslate = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dedupKey);
+
+        if (forceRetranslate)
+        {
+            return new LongTextEnqueueDecision(
+                LongTextEnqueueAction.ForceRetranslate,
+                "强制重新翻译：将忽略历史记录并重新入队。",
+                _entries.TryGetValue(dedupKey, out var forceEntry) ? forceEntry : null);
+        }
+
+        if (!_entries.TryGetValue(dedupKey, out var existingEntry))
+        {
+            return new LongTextEnqueueDecision(LongTextEnqueueAction.EnqueueNew, "未命中历史记录，创建新翻译任务。", null);
+        }
+
+        if (existingEntry.Status == LongTextTaskStatus.Completed)
+        {
+            return new LongTextEnqueueDecision(
+                LongTextEnqueueAction.ReuseCompletedOutput,
+                "命中已完成任务：可复用历史输出，或选择强制重新翻译。",
+                existingEntry);
+        }
+
+        if (existingEntry.Status == LongTextTaskStatus.Partial && !string.IsNullOrWhiteSpace(existingEntry.CheckpointPath))
+        {
+            return new LongTextEnqueueDecision(
+                LongTextEnqueueAction.ResumeFromCheckpoint,
+                "命中部分成功任务：可直接加载 checkpoint 并继续重试。",
+                existingEntry);
+        }
+
+        return new LongTextEnqueueDecision(LongTextEnqueueAction.EnqueueNew, "历史记录不可复用，创建新翻译任务。", existingEntry);
+    }
+
+    public bool TryGetEntry(string dedupKey, out LongTextTaskEntry? entry)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dedupKey);
+        return _entries.TryGetValue(dedupKey, out entry);
+    }
+
+    public async Task UpsertAsync(LongTextTaskEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        _entries[entry.DedupKey] = entry with { UpdatedAtUtc = DateTimeOffset.UtcNow };
+        await SaveAsync(cancellationToken);
+    }
+
+    private IReadOnlyDictionary<string, LongTextTaskEntry> LoadEntries(string indexPath)
+    {
+        if (!File.Exists(indexPath))
+        {
+            return new Dictionary<string, LongTextTaskEntry>();
+        }
+
+        var json = File.ReadAllText(indexPath, Encoding.UTF8);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, LongTextTaskEntry>();
+        }
+
+        var loaded = JsonSerializer.Deserialize<Dictionary<string, LongTextTaskEntry>>(json, JsonOptions);
+        return loaded ?? new Dictionary<string, LongTextTaskEntry>();
+    }
+
+    private async Task SaveAsync(CancellationToken cancellationToken)
+    {
+        Dictionary<string, LongTextTaskEntry> snapshot;
+        lock (_gate)
+        {
+            snapshot = _entries.ToDictionary(static pair => pair.Key, static pair => pair.Value);
+        }
+
+        var directory = Path.GetDirectoryName(_indexPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(snapshot, JsonOptions);
+        await File.WriteAllTextAsync(_indexPath, json, Encoding.UTF8, cancellationToken);
+    }
+}

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/LongTextTaskIndexServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/LongTextTaskIndexServiceTests.cs
@@ -1,0 +1,135 @@
+using System.Security.Cryptography;
+using System.Text;
+using Easydict.WinUI.Services;
+using FluentAssertions;
+
+namespace Easydict.WinUI.Tests.Services;
+
+[Trait("Category", "WinUI")]
+public class LongTextTaskIndexServiceTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public LongTextTaskIndexServiceTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "easydict-longtext-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    [Fact]
+    public async Task ComputeFileHashAsync_UsesStreamingHashAndReturnsSha256()
+    {
+        var filePath = Path.Combine(_tempRoot, "large-input.txt");
+        var payload = string.Concat(Enumerable.Repeat("abcdefghijklmnopqrstuvwxyz0123456789", 4096));
+        await File.WriteAllTextAsync(filePath, payload, Encoding.UTF8);
+
+        var computed = await LongTextTaskIndexService.ComputeFileHashAsync(filePath);
+
+        var expected = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+        computed.Should().Be(expected);
+    }
+
+    [Fact]
+    public void BuildDedupKey_ContainsAllRequiredParts()
+    {
+        var key = LongTextTaskIndexService.BuildDedupKey("hash123", "google", "en", "zh", "v3");
+
+        key.Should().Be("hash123|google|en|zh|v3");
+    }
+
+    [Fact]
+    public async Task GetEnqueueDecision_WhenCompletedEntryExists_ReturnsReuseMessage()
+    {
+        var indexPath = Path.Combine(_tempRoot, "index.json");
+        var service = new LongTextTaskIndexService(indexPath);
+        var dedupKey = LongTextTaskIndexService.BuildDedupKey("hash-a", "google", "en", "zh", "v1");
+
+        await service.UpsertAsync(new LongTextTaskEntry
+        {
+            DedupKey = dedupKey,
+            FileHash = "hash-a",
+            ServiceId = "google",
+            FromLang = "en",
+            ToLang = "zh",
+            PipelineVersion = "v1",
+            OutputPath = "out/result.txt",
+            Status = LongTextTaskStatus.Completed
+        });
+
+        var decision = service.GetEnqueueDecision(dedupKey);
+
+        decision.Action.Should().Be(LongTextEnqueueAction.ReuseCompletedOutput);
+        decision.Prompt.Should().Contain("复用历史输出");
+    }
+
+    [Fact]
+    public async Task GetEnqueueDecision_WhenPartialWithCheckpointExists_ReturnsResumeAction()
+    {
+        var indexPath = Path.Combine(_tempRoot, "index-partial.json");
+        var service = new LongTextTaskIndexService(indexPath);
+        var dedupKey = LongTextTaskIndexService.BuildDedupKey("hash-b", "deepseek", "ja", "zh", "v2");
+
+        await service.UpsertAsync(new LongTextTaskEntry
+        {
+            DedupKey = dedupKey,
+            FileHash = "hash-b",
+            ServiceId = "deepseek",
+            FromLang = "ja",
+            ToLang = "zh",
+            PipelineVersion = "v2",
+            OutputPath = "out/partial.txt",
+            CheckpointPath = "checkpoints/partial.ckpt.json",
+            Status = LongTextTaskStatus.Partial
+        });
+
+        var decision = service.GetEnqueueDecision(dedupKey);
+
+        decision.Action.Should().Be(LongTextEnqueueAction.ResumeFromCheckpoint);
+        decision.Prompt.Should().Contain("checkpoint");
+        decision.ExistingEntry.Should().NotBeNull();
+        decision.ExistingEntry!.CheckpointPath.Should().Be("checkpoints/partial.ckpt.json");
+    }
+
+    [Fact]
+    public async Task UpsertAsync_PersistsEntriesToLocalJsonIndex()
+    {
+        var indexPath = Path.Combine(_tempRoot, "persist-index.json");
+        var dedupKey = LongTextTaskIndexService.BuildDedupKey("hash-c", "ollama", "auto", "en", "v5");
+
+        var first = new LongTextTaskIndexService(indexPath);
+        await first.UpsertAsync(new LongTextTaskEntry
+        {
+            DedupKey = dedupKey,
+            FileHash = "hash-c",
+            ServiceId = "ollama",
+            FromLang = "auto",
+            ToLang = "en",
+            PipelineVersion = "v5",
+            OutputPath = "out/final.md",
+            Status = LongTextTaskStatus.Completed
+        });
+
+        var reloaded = new LongTextTaskIndexService(indexPath);
+        var found = reloaded.TryGetEntry(dedupKey, out var entry);
+
+        found.Should().BeTrue();
+        entry.Should().NotBeNull();
+        entry!.OutputPath.Should().Be("out/final.md");
+        entry.Status.Should().Be(LongTextTaskStatus.Completed);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best effort cleanup only.
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- 避免对相同大文件出现重复长文翻译，通过在入队前计算文件哈希并结合翻译参数生成去重键以复用历史结果或继续未完成任务。 
- 支持对大文件的流式 `SHA-256` 计算以节省内存并保证哈希正确性。 
- 需要本地索引记录输出路径和任务状态，以便实现“复用历史输出 / 强制重新翻译 / 从 checkpoint 恢复” 的入队决策。 

### Description

- 新增 `LongTextTaskIndexService`（`dotnet/src/Easydict.WinUI/Services/LongTextTaskIndexService.cs`）包含去重实体、状态枚举和索引服务实现。 
- 提供 `ComputeFileHashAsync` 方法实现流式 `SHA-256` 计算，以及 `BuildDedupKey` 按 `fileHash|serviceId|fromLang|toLang|pipelineVersion` 组装去重键。 
- 实现本地 JSON 索引持久化（加载/保存），并提供 `UpsertAsync` / `TryGetEntry` 接口用于维护条目。 
- 提供 `GetEnqueueDecision`，在入队时返回 `ReuseCompletedOutput`、`ResumeFromCheckpoint`、`EnqueueNew` 或 `ForceRetranslate` 等决策以驱动后续入队逻辑。 
- 新增单元测试 `dotnet/tests/Easydict.WinUI.Tests/Services/LongTextTaskIndexServiceTests.cs`，覆盖哈希计算、去重键构建、已完成命中、部分成功命中（含 checkpoint）及 JSON 持久化恢复。 

### Testing

- 添加了针对 `LongTextTaskIndexService` 的 xUnit 测试（见 `dotnet/tests/Easydict.WinUI.Tests/Services/LongTextTaskIndexServiceTests.cs`），用例覆盖哈希、去重键、决策路由和持久化。 
- 在当前运行环境尝试执行 `dotnet test tests/Easydict.WinUI.Tests/Easydict.WinUI.Tests.csproj --filter "FullyQualifiedName~LongTextTaskIndexServiceTests" --logger "console;verbosity=minimal"` 时失败，原因是环境中未安装 `dotnet` CLI（错误：`command not found`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ad7754d083229ac15ae64650418e)