### PR TITLE
feat: staged LongDocumentTranslationService pipeline with structured IR, formula protection, OCR fallback and glossary support

### DIFF
--- a/dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentModels.cs
+++ b/dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentModels.cs
@@ -1,0 +1,152 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Easydict.TranslationService.Models;
+
+namespace Easydict.TranslationService.LongDocument;
+
+public enum DocumentBlockType
+{
+    Paragraph,
+    Caption,
+    Table,
+    Formula,
+    FormulaPlaceholder,
+    Heading,
+    Unknown,
+}
+
+public sealed record DocumentCoordinates(float X, float Y, float Width, float Height);
+
+public sealed record SourceDocumentBlock
+{
+    public required string Id { get; init; }
+    public required int PageNumber { get; init; }
+    public required int ReadingOrder { get; init; }
+    public required DocumentBlockType BlockType { get; init; }
+    public required string Text { get; init; }
+    public DocumentCoordinates? Coordinates { get; init; }
+    public string? ParentBlockId { get; init; }
+}
+
+public sealed record SourceDocumentPage
+{
+    public required int PageNumber { get; init; }
+    public required IReadOnlyList<SourceDocumentBlock> Blocks { get; init; }
+}
+
+public sealed record LongDocumentTranslationRequest
+{
+    public required Language FromLanguage { get; init; }
+    public required Language ToLanguage { get; init; }
+    public required IReadOnlyList<SourceDocumentPage> Pages { get; init; }
+    public bool IsScannedPdf { get; init; }
+    public IReadOnlyList<SourceDocumentPage>? OcrFallbackPages { get; init; }
+    public LongDocumentTranslationOptions Options { get; init; } = new();
+}
+
+public sealed record LongDocumentTranslationOptions
+{
+    public bool EnableOcrFallback { get; init; } = true;
+    public bool EnableGlossaryConsistency { get; init; }
+    public IReadOnlyDictionary<string, string>? Glossary { get; init; }
+    public int MaxRetriesPerBlock { get; init; } = 1;
+    public int TimeoutMs { get; init; } = 30000;
+}
+
+public sealed record DocumentBlockIr
+{
+    public required string Id { get; init; }
+    public required int PageNumber { get; init; }
+    public required int ReadingOrder { get; init; }
+    public required DocumentBlockType BlockType { get; init; }
+    public required string Text { get; init; }
+    public required string SourceHash { get; init; }
+    public DocumentCoordinates? Coordinates { get; init; }
+    public string? ParentBlockId { get; init; }
+
+    public static string ComputeHash(string text)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(text));
+        return Convert.ToHexString(bytes);
+    }
+}
+
+public sealed record DocumentPageIr
+{
+    public required int PageNumber { get; init; }
+    public required IReadOnlyList<DocumentBlockIr> Blocks { get; init; }
+}
+
+public sealed record DocumentIr
+{
+    public required IReadOnlyList<DocumentPageIr> Pages { get; init; }
+    public bool UsedOcrFallback { get; init; }
+}
+
+public sealed record TranslatedDocumentBlock
+{
+    public required string Id { get; init; }
+    public required int PageNumber { get; init; }
+    public required int ReadingOrder { get; init; }
+    public required DocumentBlockType BlockType { get; init; }
+    public required string SourceText { get; init; }
+    public required string SourceHash { get; init; }
+    public required string TranslatedText { get; init; }
+    public DocumentCoordinates? Coordinates { get; init; }
+    public string? ParentBlockId { get; init; }
+}
+
+public sealed record TranslatedDocumentPage
+{
+    public required int PageNumber { get; init; }
+    public required IReadOnlyList<TranslatedDocumentBlock> Blocks { get; init; }
+}
+
+public sealed record FailedDocumentBlock(int PageNumber, string BlockId, int Attempts, string ErrorMessage);
+public sealed record StageTiming(string Stage, long DurationMs);
+
+public sealed record LongDocumentQualityReport
+{
+    public required IReadOnlyList<int> FailedPages { get; init; }
+    public required IReadOnlyList<FailedDocumentBlock> FailedBlocks { get; init; }
+    public required int RetryCount { get; init; }
+    public required IReadOnlyList<StageTiming> StageTimings { get; init; }
+}
+
+public sealed record LongDocumentTranslationResult
+{
+    public required DocumentIr IntermediateRepresentation { get; init; }
+    public required IReadOnlyList<TranslatedDocumentPage> Pages { get; init; }
+    public required string StructuredOutputText { get; init; }
+    public required LongDocumentQualityReport QualityReport { get; init; }
+}
+
+internal static partial class FormulaPatterns
+{
+    [GeneratedRegex("\\$\\$(?<m>[\\s\\S]*?)\\$\\$", RegexOptions.Compiled)]
+    public static partial Regex DisplayMathRegex();
+
+    [GeneratedRegex("\\\\\\[(?<m>[\\s\\S]*?)\\\\\\]", RegexOptions.Compiled)]
+    public static partial Regex BracketMathRegex();
+}
+
+internal static class DocumentPipelineStopwatch
+{
+    public static (T Value, StageTiming Timing) Measure<T>(string stage, Func<T> action)
+    {
+        var sw = Stopwatch.StartNew();
+        var value = action();
+        sw.Stop();
+        return (value, new StageTiming(stage, sw.ElapsedMilliseconds));
+    }
+
+    public static async Task<(T Value, StageTiming Timing)> MeasureAsync<T>(string stage, Func<Task<T>> action)
+    {
+        var sw = Stopwatch.StartNew();
+        var value = await action().ConfigureAwait(false);
+        sw.Stop();
+        return (value, new StageTiming(stage, sw.ElapsedMilliseconds));
+    }
+}

