### PR TITLE
Fix TTS first activation delay causing incomplete audio

### DIFF
--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -421,6 +421,19 @@ namespace Easydict.WinUI
             // Apply saved theme setting
             ApplyTheme(settings.AppTheme);
 
+            // Pre-warm TTS service to avoid first-use delay
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    TextToSpeechService.Instance.WarmUp();
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[App] TTS pre-warm failed: {ex.Message}");
+                }
+            });
+
         }
 
         private void OnShowWindowHotkey()

--- a/dotnet/src/Easydict.WinUI/Services/TextToSpeechService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TextToSpeechService.cs
@@ -19,6 +19,7 @@ public sealed class TextToSpeechService : IDisposable
 
     private readonly SpeechSynthesizer _synthesizer;
     private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private static IReadOnlyList<VoiceInformation>? _cachedVoices;
     private MediaPlayer? _mediaPlayer;
     private SpeechSynthesisStream? _currentStream;
     private bool _isDisposed;
@@ -36,6 +37,17 @@ public sealed class TextToSpeechService : IDisposable
     private TextToSpeechService()
     {
         _synthesizer = new SpeechSynthesizer();
+    }
+
+    /// <summary>
+    /// Pre-warms the TTS engine by forcing voice enumeration.
+    /// Call from a background thread at app startup to avoid first-use delay.
+    /// </summary>
+    public void WarmUp()
+    {
+        Debug.WriteLine("[TTS] Pre-warming: enumerating voices...");
+        _cachedVoices = SpeechSynthesizer.AllVoices;
+        Debug.WriteLine($"[TTS] Pre-warm complete: {_cachedVoices.Count} voices found");
     }
 
     /// <summary>
@@ -74,10 +86,11 @@ public sealed class TextToSpeechService : IDisposable
             _currentStream = stream;
             _mediaPlayer = new MediaPlayer
             {
-                Source = MediaSource.CreateFromStream(stream, stream.ContentType),
-                AutoPlay = true
+                AutoPlay = false
             };
+            _mediaPlayer.MediaOpened += OnMediaOpened;
             _mediaPlayer.MediaEnded += OnMediaEnded;
+            _mediaPlayer.Source = MediaSource.CreateFromStream(stream, stream.ContentType);
         }
         catch (OperationCanceledException)
         {
@@ -105,6 +118,12 @@ public sealed class TextToSpeechService : IDisposable
         }
     }
 
+    private void OnMediaOpened(MediaPlayer sender, object args)
+    {
+        Debug.WriteLine("[TTS] Media opened, starting playback");
+        sender.Play();
+    }
+
     private void OnMediaEnded(MediaPlayer sender, object args)
     {
         PlaybackEnded?.Invoke();
@@ -114,6 +133,7 @@ public sealed class TextToSpeechService : IDisposable
     {
         if (_mediaPlayer != null)
         {
+            _mediaPlayer.MediaOpened -= OnMediaOpened;
             _mediaPlayer.MediaEnded -= OnMediaEnded;
             _mediaPlayer.Dispose();
             _mediaPlayer = null;
@@ -128,7 +148,7 @@ public sealed class TextToSpeechService : IDisposable
         var bcp47 = language.ToBcp47();
 
         // Try exact match first, then prefix match
-        var voices = SpeechSynthesizer.AllVoices;
+        var voices = _cachedVoices ?? SpeechSynthesizer.AllVoices;
 
         var exactMatch = voices.FirstOrDefault(v =>
             v.Language.Equals(bcp47, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Summary

- **Pre-warm TTS at app startup**: enumerate `SpeechSynthesizer.AllVoices` on a background thread during `InitializeServices()`, caching the result so `FindVoiceForLanguage()` doesn't block on first call
- **Replace `AutoPlay=true` with `MediaOpened` event**: set `AutoPlay=false` and call `Play()` only after the media pipeline is fully initialized via `MediaOpened`, ensuring playback starts from the very beginning of the audio

## Test plan

- [ ] Launch app, wait a few seconds for pre-warm to complete
- [ ] Click TTS speaker button for the first time — audio should play completely from the beginning with no clipping
- [ ] Click TTS again — subsequent plays should still work correctly
- [ ] Test with different languages (Chinese, English, etc.)
- [ ] Verify Stop button still works during playback
- [ ] Verify TTS works if triggered very quickly after app launch (before pre-warm completes — should fall back gracefully)

https://claude.ai/code/session_014U6VFyPs2ZzZTxUNBhZis6