### PR TITLE
feat(longdoc): staged long-document pipeline, IR models, UI support, dedup & tests

### DIFF
--- a/dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentModels.cs
+++ b/dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentModels.cs
@@ -1,0 +1,125 @@
+using Easydict.TranslationService.Models;
+
+namespace Easydict.TranslationService.LongDocument;
+
+public enum SourceBlockType
+{
+    Paragraph,
+    Heading,
+    Caption,
+    TableCell,
+    Formula,
+    Unknown
+}
+
+public enum BlockType
+{
+    Paragraph,
+    Heading,
+    Caption,
+    Table,
+    Formula,
+    Unknown
+}
+
+public readonly record struct BlockRect(double X, double Y, double Width, double Height);
+
+public sealed record SourceDocumentBlock
+{
+    public required string BlockId { get; init; }
+    public required SourceBlockType BlockType { get; init; }
+    public required string Text { get; init; }
+    public BlockRect? BoundingBox { get; init; }
+    public string? ParentBlockId { get; init; }
+    public bool IsFormulaLike { get; init; }
+}
+
+public sealed record SourceDocumentPage
+{
+    public required int PageNumber { get; init; }
+    public required IReadOnlyList<SourceDocumentBlock> Blocks { get; init; }
+    public bool IsScanned { get; init; }
+}
+
+public sealed record SourceDocument
+{
+    public required string DocumentId { get; init; }
+    public required IReadOnlyList<SourceDocumentPage> Pages { get; init; }
+}
+
+public sealed record DocumentBlockIr
+{
+    public required string IrBlockId { get; init; }
+    public required int PageNumber { get; init; }
+    public required string SourceBlockId { get; init; }
+    public required BlockType BlockType { get; init; }
+    public required string OriginalText { get; init; }
+    public required string ProtectedText { get; init; }
+    public required string SourceHash { get; init; }
+    public BlockRect? BoundingBox { get; init; }
+    public string? ParentIrBlockId { get; init; }
+    public bool TranslationSkipped { get; init; }
+}
+
+public sealed record DocumentIr
+{
+    public required string DocumentId { get; init; }
+    public required IReadOnlyList<DocumentBlockIr> Blocks { get; init; }
+}
+
+public sealed record TranslatedDocumentPage
+{
+    public required int PageNumber { get; init; }
+    public required IReadOnlyList<TranslatedDocumentBlock> Blocks { get; init; }
+}
+
+public sealed record TranslatedDocumentBlock
+{
+    public required string IrBlockId { get; init; }
+    public required string SourceBlockId { get; init; }
+    public required BlockType BlockType { get; init; }
+    public required string OriginalText { get; init; }
+    public required string ProtectedText { get; init; }
+    public required string TranslatedText { get; init; }
+    public required string SourceHash { get; init; }
+    public BlockRect? BoundingBox { get; init; }
+    public bool TranslationSkipped { get; init; }
+    public int RetryCount { get; init; }
+    public string? LastError { get; init; }
+}
+
+public sealed record LongDocumentTranslationOptions
+{
+    public string ServiceId { get; init; } = "google";
+    public Language FromLanguage { get; init; } = Language.Auto;
+    public required Language ToLanguage { get; init; }
+    public bool EnableFormulaProtection { get; init; } = true;
+    public bool EnableOcrFallback { get; init; } = true;
+    public int MaxRetriesPerBlock { get; init; } = 1;
+    public IReadOnlyDictionary<string, string>? Glossary { get; init; }
+}
+
+public sealed record FailedBlockInfo
+{
+    public required string IrBlockId { get; init; }
+    public required string SourceBlockId { get; init; }
+    public required int PageNumber { get; init; }
+    public required int RetryCount { get; init; }
+    public required string Error { get; init; }
+}
+
+public sealed record LongDocumentQualityReport
+{
+    public required IReadOnlyDictionary<string, long> StageTimingsMs { get; init; }
+    public required int TotalBlocks { get; init; }
+    public required int TranslatedBlocks { get; init; }
+    public required int SkippedBlocks { get; init; }
+    public required IReadOnlyList<FailedBlockInfo> FailedBlocks { get; init; }
+}
+
+public sealed record LongDocumentTranslationResult
+{
+    public required DocumentIr Ir { get; init; }
+    public required IReadOnlyList<TranslatedDocumentPage> Pages { get; init; }
+    public required LongDocumentQualityReport QualityReport { get; init; }
+}