--- a/dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentTranslationService.cs
+++ b/dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentTranslationService.cs
@@ -1,0 +1,283 @@
+using System.Text;
+using Easydict.TranslationService.Models;
+
+namespace Easydict.TranslationService.LongDocument;
+
+public sealed class LongDocumentTranslationService
+{
+    private readonly ITranslationService _translationService;
+
+    public LongDocumentTranslationService(ITranslationService translationService)
+    {
+        _translationService = translationService;
+    }
+
+    public async Task<LongDocumentTranslationResult> TranslateAsync(
+        LongDocumentTranslationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var timings = new List<StageTiming>();
+        var retryCount = 0;
+        var failedBlocks = new List<FailedDocumentBlock>();
+
+        var (pages, ingestTiming) = DocumentPipelineStopwatch.Measure("ingest", () => SelectSourcePages(request));
+        timings.Add(ingestTiming);
+
+        var (ir, irTiming) = DocumentPipelineStopwatch.Measure("build-ir", () => BuildIntermediateRepresentation(pages, request.IsScannedPdf && request.Options.EnableOcrFallback));
+        timings.Add(irTiming);
+
+        var (protectedIr, protectTiming) = DocumentPipelineStopwatch.Measure("formula-protection", () => ProtectFormulas(ir));
+        timings.Add(protectTiming);
+
+        var (translatedPages, translateTiming) = await DocumentPipelineStopwatch.MeasureAsync("translate", async () =>
+            await TranslateBlocksAsync(request, protectedIr, failedBlocks, r => retryCount += r, cancellationToken).ConfigureAwait(false));
+        timings.Add(translateTiming);
+
+        var (structuredOutput, outputTiming) = DocumentPipelineStopwatch.Measure("structured-layout-output", () => BuildStructuredOutput(translatedPages));
+        timings.Add(outputTiming);
+
+        var failedPages = failedBlocks
+            .Select(x => x.PageNumber)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToList();
+
+        return new LongDocumentTranslationResult
+        {
+            IntermediateRepresentation = protectedIr,
+            Pages = translatedPages,
+            StructuredOutputText = structuredOutput,
+            QualityReport = new LongDocumentQualityReport
+            {
+                FailedPages = failedPages,
+                FailedBlocks = failedBlocks,
+                RetryCount = retryCount,
+                StageTimings = timings,
+            },
+        };
+    }
+
+    private static IReadOnlyList<SourceDocumentPage> SelectSourcePages(LongDocumentTranslationRequest request)
+    {
+        if (request.IsScannedPdf &&
+            request.Options.EnableOcrFallback &&
+            request.OcrFallbackPages is { Count: > 0 })
+        {
+            return request.OcrFallbackPages;
+        }
+
+        return request.Pages;
+    }
+
+    private static DocumentIr BuildIntermediateRepresentation(IReadOnlyList<SourceDocumentPage> pages, bool usedOcrFallback)
+    {
+        var irPages = pages
+            .OrderBy(p => p.PageNumber)
+            .Select(page => new DocumentPageIr
+            {
+                PageNumber = page.PageNumber,
+                Blocks = page.Blocks
+                    .OrderBy(b => b.ReadingOrder)
+                    .Select(block => new DocumentBlockIr
+                    {
+                        Id = block.Id,
+                        PageNumber = block.PageNumber,
+                        ReadingOrder = block.ReadingOrder,
+                        BlockType = block.BlockType,
+                        Text = block.Text,
+                        SourceHash = DocumentBlockIr.ComputeHash(block.Text),
+                        Coordinates = block.Coordinates,
+                        ParentBlockId = block.ParentBlockId,
+                    })
+                    .ToList(),
+            })
+            .ToList();
+
+        return new DocumentIr
+        {
+            Pages = irPages,
+            UsedOcrFallback = usedOcrFallback,
+        };
+    }
+
+    private static DocumentIr ProtectFormulas(DocumentIr documentIr)
+    {
+        var pages = new List<DocumentPageIr>();
+
+        foreach (var page in documentIr.Pages)
+        {
+            var protectedBlocks = new List<DocumentBlockIr>();
+
+            foreach (var block in page.Blocks)
+            {
+                if (block.BlockType == DocumentBlockType.Formula)
+                {
+                    protectedBlocks.Add(block with { BlockType = DocumentBlockType.FormulaPlaceholder, Text = "[FORMULA_BLOCK]" });
+                    continue;
+                }
+
+                var protectedText = FormulaPatterns.DisplayMathRegex().Replace(block.Text, "[FORMULA_BLOCK]");
+                protectedText = FormulaPatterns.BracketMathRegex().Replace(protectedText, "[FORMULA_BLOCK]");
+
+                protectedBlocks.Add(block with
+                {
+                    Text = protectedText,
+                    SourceHash = DocumentBlockIr.ComputeHash(block.Text),
+                });
+            }
+
+            pages.Add(new DocumentPageIr
+            {
+                PageNumber = page.PageNumber,
+                Blocks = protectedBlocks,
+            });
+        }
+
+        return documentIr with { Pages = pages };
+    }
+
+    private async Task<IReadOnlyList<TranslatedDocumentPage>> TranslateBlocksAsync(
+        LongDocumentTranslationRequest request,
+        DocumentIr ir,
+        List<FailedDocumentBlock> failedBlocks,
+        Action<int> retryCounter,
+        CancellationToken cancellationToken)
+    {
+        var result = new List<TranslatedDocumentPage>();
+
+        foreach (var page in ir.Pages)
+        {
+            var translatedBlocks = new List<TranslatedDocumentBlock>();
+
+            foreach (var block in page.Blocks.OrderBy(x => x.ReadingOrder))
+            {
+                if (block.BlockType is DocumentBlockType.Formula or DocumentBlockType.FormulaPlaceholder)
+                {
+                    translatedBlocks.Add(ToTranslatedBlock(block, block.Text));
+                    continue;
+                }
+
+                var translatedText = await TranslateWithRetryAsync(
+                    block,
+                    request,
+                    failedBlocks,
+                    retryCounter,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (request.Options.EnableGlossaryConsistency && request.Options.Glossary is { Count: > 0 })
+                {
+                    translatedText = EnforceGlossary(translatedText, request.Options.Glossary);
+                }
+
+                translatedBlocks.Add(ToTranslatedBlock(block, translatedText));
+            }
+
+            result.Add(new TranslatedDocumentPage
+            {
+                PageNumber = page.PageNumber,
+                Blocks = translatedBlocks,
+            });
+        }
+
+        return result;
+    }
+
+    private async Task<string> TranslateWithRetryAsync(
+        DocumentBlockIr block,
+        LongDocumentTranslationRequest request,
+        List<FailedDocumentBlock> failedBlocks,
+        Action<int> retryCounter,
+        CancellationToken cancellationToken)
+    {
+        var maxAttempts = request.Options.MaxRetriesPerBlock + 1;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                var translationRequest = new TranslationRequest
+                {
+                    Text = block.Text,
+                    FromLanguage = request.FromLanguage,
+                    ToLanguage = request.ToLanguage,
+                    TimeoutMs = request.Options.TimeoutMs,
+                };
+
+                var translated = await _translationService.TranslateAsync(translationRequest, cancellationToken).ConfigureAwait(false);
+                return translated.TranslatedText;
+            }
+            catch (Exception ex) when (attempt < maxAttempts)
+            {
+                retryCounter(1);
+            }
+            catch (Exception ex)
+            {
+                failedBlocks.Add(new FailedDocumentBlock(block.PageNumber, block.Id, attempt, ex.Message));
+                return block.Text;
+            }
+        }
+
+        return block.Text;
+    }
+
+    private static TranslatedDocumentBlock ToTranslatedBlock(DocumentBlockIr block, string translatedText)
+    {
+        return new TranslatedDocumentBlock
+        {
+            Id = block.Id,
+            PageNumber = block.PageNumber,
+            ReadingOrder = block.ReadingOrder,
+            BlockType = block.BlockType,
+            SourceText = block.Text,
+            SourceHash = block.SourceHash,
+            TranslatedText = translatedText,
+            Coordinates = block.Coordinates,
+            ParentBlockId = block.ParentBlockId,
+        };
+    }
+
+    private static string BuildStructuredOutput(IReadOnlyList<TranslatedDocumentPage> pages)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var page in pages.OrderBy(x => x.PageNumber))
+        {
+            sb.AppendLine($"## Page {page.PageNumber}");
+
+            var lookup = page.Blocks.ToDictionary(x => x.Id, x => x);
+            foreach (var block in page.Blocks.OrderBy(x => x.ReadingOrder))
+            {
+                if (block.BlockType == DocumentBlockType.Caption &&
+                    !string.IsNullOrEmpty(block.ParentBlockId) &&
+                    lookup.TryGetValue(block.ParentBlockId, out var parent))
+                {
+                    sb.AppendLine($"- Caption (for {parent.BlockType}:{parent.Id}): {block.TranslatedText}");
+                    continue;
+                }
+
+                if (block.BlockType == DocumentBlockType.Paragraph)
+                {
+                    sb.AppendLine($"- Paragraph: {block.TranslatedText}");
+                    continue;
+                }
+
+                sb.AppendLine($"- {block.BlockType}: {block.TranslatedText}");
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    private static string EnforceGlossary(string text, IReadOnlyDictionary<string, string> glossary)
+    {
+        var normalized = text;
+        foreach (var item in glossary)
+        {
+            normalized = normalized.Replace(item.Key, item.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return normalized;
+    }
+}

--- a/dotnet/tests/Easydict.TranslationService.Tests/LongDocument/LongDocumentTranslationServiceTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/LongDocument/LongDocumentTranslationServiceTests.cs
@@ -1,0 +1,237 @@
+using Easydict.TranslationService.LongDocument;
+using Easydict.TranslationService.Models;
+using FluentAssertions;
+
+namespace Easydict.TranslationService.Tests.LongDocument;
+
+public class LongDocumentTranslationServiceTests
+{
+    [Fact]
+    public async Task TranslateAsync_BuildsStructuredIr_PreservesMetadataAndCaptionOwnership()
+    {
+        var fakeService = new FakeTranslationService(text => $"ZH:{text}");
+        var sut = new LongDocumentTranslationService(fakeService);
+
+        var request = new LongDocumentTranslationRequest
+        {
+            FromLanguage = Language.English,
+            ToLanguage = Language.ChineseSimplified,
+            Pages =
+            [
+                new SourceDocumentPage
+                {
+                    PageNumber = 1,
+                    Blocks =
+                    [
+                        new SourceDocumentBlock
+                        {
+                            Id = "p1-b1",
+                            PageNumber = 1,
+                            ReadingOrder = 1,
+                            BlockType = DocumentBlockType.Paragraph,
+                            Text = "This is a paragraph.",
+                            Coordinates = new DocumentCoordinates(1, 1, 100, 24),
+                        },
+                        new SourceDocumentBlock
+                        {
+                            Id = "p1-b2",
+                            PageNumber = 1,
+                            ReadingOrder = 2,
+                            BlockType = DocumentBlockType.Table,
+                            Text = "A | B",
+                        },
+                        new SourceDocumentBlock
+                        {
+                            Id = "p1-b3",
+                            PageNumber = 1,
+                            ReadingOrder = 3,
+                            BlockType = DocumentBlockType.Caption,
+                            ParentBlockId = "p1-b2",
+                            Text = "Table 1: Summary",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var result = await sut.TranslateAsync(request);
+
+        result.IntermediateRepresentation.Pages.Should().HaveCount(1);
+        result.IntermediateRepresentation.Pages[0].Blocks.Should().HaveCount(3);
+        result.Pages[0].Blocks[0].SourceHash.Should().NotBeNullOrWhiteSpace();
+        result.Pages[0].Blocks[0].Coordinates.Should().BeEquivalentTo(new DocumentCoordinates(1, 1, 100, 24));
+
+        result.StructuredOutputText.Should().Contain("Paragraph: ZH:This is a paragraph.");
+        result.StructuredOutputText.Should().Contain("Caption (for Table:p1-b2): ZH:Table 1: Summary");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ProtectsFormulaBlocks_AndSkipsTranslation()
+    {
+        var fakeService = new FakeTranslationService(text => $"TR:{text}");
+        var sut = new LongDocumentTranslationService(fakeService);
+
+        var request = new LongDocumentTranslationRequest
+        {
+            FromLanguage = Language.English,
+            ToLanguage = Language.ChineseSimplified,
+            Pages =
+            [
+                new SourceDocumentPage
+                {
+                    PageNumber = 1,
+                    Blocks =
+                    [
+                        new SourceDocumentBlock
+                        {
+                            Id = "f1",
+                            PageNumber = 1,
+                            ReadingOrder = 1,
+                            BlockType = DocumentBlockType.Formula,
+                            Text = "$$E=mc^2$$",
+                        },
+                        new SourceDocumentBlock
+                        {
+                            Id = "p1",
+                            PageNumber = 1,
+                            ReadingOrder = 2,
+                            BlockType = DocumentBlockType.Paragraph,
+                            Text = "Equation $$E=mc^2$$ should remain.",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var result = await sut.TranslateAsync(request);
+
+        result.Pages[0].Blocks[0].TranslatedText.Should().Be("[FORMULA_BLOCK]");
+        result.Pages[0].Blocks[1].SourceText.Should().Contain("[FORMULA_BLOCK]");
+        fakeService.TranslateCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TranslateAsync_UsesOcrFallbackGlossaryAndQualityReport()
+    {
+        var fakeService = new FakeTranslationService(text =>
+        {
+            if (text.Contains("fail", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("synthetic failure");
+            }
+
+            return $"AI output: {text}";
+        });
+
+        var sut = new LongDocumentTranslationService(fakeService);
+
+        var request = new LongDocumentTranslationRequest
+        {
+            FromLanguage = Language.English,
+            ToLanguage = Language.ChineseSimplified,
+            IsScannedPdf = true,
+            Pages =
+            [
+                new SourceDocumentPage
+                {
+                    PageNumber = 1,
+                    Blocks =
+                    [
+                        new SourceDocumentBlock
+                        {
+                            Id = "orig",
+                            PageNumber = 1,
+                            ReadingOrder = 1,
+                            BlockType = DocumentBlockType.Paragraph,
+                            Text = "original ignored",
+                        },
+                    ],
+                },
+            ],
+            OcrFallbackPages =
+            [
+                new SourceDocumentPage
+                {
+                    PageNumber = 5,
+                    Blocks =
+                    [
+                        new SourceDocumentBlock
+                        {
+                            Id = "ocr1",
+                            PageNumber = 5,
+                            ReadingOrder = 1,
+                            BlockType = DocumentBlockType.Paragraph,
+                            Text = "AI term",
+                        },
+                        new SourceDocumentBlock
+                        {
+                            Id = "ocr2",
+                            PageNumber = 5,
+                            ReadingOrder = 2,
+                            BlockType = DocumentBlockType.Paragraph,
+                            Text = "please fail",
+                        },
+                    ],
+                },
+            ],
+            Options = new LongDocumentTranslationOptions
+            {
+                EnableOcrFallback = true,
+                EnableGlossaryConsistency = true,
+                Glossary = new Dictionary<string, string>
+                {
+                    ["AI"] = "人工智能",
+                },
+                MaxRetriesPerBlock = 2,
+            },
+        };
+
+        var result = await sut.TranslateAsync(request);
+
+        result.IntermediateRepresentation.UsedOcrFallback.Should().BeTrue();
+        result.Pages[0].PageNumber.Should().Be(5);
+        result.Pages[0].Blocks[0].TranslatedText.Should().Contain("人工智能 output");
+        result.QualityReport.FailedPages.Should().ContainSingle().Which.Should().Be(5);
+        result.QualityReport.FailedBlocks.Should().ContainSingle(x => x.BlockId == "ocr2");
+        result.QualityReport.RetryCount.Should().Be(2);
+        result.QualityReport.StageTimings.Should().Contain(x => x.Stage == "translate");
+    }
+
+    private sealed class FakeTranslationService : ITranslationService
+    {
+        private readonly Func<string, string> _translator;
+
+        public FakeTranslationService(Func<string, string> translator)
+        {
+            _translator = translator;
+        }
+
+        public int TranslateCalls { get; private set; }
+
+        public string ServiceId => "fake";
+        public string DisplayName => "Fake";
+        public bool RequiresApiKey => false;
+        public bool IsConfigured => true;
+        public IReadOnlyList<Language> SupportedLanguages => [Language.Auto, Language.English, Language.ChineseSimplified];
+
+        public bool SupportsLanguagePair(Language from, Language to) => true;
+
+        public Task<Language> DetectLanguageAsync(string text, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Language.English);
+        }
+
+        public Task<TranslationResult> TranslateAsync(TranslationRequest request, CancellationToken cancellationToken = default)
+        {
+            TranslateCalls++;
+            var translated = _translator(request.Text);
+            return Task.FromResult(new TranslationResult
+            {
+                OriginalText = request.Text,
+                TranslatedText = translated,
+                TargetLanguage = request.ToLanguage,
+                ServiceName = "fake",
+            });
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a structured, multi-stage pipeline to support translating long/structured documents (pages, paragraphs, captions, tables, formulas) while preserving layout and block-level metadata.
- Protect math content from being corrupted by translation by introducing formula placeholders and excluding them from translation requests.
- Provide robust fallbacks and diagnostics (OCR fallback for scanned PDFs, glossary consistency option, per-block retries and a quality report) to improve accuracy and observability.

### Description
- Add long-document domain and IR models in `dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentModels.cs` including `SourceDocumentPage`/`Block`, `DocumentBlockIr`, `DocumentIr`, `TranslatedDocumentPage`, glossary/options and quality report types.
- Implement `LongDocumentTranslationService` in `dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentTranslationService.cs` which runs the staged pipeline: `ingest -> build-ir -> formula-protection -> translate -> structured-layout-output`, preserves block metadata (page, coords, block type, source hash, parent relations), supports OCR fallback selection, applies optional glossary post-processing, implements per-block retry and collects failed-block info and per-stage timings.
- Add unit tests in `dotnet/tests/Easydict.TranslationService.Tests/LongDocument/LongDocumentTranslationServiceTests.cs` covering IR/metadata retention, formula protection and skipping translation, OCR fallback behavior, glossary enforcement, retry accounting and quality-report fields.

### Testing
- Added xUnit tests under `dotnet/tests/Easydict.TranslationService.Tests/LongDocument` that exercise main scenarios but were not executed in this environment.
- Attempted to run `dotnet test --filter "FullyQualifiedName~LongDocumentTranslationServiceTests"` but `dotnet` is unavailable here so tests could not be run locally in the CI environment.
- The change is self-contained to the `Easydict.TranslationService` project and tests; please run `dotnet test` on a machine with the .NET SDK to validate behavior and timing assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ad827ed883229967b1f63dfe338c)