--- a/dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentTranslationService.cs
+++ b/dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentTranslationService.cs
@@ -1,0 +1,326 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Easydict.TranslationService.Models;
+
+namespace Easydict.TranslationService.LongDocument;
+
+public sealed class LongDocumentTranslationService
+{
+    private static readonly Regex FormulaRegex = new(@"(\$[^$]+\$|\\\([^\)]+\\\)|\\\[[^\]]+\\\]|[A-Za-z]\s*=\s*[^\s]+)", RegexOptions.Compiled);
+
+    private readonly Func<TranslationRequest, string, CancellationToken, Task<TranslationResult>> _translateWithService;
+    private readonly Func<SourceDocumentPage, CancellationToken, Task<string?>> _ocrExtractor;
+
+    public LongDocumentTranslationService(
+        TranslationManager? manager = null,
+        Func<TranslationRequest, string, CancellationToken, Task<TranslationResult>>? translateWithService = null,
+        Func<SourceDocumentPage, CancellationToken, Task<string?>>? ocrExtractor = null)
+    {
+        if (translateWithService is not null)
+        {
+            _translateWithService = translateWithService;
+        }
+        else
+        {
+            var activeManager = manager ?? new TranslationManager();
+            _translateWithService = (request, serviceId, ct) => activeManager.TranslateAsync(request, ct, serviceId);
+        }
+
+        _ocrExtractor = ocrExtractor ?? ((_, _) => Task.FromResult<string?>(null));
+    }
+
+    public async Task<LongDocumentTranslationResult> TranslateAsync(
+        SourceDocument source,
+        LongDocumentTranslationOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        var timings = new Dictionary<string, long>();
+
+        var ingestSw = Stopwatch.StartNew();
+        var ingested = await IngestAsync(source, options, cancellationToken);
+        ingestSw.Stop();
+        timings["ingest"] = ingestSw.ElapsedMilliseconds;
+
+        var buildIrSw = Stopwatch.StartNew();
+        var ir = BuildIr(ingested);
+        buildIrSw.Stop();
+        timings["build-ir"] = buildIrSw.ElapsedMilliseconds;
+
+        var formulaSw = Stopwatch.StartNew();
+        ir = options.EnableFormulaProtection ? ApplyFormulaProtection(ir) : ir;
+        formulaSw.Stop();
+        timings["formula-protection"] = formulaSw.ElapsedMilliseconds;
+
+        var translateSw = Stopwatch.StartNew();
+        var translatedBlocks = await TranslateBlocksAsync(ir, options, cancellationToken);
+        translateSw.Stop();
+        timings["translate"] = translateSw.ElapsedMilliseconds;
+
+        var layoutSw = Stopwatch.StartNew();
+        var pages = BuildStructuredOutput(ir, translatedBlocks);
+        layoutSw.Stop();
+        timings["structured-layout-output"] = layoutSw.ElapsedMilliseconds;
+
+        var failedBlocks = translatedBlocks.Values
+            .Where(block => !string.IsNullOrWhiteSpace(block.LastError))
+            .Select(block => new FailedBlockInfo
+            {
+                IrBlockId = block.IrBlockId,
+                SourceBlockId = block.SourceBlockId,
+                PageNumber = ir.Blocks.First(b => b.IrBlockId == block.IrBlockId).PageNumber,
+                RetryCount = block.RetryCount,
+                Error = block.LastError!
+            })
+            .ToList();
+
+        var translatedCount = translatedBlocks.Values.Count(b => !b.TranslationSkipped && string.IsNullOrWhiteSpace(b.LastError));
+        var skippedCount = translatedBlocks.Values.Count(b => b.TranslationSkipped);
+
+        return new LongDocumentTranslationResult
+        {
+            Ir = ir,
+            Pages = pages,
+            QualityReport = new LongDocumentQualityReport
+            {
+                StageTimingsMs = timings,
+                TotalBlocks = ir.Blocks.Count,
+                TranslatedBlocks = translatedCount,
+                SkippedBlocks = skippedCount,
+                FailedBlocks = failedBlocks
+            }
+        };
+    }
+
+    private async Task<SourceDocument> IngestAsync(
+        SourceDocument source,
+        LongDocumentTranslationOptions options,
+        CancellationToken cancellationToken)
+    {
+        if (!options.EnableOcrFallback)
+        {
+            return source;
+        }
+
+        var pages = new List<SourceDocumentPage>(source.Pages.Count);
+        foreach (var page in source.Pages)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!page.IsScanned || page.Blocks.Count > 0)
+            {
+                pages.Add(page);
+                continue;
+            }
+
+            var ocrText = await _ocrExtractor(page, cancellationToken);
+            if (string.IsNullOrWhiteSpace(ocrText))
+            {
+                pages.Add(page);
+                continue;
+            }
+
+            pages.Add(page with
+            {
+                IsScanned = false,
+                Blocks =
+                [
+                    new SourceDocumentBlock
+                    {
+                        BlockId = $"ocr-p{page.PageNumber}",
+                        BlockType = SourceBlockType.Paragraph,
+                        Text = ocrText,
+                        IsFormulaLike = false
+                    }
+                ]
+            });
+        }
+
+        return source with { Pages = pages };
+    }
+
+    private static DocumentIr BuildIr(SourceDocument source)
+    {
+        var irBlocks = new List<DocumentBlockIr>();
+
+        foreach (var page in source.Pages)
+        {
+            foreach (var block in page.Blocks)
+            {
+                var irBlockId = $"ir-{page.PageNumber}-{block.BlockId}";
+                var sourceHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(block.Text ?? string.Empty)));
+
+                irBlocks.Add(new DocumentBlockIr
+                {
+                    IrBlockId = irBlockId,
+                    PageNumber = page.PageNumber,
+                    SourceBlockId = block.BlockId,
+                    BlockType = MapBlockType(block.BlockType),
+                    OriginalText = block.Text,
+                    ProtectedText = block.Text,
+                    SourceHash = sourceHash,
+                    BoundingBox = block.BoundingBox,
+                    ParentIrBlockId = block.ParentBlockId is null ? null : $"ir-{page.PageNumber}-{block.ParentBlockId}",
+                    TranslationSkipped = block.BlockType == SourceBlockType.Formula || block.IsFormulaLike
+                });
+            }
+        }
+
+        return new DocumentIr
+        {
+            DocumentId = source.DocumentId,
+            Blocks = irBlocks
+        };
+    }
+
+    private static DocumentIr ApplyFormulaProtection(DocumentIr ir)
+    {
+        var blocks = ir.Blocks.Select(block =>
+        {
+            if (block.TranslationSkipped)
+            {
+                return block;
+            }
+
+            var protectedText = FormulaRegex.Replace(block.ProtectedText, m => $"[[FORMULA:{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(m.Value))).Substring(0, 8)}]]");
+            var shouldSkip = protectedText.StartsWith("[[FORMULA:", StringComparison.Ordinal) &&
+                             protectedText.EndsWith("]]", StringComparison.Ordinal) &&
+                             !protectedText.Contains(' ');
+
+            return block with
+            {
+                ProtectedText = protectedText,
+                TranslationSkipped = shouldSkip
+            };
+        }).ToList();
+
+        return ir with { Blocks = blocks };
+    }
+
+    private async Task<Dictionary<string, TranslatedDocumentBlock>> TranslateBlocksAsync(
+        DocumentIr ir,
+        LongDocumentTranslationOptions options,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<string, TranslatedDocumentBlock>(StringComparer.Ordinal);
+
+        foreach (var block in ir.Blocks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (block.TranslationSkipped)
+            {
+                result[block.IrBlockId] = new TranslatedDocumentBlock
+                {
+                    IrBlockId = block.IrBlockId,
+                    SourceBlockId = block.SourceBlockId,
+                    BlockType = block.BlockType,
+                    OriginalText = block.OriginalText,
+                    ProtectedText = block.ProtectedText,
+                    TranslatedText = block.OriginalText,
+                    SourceHash = block.SourceHash,
+                    BoundingBox = block.BoundingBox,
+                    TranslationSkipped = true,
+                    RetryCount = 0
+                };
+                continue;
+            }
+
+            var retryCount = 0;
+            string? lastError = null;
+            string translatedText = block.ProtectedText;
+
+            for (; retryCount <= options.MaxRetriesPerBlock; retryCount++)
+            {
+                try
+                {
+                    var request = new TranslationRequest
+                    {
+                        Text = block.ProtectedText,
+                        FromLanguage = options.FromLanguage,
+                        ToLanguage = options.ToLanguage
+                    };
+
+                    var translated = await _translateWithService(request, options.ServiceId, cancellationToken);
+                    translatedText = ApplyGlossary(translated.TranslatedText, options.Glossary);
+                    lastError = null;
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    lastError = ex.Message;
+                    if (retryCount >= options.MaxRetriesPerBlock)
+                    {
+                        translatedText = block.OriginalText;
+                    }
+                }
+            }
+
+            result[block.IrBlockId] = new TranslatedDocumentBlock
+            {
+                IrBlockId = block.IrBlockId,
+                SourceBlockId = block.SourceBlockId,
+                BlockType = block.BlockType,
+                OriginalText = block.OriginalText,
+                ProtectedText = block.ProtectedText,
+                TranslatedText = translatedText,
+                SourceHash = block.SourceHash,
+                BoundingBox = block.BoundingBox,
+                TranslationSkipped = false,
+                RetryCount = retryCount,
+                LastError = lastError
+            };
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyList<TranslatedDocumentPage> BuildStructuredOutput(
+        DocumentIr ir,
+        Dictionary<string, TranslatedDocumentBlock> translatedBlocks)
+    {
+        return ir.Blocks
+            .GroupBy(b => b.PageNumber)
+            .OrderBy(g => g.Key)
+            .Select(group => new TranslatedDocumentPage
+            {
+                PageNumber = group.Key,
+                Blocks = group
+                    .OrderBy(b => b.IrBlockId, StringComparer.Ordinal)
+                    .Select(b => translatedBlocks[b.IrBlockId])
+                    .ToList()
+            })
+            .ToList();
+    }
+
+    private static BlockType MapBlockType(SourceBlockType sourceType) => sourceType switch
+    {
+        SourceBlockType.Paragraph => BlockType.Paragraph,
+        SourceBlockType.Heading => BlockType.Heading,
+        SourceBlockType.Caption => BlockType.Caption,
+        SourceBlockType.TableCell => BlockType.Table,
+        SourceBlockType.Formula => BlockType.Formula,
+        _ => BlockType.Unknown
+    };
+
+    private static string ApplyGlossary(string text, IReadOnlyDictionary<string, string>? glossary)
+    {
+        if (glossary is null || glossary.Count == 0)
+        {
+            return text;
+        }
+
+        var output = text;
+        foreach (var pair in glossary)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+            {
+                continue;
+            }
+            output = output.Replace(pair.Key, pair.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return output;
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Easydict.WinUI.csproj
+++ b/dotnet/src/Easydict.WinUI/Easydict.WinUI.csproj
@@ -152,6 +152,8 @@
     <!-- FlaUI for proper UI Automation text selection -->
     <ItemGroup>
       <PackageReference Include="FlaUI.UIA3" Version="4.0.0" />
+      <PackageReference Include="PdfSharpCore" Version="1.3.67" />
+      <PackageReference Include="UglyToad.PdfPig" Version="0.1.9" />
     </ItemGroup>
 
     <!-- 

--- a/dotnet/src/Easydict.WinUI/Services/LongDocumentDeduplicationService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/LongDocumentDeduplicationService.cs
@@ -1,0 +1,130 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Easydict.TranslationService.Models;
+
+namespace Easydict.WinUI.Services;
+
+public sealed class LongDocumentDeduplicationService
+{
+    private readonly string _indexFilePath;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    public LongDocumentDeduplicationService()
+    {
+        var baseDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Easydict");
+        Directory.CreateDirectory(baseDir);
+        _indexFilePath = Path.Combine(baseDir, "longdoc_dedup_index.json");
+    }
+
+    public async Task<string> CreateDedupKeyAsync(
+        LongDocumentInputMode mode,
+        string input,
+        string serviceId,
+        Language from,
+        Language to,
+        CancellationToken cancellationToken = default)
+    {
+        var inputHash = await ComputeInputHashAsync(mode, input, cancellationToken);
+        var canonical = $"v1|{mode}|{serviceId}|{from.ToCode()}|{to.ToCode()}|{inputHash}";
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+    }
+
+    public async Task<string?> TryGetExistingOutputPathAsync(string dedupKey, CancellationToken cancellationToken = default)
+    {
+        await _lock.WaitAsync(cancellationToken);
+        try
+        {
+            var index = await ReadIndexCoreAsync(cancellationToken);
+            if (!index.TryGetValue(dedupKey, out var entry))
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.OutputPath) || !File.Exists(entry.OutputPath))
+            {
+                index.Remove(dedupKey);
+                await WriteIndexCoreAsync(index, cancellationToken);
+                return null;
+            }
+
+            entry.LastUsedUtc = DateTime.UtcNow;
+            index[dedupKey] = entry;
+            await WriteIndexCoreAsync(index, cancellationToken);
+            return entry.OutputPath;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task RegisterOutputAsync(string dedupKey, string outputPath, CancellationToken cancellationToken = default)
+    {
+        await _lock.WaitAsync(cancellationToken);
+        try
+        {
+            var index = await ReadIndexCoreAsync(cancellationToken);
+            index[dedupKey] = new DedupEntry
+            {
+                OutputPath = outputPath,
+                CreatedUtc = DateTime.UtcNow,
+                LastUsedUtc = DateTime.UtcNow
+            };
+            await WriteIndexCoreAsync(index, cancellationToken);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private static async Task<string> ComputeInputHashAsync(
+        LongDocumentInputMode mode,
+        string input,
+        CancellationToken cancellationToken)
+    {
+        if (mode == LongDocumentInputMode.Pdf)
+        {
+            if (!File.Exists(input))
+            {
+                throw new FileNotFoundException("PDF file not found.", input);
+            }
+
+            await using var stream = File.OpenRead(input);
+            using var sha = SHA256.Create();
+            var hash = await sha.ComputeHashAsync(stream, cancellationToken);
+            return Convert.ToHexString(hash);
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(input.Trim());
+        return Convert.ToHexString(SHA256.HashData(bytes));
+    }
+
+    private async Task<Dictionary<string, DedupEntry>> ReadIndexCoreAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_indexFilePath))
+        {
+            return new Dictionary<string, DedupEntry>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        await using var fs = File.OpenRead(_indexFilePath);
+        var index = await JsonSerializer.DeserializeAsync<Dictionary<string, DedupEntry>>(fs, cancellationToken: cancellationToken);
+        return index ?? new Dictionary<string, DedupEntry>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private async Task WriteIndexCoreAsync(Dictionary<string, DedupEntry> index, CancellationToken cancellationToken)
+    {
+        await using var fs = File.Create(_indexFilePath);
+        await JsonSerializer.SerializeAsync(fs, index, cancellationToken: cancellationToken);
+    }
+
+    private sealed class DedupEntry
+    {
+        public string OutputPath { get; set; } = string.Empty;
+        public DateTime CreatedUtc { get; set; }
+        public DateTime LastUsedUtc { get; set; }
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Services/LongDocumentTranslationService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/LongDocumentTranslationService.cs
@@ -1,0 +1,281 @@
+using System.Text;
+using Easydict.TranslationService;
+using Easydict.TranslationService.Models;
+using PdfSharpCore.Drawing;
+using PdfSharpCore.Pdf;
+using UglyToad.PdfPig;
+
+namespace Easydict.WinUI.Services;
+
+public enum LongDocumentInputMode
+{
+    Manual,
+    Pdf
+}
+
+public enum LongDocumentJobState
+{
+    Completed,
+    PartialSuccess,
+    Failed
+}
+
+public sealed class LongDocumentTranslationCheckpoint
+{
+    public required List<string> SourceChunks { get; init; }
+    public required Dictionary<int, string> TranslatedChunks { get; init; }
+    public required HashSet<int> FailedChunkIndexes { get; init; }
+}
+
+public sealed class LongDocumentTranslationResult
+{
+    public required LongDocumentJobState State { get; init; }
+    public required string OutputPath { get; init; }
+    public required int TotalChunks { get; init; }
+    public required int SucceededChunks { get; init; }
+    public required IReadOnlyList<int> FailedChunkIndexes { get; init; }
+    public required LongDocumentTranslationCheckpoint Checkpoint { get; init; }
+}
+
+public sealed class LongDocumentTranslationService
+{
+    private const int ChunkSize = 1200;
+
+    public async Task<LongDocumentTranslationResult> TranslateToPdfAsync(
+        LongDocumentInputMode mode,
+        string input,
+        Language from,
+        Language to,
+        string outputPath,
+        string serviceId,
+        Action<string>? onProgress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var sourceText = mode switch
+        {
+            LongDocumentInputMode.Manual => input,
+            LongDocumentInputMode.Pdf => ExtractPdfText(input),
+            _ => input
+        };
+
+        if (string.IsNullOrWhiteSpace(sourceText))
+        {
+            throw new InvalidOperationException("No source text found for translation.");
+        }
+
+        onProgress?.Invoke("Preparing chunks...");
+        var chunks = SplitChunks(sourceText, ChunkSize);
+        var checkpoint = new LongDocumentTranslationCheckpoint
+        {
+            SourceChunks = chunks,
+            TranslatedChunks = new Dictionary<int, string>(),
+            FailedChunkIndexes = new HashSet<int>()
+        };
+
+        await TranslatePendingChunksAsync(checkpoint, from, to, serviceId, onProgress, cancellationToken);
+        return FinalizeResult(checkpoint, outputPath, onProgress);
+    }
+
+    public async Task<LongDocumentTranslationResult> RetryFailedChunksAsync(
+        LongDocumentTranslationCheckpoint checkpoint,
+        Language from,
+        Language to,
+        string outputPath,
+        string serviceId,
+        Action<string>? onProgress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (checkpoint.FailedChunkIndexes.Count == 0)
+        {
+            return FinalizeResult(checkpoint, outputPath, onProgress);
+        }
+
+        onProgress?.Invoke($"Retrying {checkpoint.FailedChunkIndexes.Count} failed chunks...");
+        await TranslatePendingChunksAsync(checkpoint, from, to, serviceId, onProgress, cancellationToken);
+        return FinalizeResult(checkpoint, outputPath, onProgress);
+    }
+
+    private static async Task TranslatePendingChunksAsync(
+        LongDocumentTranslationCheckpoint checkpoint,
+        Language from,
+        Language to,
+        string serviceId,
+        Action<string>? onProgress,
+        CancellationToken cancellationToken)
+    {
+        var manager = TranslationManagerService.Instance.Manager;
+        var pendingIndexes = checkpoint.FailedChunkIndexes.Count > 0
+            ? checkpoint.FailedChunkIndexes.OrderBy(i => i).ToList()
+            : Enumerable.Range(0, checkpoint.SourceChunks.Count).ToList();
+
+        checkpoint.FailedChunkIndexes.Clear();
+
+        for (var i = 0; i < pendingIndexes.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var chunkIndex = pendingIndexes[i];
+            onProgress?.Invoke($"Translating chunk {chunkIndex + 1}/{checkpoint.SourceChunks.Count} (pending {i + 1}/{pendingIndexes.Count})...");
+
+            try
+            {
+                var request = new TranslationRequest
+                {
+                    Text = checkpoint.SourceChunks[chunkIndex],
+                    FromLanguage = from,
+                    ToLanguage = to
+                };
+
+                var result = await manager.TranslateAsync(request, cancellationToken, serviceId);
+                if (string.IsNullOrWhiteSpace(result.TranslatedText))
+                {
+                    checkpoint.FailedChunkIndexes.Add(chunkIndex);
+                    continue;
+                }
+
+                checkpoint.TranslatedChunks[chunkIndex] = result.TranslatedText.Trim();
+            }
+            catch
+            {
+                checkpoint.FailedChunkIndexes.Add(chunkIndex);
+            }
+        }
+    }
+
+    private static LongDocumentTranslationResult FinalizeResult(
+        LongDocumentTranslationCheckpoint checkpoint,
+        string outputPath,
+        Action<string>? onProgress)
+    {
+        var succeededCount = checkpoint.TranslatedChunks.Count;
+        if (succeededCount == 0)
+        {
+            throw new InvalidOperationException("Translation failed for all chunks.");
+        }
+
+        onProgress?.Invoke("Generating output PDF...");
+        ExportTextPdf(ComposeOutputText(checkpoint), outputPath);
+
+        var state = checkpoint.FailedChunkIndexes.Count switch
+        {
+            0 => LongDocumentJobState.Completed,
+            _ => LongDocumentJobState.PartialSuccess
+        };
+
+        onProgress?.Invoke(state == LongDocumentJobState.Completed
+            ? $"Completed: {outputPath}"
+            : $"Partially completed: {succeededCount}/{checkpoint.SourceChunks.Count} chunks. You can retry failed chunks.");
+
+        return new LongDocumentTranslationResult
+        {
+            State = state,
+            OutputPath = outputPath,
+            TotalChunks = checkpoint.SourceChunks.Count,
+            SucceededChunks = succeededCount,
+            FailedChunkIndexes = checkpoint.FailedChunkIndexes.OrderBy(i => i).ToList(),
+            Checkpoint = checkpoint
+        };
+    }
+
+    private static string ComposeOutputText(LongDocumentTranslationCheckpoint checkpoint)
+    {
+        var sb = new StringBuilder();
+
+        for (var i = 0; i < checkpoint.SourceChunks.Count; i++)
+        {
+            if (checkpoint.TranslatedChunks.TryGetValue(i, out var translated))
+            {
+                sb.AppendLine(translated);
+                sb.AppendLine();
+            }
+            else
+            {
+                sb.AppendLine($"[Chunk {i + 1} translation failed. Retry required.]");
+                sb.AppendLine();
+            }
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    private static string ExtractPdfText(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException("PDF file not found.", path);
+        }
+
+        var sb = new StringBuilder();
+        using var document = PdfDocument.Open(path);
+        foreach (var page in document.GetPages())
+        {
+            sb.AppendLine(page.Text);
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private static List<string> SplitChunks(string text, int chunkSize)
+    {
+        var chunks = new List<string>();
+        var start = 0;
+        while (start < text.Length)
+        {
+            var len = Math.Min(chunkSize, text.Length - start);
+            chunks.Add(text.Substring(start, len));
+            start += len;
+        }
+
+        return chunks;
+    }
+
+    private static void ExportTextPdf(string text, string outputPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+        var doc = new PdfSharpCore.Pdf.PdfDocument();
+        var page = doc.AddPage();
+        var gfx = XGraphics.FromPdfPage(page);
+        var font = new XFont("Arial", 11);
+
+        const int margin = 40;
+        var y = margin;
+        var width = page.Width - margin * 2;
+
+        foreach (var line in WrapText(text, 95))
+        {
+            if (y > page.Height - margin)
+            {
+                page = doc.AddPage();
+                gfx = XGraphics.FromPdfPage(page);
+                y = margin;
+            }
+
+            gfx.DrawString(line, font, XBrushes.Black, new XRect(margin, y, width, 20), XStringFormats.TopLeft);
+            y += 16;
+        }
+
+        doc.Save(outputPath);
+    }
+
+    private static IEnumerable<string> WrapText(string text, int maxChars)
+    {
+        foreach (var paragraph in text.Split('\n'))
+        {
+            var p = paragraph.TrimEnd('\r');
+            if (p.Length <= maxChars)
+            {
+                yield return p;
+                continue;
+            }
+
+            var start = 0;
+            while (start < p.Length)
+            {
+                var len = Math.Min(maxChars, p.Length - start);
+                yield return p.Substring(start, len);
+                start += len;
+            }
+        }
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
@@ -9,9 +9,11 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto"
-                  HorizontalScrollBarVisibility="Disabled">
-        <Grid Padding="4">
+    <TabView Margin="0">
+        <TabViewItem Header="Quick Translate">
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <Grid Padding="4">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutStates">
                 <!-- Wide layout: all controls in one row -->
@@ -408,6 +410,61 @@
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center" />
         </Grid>
-        </Grid>
-    </ScrollViewer>
+                </Grid>
+            </ScrollViewer>
+        </TabViewItem>
+
+        <TabViewItem Header="Long Document">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                <StackPanel Padding="12" Spacing="10">
+                    <TextBlock Text="Long document translation (C# native pipeline)" FontSize="16" FontWeight="SemiBold" />
+                    <TextBlock Text="Web pages should be sent by browser extension as rendered PDF. Main window supports only manual text and local PDF." TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+                    <TextBlock Text="Translation Service (single select)" />
+                    <ComboBox x:Name="LongDocServiceCombo" />
+
+                    <ComboBox x:Name="LongDocInputModeCombo" SelectedIndex="0" SelectionChanged="OnLongDocInputModeChanged">
+                        <ComboBoxItem Content="Manual Input" Tag="manual" />
+                        <ComboBoxItem Content="PDF File" Tag="pdf" />
+                    </ComboBox>
+
+                    <TextBlock x:Name="LongDocManualLabel" Text="Manual text" />
+                    <TextBox x:Name="LongDocManualTextBox"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             Height="240"
+                             PlaceholderText="Paste long text content here..."
+                             VerticalAlignment="Stretch" />
+
+                    <StackPanel x:Name="LongDocPdfPanel" Orientation="Horizontal" Spacing="8" Visibility="Collapsed">
+                        <TextBox x:Name="LongDocPdfPathTextBox" Width="480" PlaceholderText="PDF file path..." />
+                    </StackPanel>
+
+                    <TextBlock Text="Batch PDF Queue (one path per line, optional)" />
+                    <TextBox x:Name="LongDocBatchPdfPathsTextBox"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             Height="120"
+                             PlaceholderText="D:\docs\a.pdf&#10;D:\docs\b.pdf" />
+
+                    <CheckBox x:Name="LongDocRunInBackgroundCheckBox" Content="Run queue in background" IsChecked="True" />
+
+                    <TextBlock Text="Output Folder" />
+                    <TextBox x:Name="LongDocOutputFolderTextBox" PlaceholderText="e.g. C:\Users\&lt;you&gt;\Documents\Easydict\LongDocOutputs" />
+
+                    <TextBlock Text="Output File Name" />
+                    <TextBox x:Name="LongDocOutputFileNameTextBox" PlaceholderText="translated.pdf" />
+
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Button x:Name="LongDocTranslateButton" Content="Translate and Export PDF" Click="OnLongDocTranslateClicked" />
+                        <Button x:Name="LongDocRetryButton" Content="Retry Failed Chunks" Click="OnLongDocRetryClicked" IsEnabled="False" />
+                        <Button x:Name="LongDocStartQueueButton" Content="Start PDF Queue" Click="OnLongDocStartQueueClicked" />
+                        <Button x:Name="LongDocCancelQueueButton" Content="Cancel Queue" Click="OnLongDocCancelQueueClicked" IsEnabled="False" />
+                    </StackPanel>
+
+                    <TextBlock x:Name="LongDocStatusText" Text="Idle" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+                </StackPanel>
+            </ScrollViewer>
+        </TabViewItem>
+    </TabView>
 </Page>

--- a/dotnet/tests/Easydict.TranslationService.Tests/LongDocument/LongDocumentTranslationServiceTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/LongDocument/LongDocumentTranslationServiceTests.cs
@@ -1,0 +1,242 @@
+using Easydict.TranslationService.LongDocument;
+using Easydict.TranslationService.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Easydict.TranslationService.Tests.LongDocument;
+
+public class LongDocumentTranslationServiceTests
+{
+    [Fact]
+    public async Task TranslateAsync_ShouldRetainIrMetadata()
+    {
+        var sut = new LongDocumentTranslationService(translateWithService: FakeTranslate);
+        var source = BuildSourceDocument();
+
+        var result = await sut.TranslateAsync(source, new LongDocumentTranslationOptions
+        {
+            ToLanguage = Language.SimplifiedChinese,
+            ServiceId = "google"
+        });
+
+        result.Ir.Blocks.Should().HaveCount(2);
+        result.Ir.Blocks[0].PageNumber.Should().Be(1);
+        result.Ir.Blocks[0].SourceBlockId.Should().Be("p1-b1");
+        result.Ir.Blocks[0].BoundingBox.Should().NotBeNull();
+        result.Ir.Blocks[0].SourceHash.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ShouldProtectFormulaAndSkipFormulaBlockTranslation()
+    {
+        var calls = 0;
+        var sut = new LongDocumentTranslationService(translateWithService: (request, _, _) =>
+        {
+            calls++;
+            return Task.FromResult(new TranslationResult
+            {
+                OriginalText = request.Text,
+                TranslatedText = $"T:{request.Text}",
+                ServiceName = "fake",
+                TargetLanguage = request.ToLanguage
+            });
+        });
+
+        var source = new SourceDocument
+        {
+            DocumentId = "doc-formula",
+            Pages =
+            [
+                new SourceDocumentPage
+                {
+                    PageNumber = 1,
+                    Blocks =
+                    [
+                        new SourceDocumentBlock
+                        {
+                            BlockId = "formula",
+                            BlockType = SourceBlockType.Formula,
+                            Text = "E = mc^2"
+                        },
+                        new SourceDocumentBlock
+                        {
+                            BlockId = "text",
+                            BlockType = SourceBlockType.Paragraph,
+                            Text = "Energy is represented as $E = mc^2$."
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var result = await sut.TranslateAsync(source, new LongDocumentTranslationOptions
+        {
+            ToLanguage = Language.SimplifiedChinese,
+            ServiceId = "google",
+            EnableFormulaProtection = true
+        });
+
+        calls.Should().Be(1);
+        result.Pages.SelectMany(p => p.Blocks).Single(b => b.SourceBlockId == "formula").TranslationSkipped.Should().BeTrue();
+        result.Ir.Blocks.Single(b => b.SourceBlockId == "text").ProtectedText.Should().Contain("[[FORMULA:");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ShouldUseOcrFallbackForScannedPage()
+    {
+        var sut = new LongDocumentTranslationService(
+            translateWithService: FakeTranslate,
+            ocrExtractor: (_, _) => Task.FromResult<string?>("OCR recovered text"));
+
+        var source = new SourceDocument
+        {
+            DocumentId = "doc-ocr",
+            Pages =
+            [
+                new SourceDocumentPage
+                {
+                    PageNumber = 1,
+                    IsScanned = true,
+                    Blocks = []
+                }
+            ]
+        };
+
+        var result = await sut.TranslateAsync(source, new LongDocumentTranslationOptions
+        {
+            ToLanguage = Language.English,
+            ServiceId = "google",
+            EnableOcrFallback = true
+        });
+
+        result.Ir.Blocks.Should().ContainSingle();
+        result.Ir.Blocks[0].OriginalText.Should().Be("OCR recovered text");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ShouldApplyGlossary()
+    {
+        var sut = new LongDocumentTranslationService(translateWithService: (_, _, _) => Task.FromResult(new TranslationResult
+        {
+            OriginalText = "hello",
+            TranslatedText = "The model term appears here.",
+            ServiceName = "fake",
+            TargetLanguage = Language.English
+        }));
+
+        var result = await sut.TranslateAsync(BuildSourceDocument(), new LongDocumentTranslationOptions
+        {
+            ToLanguage = Language.English,
+            ServiceId = "google",
+            Glossary = new Dictionary<string, string>
+            {
+                ["model"] = "engine"
+            }
+        });
+
+        var translated = result.Pages.SelectMany(p => p.Blocks).First(b => !b.TranslationSkipped).TranslatedText;
+        translated.Should().Contain("engine");
+        translated.Should().NotContain("model");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ShouldRetryFailedBlocksAndCollectQualityReport()
+    {
+        var attempts = 0;
+        var sut = new LongDocumentTranslationService(translateWithService: (_, _, _) =>
+        {
+            attempts++;
+            if (attempts < 3)
+            {
+                throw new InvalidOperationException("transient");
+            }
+
+            return Task.FromResult(new TranslationResult
+            {
+                OriginalText = "x",
+                TranslatedText = "ok",
+                ServiceName = "fake",
+                TargetLanguage = Language.English
+            });
+        });
+
+        var source = new SourceDocument
+        {
+            DocumentId = "doc-retry",
+            Pages =
+            [
+                new SourceDocumentPage
+                {
+                    PageNumber = 1,
+                    Blocks =
+                    [
+                        new SourceDocumentBlock
+                        {
+                            BlockId = "b1",
+                            BlockType = SourceBlockType.Paragraph,
+                            Text = "retry me"
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var result = await sut.TranslateAsync(source, new LongDocumentTranslationOptions
+        {
+            ToLanguage = Language.English,
+            ServiceId = "google",
+            MaxRetriesPerBlock = 3
+        });
+
+        attempts.Should().Be(3);
+        result.QualityReport.FailedBlocks.Should().BeEmpty();
+        result.QualityReport.StageTimingsMs.Keys.Should().Contain(new[]
+        {
+            "ingest", "build-ir", "formula-protection", "translate", "structured-layout-output"
+        });
+        result.Pages[0].Blocks[0].RetryCount.Should().Be(2);
+    }
+
+    private static Task<TranslationResult> FakeTranslate(TranslationRequest request, string _, CancellationToken __)
+    {
+        return Task.FromResult(new TranslationResult
+        {
+            OriginalText = request.Text,
+            TranslatedText = $"translated:{request.Text}",
+            ServiceName = "fake",
+            TargetLanguage = request.ToLanguage
+        });
+    }
+
+    private static SourceDocument BuildSourceDocument()
+    {
+        return new SourceDocument
+        {
+            DocumentId = "doc-1",
+            Pages =
+            [
+                new SourceDocumentPage
+                {
+                    PageNumber = 1,
+                    Blocks =
+                    [
+                        new SourceDocumentBlock
+                        {
+                            BlockId = "p1-b1",
+                            BlockType = SourceBlockType.Paragraph,
+                            Text = "Hello world",
+                            BoundingBox = new BlockRect(10, 20, 100, 40)
+                        },
+                        new SourceDocumentBlock
+                        {
+                            BlockId = "p1-b2",
+                            BlockType = SourceBlockType.Caption,
+                            Text = "Figure caption",
+                            ParentBlockId = "p1-b1"
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a structured, multi-stage pipeline to translate long/structured documents while preserving layout, block metadata and parent relations. 
- Protect math/formula content from being corrupted by translation by replacing with placeholders and optionally skipping translation for pure-formula blocks. 
- Improve robustness with OCR fallback for scanned PDFs, per-block retries, glossary enforcement and per-stage diagnostics. 
- Expose a user-facing WinUI workflow for translating/exporting long documents and avoid repeating work via a local deduplication index.

### Description
- Add long-document domain and IR models in `dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentModels.cs` (`SourceDocument*`, `DocumentIr`, translated models, `LongDocumentTranslationOptions`, quality/failed-block types). 
- Implement a staged pipeline in `dotnet/src/Easydict.TranslationService/LongDocument/LongDocumentTranslationService.cs` with stages: `ingest` (OCR fallback), `build-ir` (hash/coords/parent relations), `formula-protection`, `translate` (service callback with retries + glossary pass), and `structured-layout-output`, and emit a `LongDocumentQualityReport`. 
- Add WinUI integration: UI controls in `MainPage.xaml` and orchestration in `MainPage.xaml.cs` for long-document workflow, plus a WinUI-side `LongDocumentTranslationService` (chunking/export to PDF) and `LongDocumentDeduplicationService` for caching outputs; and add PDF libraries to `Easydict.WinUI.csproj`. 
- Add unit tests in `dotnet/tests/Easydict.TranslationService.Tests/LongDocument/LongDocumentTranslationServiceTests.cs` that cover IR metadata retention, formula protection/skip, OCR fallback, glossary post-processing, retry behavior and quality-report fields.

### Testing
- Added xUnit tests under `dotnet/tests/Easydict.TranslationService.Tests/LongDocument` to exercise the main scenarios described above. 
- Attempted to run the targeted tests with `dotnet test --filter "FullyQualifiedName~LongDocumentTranslationServiceTests"` but the `dotnet` CLI is not available in this environment so tests were not executed. 
- Performed repository inspections and file validation with tools like `rg` and file previews to sanity-check the added files and references (no automated test failures reported here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a5a39e3883228b6566c4a25d4f50)