### PR TITLE
feat: integrate TextLayout library into PDF export services

### DIFF
--- a/dotnet/src/Easydict.TextLayout/Segmentation/ScriptClassifier.cs
+++ b/dotnet/src/Easydict.TextLayout/Segmentation/ScriptClassifier.cs
@@ -68,6 +68,8 @@ public static class ScriptClassifier
     public static bool IsOpenPunctuation(char ch)
     {
         return ch is '(' or '[' or '{' or '<'
+            or '\u3008'   // LEFT ANGLE BRACKET 〈
+            or '\u300A'   // LEFT DOUBLE ANGLE BRACKET 《
             or '\u300C'   // LEFT CORNER BRACKET
             or '\u300E'   // LEFT WHITE CORNER BRACKET
             or '\u3010'   // LEFT BLACK LENTICULAR BRACKET
@@ -75,6 +77,7 @@ public static class ScriptClassifier
             or '\u3016'   // LEFT WHITE LENTICULAR BRACKET
             or '\u3018'   // LEFT WHITE TORTOISE SHELL BRACKET
             or '\u301A'   // LEFT WHITE SQUARE BRACKET
+            or '\u301D'   // REVERSED DOUBLE PRIME QUOTATION MARK 〝
             or '\uFF08'   // FULLWIDTH LEFT PARENTHESIS
             or '\u201C'   // LEFT DOUBLE QUOTATION MARK
             or '\u2018'   // LEFT SINGLE QUOTATION MARK
@@ -91,6 +94,8 @@ public static class ScriptClassifier
             or '.' or ',' or ';' or ':' or '!' or '?' or '%'
             or '\u3001'   // IDEOGRAPHIC COMMA
             or '\u3002'   // IDEOGRAPHIC FULL STOP
+            or '\u3009'   // RIGHT ANGLE BRACKET 〉
+            or '\u300B'   // RIGHT DOUBLE ANGLE BRACKET 》
             or '\u300D'   // RIGHT CORNER BRACKET
             or '\u300F'   // RIGHT WHITE CORNER BRACKET
             or '\u3011'   // RIGHT BLACK LENTICULAR BRACKET
@@ -98,8 +103,10 @@ public static class ScriptClassifier
             or '\u3017'   // RIGHT WHITE LENTICULAR BRACKET
             or '\u3019'   // RIGHT WHITE TORTOISE SHELL BRACKET
             or '\u301B'   // RIGHT WHITE SQUARE BRACKET
+            or '\u301F'   // LOW DOUBLE PRIME QUOTATION MARK 〟
             or '\uFF09'   // FULLWIDTH RIGHT PARENTHESIS
             or '\uFF0C'   // FULLWIDTH COMMA
+            or '\uFF1A'   // FULLWIDTH COLON ：
             or '\uFF1B'   // FULLWIDTH SEMICOLON
             or '\uFF01'   // FULLWIDTH EXCLAMATION MARK
             or '\uFF1F'   // FULLWIDTH QUESTION MARK

--- a/dotnet/src/Easydict.TextLayout/TextLayoutEngine.cs
+++ b/dotnet/src/Easydict.TextLayout/TextLayoutEngine.cs
@@ -248,6 +248,9 @@ public sealed class TextLayoutEngine : ITextLayoutEngine
     /// Core line-breaking algorithm. Greedy first-fit with punctuation grouping.
     /// - Close-punctuation never starts a line (grouped with preceding content, with overflow check)
     /// - Open-punctuation never ends a line (if it would be the last token, defer to next line)
+    /// - Kinsoku line-start prohibition: CJK chars like small kana, prolonged sound marks,
+    ///   and iteration marks never start a line (carried to the preceding line)
+    /// - Left-sticky punctuation: ASCII punct (. , ! ? etc.) after CJK sticks to preceding char
     /// - Trailing spaces trimmed from width calculation consistently
     /// </summary>
     private LayoutLine? LayoutNextLineCore(PreparedParagraph prepared, LayoutCursor start, double maxWidth, bool buildText)
@@ -284,6 +287,7 @@ public sealed class TextLayoutEngine : ITextLayoutEngine
         var lineStartSeg = seg;
         var lineWidth = 0.0;     // includes trailing spaces
         var contentWidth = 0.0;  // excludes trailing spaces
+        var lastContentKind = SegmentKind.Space; // track kind of last non-space segment for left-sticky
         var sb = buildText ? new StringBuilder() : null;
 
         while (seg < segments.Length)
@@ -302,7 +306,28 @@ public sealed class TextLayoutEngine : ITextLayoutEngine
             // Check if this segment fits
             if (lineWidth + segWidth > maxWidth && lineWidth > 0)
             {
-                break;
+                // Kinsoku line-start prohibition: if this segment must not start a line,
+                // carry it onto the current line despite overflow. This prevents characters
+                // like small kana (っ, ょ), prolonged sound mark (ー), middle dot (・),
+                // and iteration marks (々) from appearing at line start.
+                // Safety: only carry if the line already has content (lineWidth > 0),
+                // and only for narrow segments (CjkGrapheme or ClosePunctuation) to avoid
+                // runaway overflow with long Word segments.
+                if (prepared.IsProhibitedLineStart[seg]
+                    && kind is SegmentKind.CjkGrapheme or SegmentKind.ClosePunctuation)
+                {
+                    // Fall through to add it to the current line
+                }
+                // Left-sticky punctuation: ASCII punct like . , ! ? after CJK content
+                // sticks to the preceding character and must not start a new line.
+                else if (IsLeftStickyBreak(segments[seg], lastContentKind))
+                {
+                    // Fall through to add it to the current line
+                }
+                else
+                {
+                    break;
+                }
             }
 
             // If segment doesn't fit and line IS empty, we must emit it (or break it)
@@ -339,6 +364,7 @@ public sealed class TextLayoutEngine : ITextLayoutEngine
                 lineWidth += segWidth;
                 sb?.Append(segments[seg]);
                 contentWidth = lineWidth;
+                lastContentKind = kind;
 
                 // Look ahead: if next segment is ClosePunctuation, group it only if it fits
                 while (seg + 1 < segments.Length && kinds[seg + 1] == SegmentKind.ClosePunctuation)
@@ -374,6 +400,18 @@ public sealed class TextLayoutEngine : ITextLayoutEngine
 
         var text = sb?.ToString().TrimEnd() ?? string.Empty;
         return new LayoutLine(lineStartSeg, seg, 0, 0, contentWidth, text);
+    }
+
+    /// <summary>
+    /// Checks whether breaking before this segment would violate left-sticky rules.
+    /// ASCII punctuation (. , ! ? : ; ) ] } % " …) should stick to preceding CJK content.
+    /// </summary>
+    private static bool IsLeftStickyBreak(string segment, SegmentKind lastContentKind)
+    {
+        if (segment.Length == 0) return false;
+        // Only applies when the preceding content was CJK
+        if (lastContentKind != SegmentKind.CjkGrapheme) return false;
+        return KinsokuTable.IsLeftSticky(segment[0]);
     }
 
     /// <summary>

--- a/dotnet/src/Easydict.WinUI/Services/DocumentExport/GlyphAdvanceMeasurer.cs
+++ b/dotnet/src/Easydict.WinUI/Services/DocumentExport/GlyphAdvanceMeasurer.cs
@@ -1,0 +1,106 @@
+using Easydict.TextLayout;
+using Easydict.TextLayout.Segmentation;
+using Easydict.TranslationService.FormulaProtection;
+
+namespace Easydict.WinUI.Services.DocumentExport;
+
+/// <summary>
+/// Measures text advance widths using TrueType font metrics (glyph map + hmtx advance widths).
+/// Used by MuPdfExportService for TextLayout integration.
+/// </summary>
+internal sealed class GlyphAdvanceMeasurer : ITextMeasurer
+{
+    private readonly IReadOnlyDictionary<char, ushort>? _primaryGlyphMap;
+    private readonly IReadOnlyDictionary<ushort, ushort>? _primaryAdvanceWidths;
+    private readonly ushort _primaryUnitsPerEm;
+    private readonly IReadOnlyDictionary<char, ushort>? _notoGlyphMap;
+    private readonly IReadOnlyDictionary<ushort, ushort>? _notoAdvanceWidths;
+    private readonly ushort _notoUnitsPerEm;
+    private readonly bool _primaryFontIsCjk;
+    private readonly double _fontSize;
+
+    public GlyphAdvanceMeasurer(
+        IReadOnlyDictionary<char, ushort>? primaryGlyphMap,
+        IReadOnlyDictionary<ushort, ushort>? primaryAdvanceWidths,
+        ushort primaryUnitsPerEm,
+        IReadOnlyDictionary<char, ushort>? notoGlyphMap,
+        IReadOnlyDictionary<ushort, ushort>? notoAdvanceWidths,
+        ushort notoUnitsPerEm,
+        bool primaryFontIsCjk,
+        double fontSize)
+    {
+        _primaryGlyphMap = primaryGlyphMap;
+        _primaryAdvanceWidths = primaryAdvanceWidths;
+        _primaryUnitsPerEm = primaryUnitsPerEm;
+        _notoGlyphMap = notoGlyphMap;
+        _notoAdvanceWidths = notoAdvanceWidths;
+        _notoUnitsPerEm = notoUnitsPerEm;
+        _primaryFontIsCjk = primaryFontIsCjk;
+        _fontSize = fontSize;
+    }
+
+    public double MeasureSegment(string text)
+    {
+        var total = 0.0;
+        foreach (var ch in text)
+            total += MeasureChar(ch);
+        return total;
+    }
+
+    public double MeasureGrapheme(string grapheme)
+    {
+        if (grapheme.Length == 0) return 0;
+        return MeasureChar(grapheme[0]);
+    }
+
+    private double MeasureChar(char ch)
+    {
+        // Super/subscript signals are zero-width rendering signals
+        if (LatexFormulaSimplifier.IsScriptSignal(ch))
+            return 0;
+
+        // Space: use a fixed 0.3em advance (matching MuPdfExportService behavior)
+        if (ch == ' ')
+            return _fontSize * 0.3;
+
+        // ASCII routing: when primary font is CJK, ASCII uses half-width advance
+        if (_primaryFontIsCjk && ch >= 0x20 && ch <= 0x7E)
+        {
+            if (_primaryGlyphMap?.TryGetValue(ch, out var gid) == true && gid != 0)
+                return _fontSize * GetGlyphAdvanceEm(gid, _primaryAdvanceWidths, _primaryUnitsPerEm, 0.55);
+
+            // Helvetica fallback
+            return _fontSize * 0.55;
+        }
+
+        // CJK characters are full-width (1 em)
+        if (ScriptClassifier.IsCjk(ch))
+            return _fontSize;
+
+        // Primary font lookup
+        if (_primaryGlyphMap?.TryGetValue(ch, out var primaryGid) == true && primaryGid != 0)
+            return _fontSize * GetGlyphAdvanceEm(primaryGid, _primaryAdvanceWidths, _primaryUnitsPerEm, 0.6);
+
+        // Noto font fallback for non-CJK scripts
+        if (_notoGlyphMap?.TryGetValue(ch, out var notoGid) == true && notoGid != 0)
+            return _fontSize * GetGlyphAdvanceEm(notoGid, _notoAdvanceWidths, _notoUnitsPerEm, 0.6);
+
+        // Final fallback
+        return _fontSize * 0.6;
+    }
+
+    private static double GetGlyphAdvanceEm(
+        ushort gid,
+        IReadOnlyDictionary<ushort, ushort>? advanceWidths,
+        ushort unitsPerEm,
+        double fallbackEm)
+    {
+        if (advanceWidths is not null
+            && advanceWidths.TryGetValue(gid, out var adv)
+            && adv > 0
+            && unitsPerEm > 0)
+            return (double)adv / unitsPerEm;
+
+        return fallbackEm;
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Services/DocumentExport/MuPdfExportService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/DocumentExport/MuPdfExportService.cs
@@ -4,7 +4,9 @@
 
 using System.Diagnostics;
 using System.Text;
-using System.Text.RegularExpressions;
+using Easydict.TextLayout;
+using Easydict.TextLayout.Layout;
+using Easydict.TextLayout.Preparation;
 using Easydict.TranslationService.LongDocument;
 using Easydict.TranslationService.FormulaProtection;
 using Easydict.TranslationService.Models;
@@ -244,7 +246,8 @@ public sealed class MuPdfExportService : IDocumentExportService
 
     /// <summary>
     /// Generates PDF text operations for a translated block.
-    /// Handles line wrapping, font size adjustment, color, and ASCII/CJK font routing.
+    /// Uses TextLayout engine for line breaking, then renders each character with
+    /// font routing, super/subscript signals, and GID encoding.
     /// </summary>
     private static string GenerateBlockTextOperations(
         string translatedText,
@@ -280,152 +283,135 @@ public sealed class MuPdfExportService : IDocumentExportService
             sb.Append($"{r:F3} {g:F3} {b:F3} rg ");
         }
 
-        // Simple line wrapping: split by existing newlines, then wrap long lines
-        var lines = translatedText.Split('\n');
+        // Use TextLayout engine for line breaking.
+        // GlyphAdvanceMeasurer returns 0 for ^ and _ signals so they don't affect layout.
+        var engine = TextLayoutEngine.Instance;
+        var measurer = new GlyphAdvanceMeasurer(
+            fonts.PrimaryGlyphMap, fonts.PrimaryAdvanceWidths, fonts.PrimaryUnitsPerEm,
+            fonts.NotoGlyphMap, fonts.NotoAdvanceWidths, fonts.NotoUnitsPerEm,
+            fonts.PrimaryFontIsCjk, fontSize);
+        var prepared = engine.Prepare(
+            new TextPrepareRequest { Text = translatedText, NormalizeWhitespace = true },
+            measurer);
+
+        // Incremental layout: one line at a time, emit PDF operators per line
+        var cursor = LayoutCursor.Start;
         var currentY = startY;
         var linesRendered = 0;
 
-        foreach (var rawLine in lines)
+        while (true)
         {
-            var line = rawLine.Trim();
-            if (string.IsNullOrEmpty(line)) continue;
-
             // Check if we've exceeded the block height
             if (linesRendered > 0 && (startY - currentY) > maxHeight)
                 break;
 
-            // Estimate character width (rough: fontSize * 0.5 for Latin, fontSize for CJK)
-            var avgCharWidth = EstimateAverageCharWidth(line, fontSize);
-            var charsPerLine = maxWidth > 0 ? (int)Math.Max(1, maxWidth / avgCharWidth) : line.Length;
+            var layoutLine = engine.LayoutNextLine(prepared, cursor, maxWidth);
+            if (layoutLine is null)
+                break;
 
-            // Wrap line if needed
-            var pos = 0;
-            // Declared outside the wrap loop so super/subscript signals survive across
-            // segment boundaries (when the ^ or _ falls at the end of a wrapped segment).
+            var lineText = layoutLine.Text;
+            var currentX = startX;
+
+            // Render each character in the laid-out line
             var superNext = false;
             var subNext = false;
-            while (pos < line.Length)
+            foreach (var ch in lineText)
             {
-                var remaining = line.Length - pos;
-                var count = Math.Min(remaining, charsPerLine);
-                var segment = line.Substring(pos, count);
-
-                // Generate PDF operators for this line segment.
-                // ^ and _ are rendering signals left by SimplifyLatexMarkup:
-                // the character immediately following them is raised/lowered as super/subscript.
-
-                foreach (var ch in segment)
+                // Consume ^ and _ as super/subscript signals (not rendered as characters)
+                if (LatexFormulaSimplifier.IsScriptSignal(ch))
                 {
-                    // Consume ^ and _ as super/subscript signals (not rendered as characters)
-                    if (LatexFormulaSimplifier.IsScriptSignal(ch))
-                    {
-                        if (ch == '^') { superNext = true; subNext = false; }
-                        else { subNext = true; superNext = false; }
-                        continue;
-                    }
-
-                    // Apply super/subscript sizing and Y offset for this character only
-                    var charFontSize = fontSize;
-                    var charY = currentY;
-                    if (superNext)
-                    {
-                        charFontSize = fontSize * 0.7;
-                        charY = currentY + fontSize * 0.4;
-                        superNext = false;
-                    }
-                    else if (subNext)
-                    {
-                        charFontSize = fontSize * 0.7;
-                        charY = currentY - fontSize * 0.3;
-                        subNext = false;
-                    }
-
-                    // Route basic ASCII when the primary font is CJK.
-                    // CJK fonts map ASCII to full-width glyphs; we want half-width rendering.
-                    if (fonts.PrimaryFontIsCjk && ch >= 0x20 && ch <= 0x7E)
-                    {
-                        if (ch == ' ')
-                        {
-                            // Emit no glyph — just advance by a proper space width.
-                            // 0.55 × fontSize (old advance) was nearly 2× too wide; 0.3 is closer to Helvetica's 0.278 em.
-                            startX += charFontSize * 0.3;
-                            superNext = false;
-                            subNext = false;
-                            continue;
-                        }
-
-                        // Prefer the primary CJK font's half-width Latin glyph (visually matches CJK stroke weight).
-                        // PrimaryGlyphMap covers the full BMP including ASCII, so this succeeds for NotoSansSC / SourceHanSerif.
-                        if (fonts.PrimaryGlyphMap?.TryGetValue(ch, out var asciiGid) == true && asciiGid != 0)
-                        {
-                            sb.Append(ContentStreamInterpreter.GenerateTextOperator(
-                                fontId, charFontSize, startX, charY, asciiGid.ToString("X4")));
-                            startX += charFontSize * GetGlyphAdvanceEm(
-                                asciiGid, fonts.PrimaryAdvanceWidths, fonts.PrimaryUnitsPerEm, fallbackEm: 0.55);
-                        }
-                        else
-                        {
-                            // Helv fallback: use 1-byte encoding (X2), not 4-byte (X4).
-                            // Built-in Helvetica is a 1-byte-encoded Type1 font; <0041> is 2 bytes (0x00 + 'A').
-                            sb.Append(ContentStreamInterpreter.GenerateTextOperator(
-                                "helv", charFontSize, startX, charY, ((int)ch).ToString("X2")));
-                            startX += charFontSize * 0.55; // helv metrics not loaded; 0.55 is a reasonable avg
-                        }
-                        continue;
-                    }
-
-                    var charFontId = fontId;
-
-                    // Check if character needs the Noto font (non-Latin, non-CJK)
-                    if (fonts.NotoFontId is not null && NeedsNotoFont(ch))
-                        charFontId = fonts.NotoFontId;
-
-                    // Encode the character for the content stream.
-                    // MuPDF embeds fonts with Identity-H encoding: the char code in
-                    // [<XXXX>] TJ must be the GID (glyph index), not the Unicode code point.
-                    // This matches pdf2zh's raw_string() for the SourceHanSerif/Noto path.
-                    string hexCid;
-                    ushort resolvedGid = 0;
-                    if (charFontId == fontId && fonts.PrimaryGlyphMap is not null)
-                    {
-                        if (!fonts.PrimaryGlyphMap.TryGetValue(ch, out resolvedGid) || resolvedGid == 0)
-                            continue; // character not in font — skip (matches pdf2zh behavior)
-                        hexCid = resolvedGid.ToString("X4");
-                    }
-                    else if (charFontId == fonts.NotoFontId && fonts.NotoGlyphMap is not null)
-                    {
-                        if (!fonts.NotoGlyphMap.TryGetValue(ch, out resolvedGid) || resolvedGid == 0)
-                            continue; // character not in font — skip
-                        hexCid = resolvedGid.ToString("X4");
-                    }
-                    else
-                    {
-                        // Built-in font (e.g., Helvetica fallback) — use Unicode code point directly
-                        hexCid = ((int)ch).ToString("X4");
-                    }
-
-                    sb.Append(ContentStreamInterpreter.GenerateTextOperator(
-                        charFontId, charFontSize, startX, charY, hexCid));
-                    // CJK characters are always full-width (1 em).
-                    // For Latin/other scripts, use per-glyph advance from hmtx when available
-                    // to avoid letter-spacing of narrow glyphs (l, i, ., etc.).
-                    if (IsCjkCharacter(ch))
-                        startX += charFontSize;
-                    else if (charFontId == fontId && resolvedGid != 0)
-                        startX += charFontSize * GetGlyphAdvanceEm(
-                            resolvedGid, fonts.PrimaryAdvanceWidths, fonts.PrimaryUnitsPerEm, fallbackEm: 0.6);
-                    else if (charFontId == fonts.NotoFontId && resolvedGid != 0)
-                        startX += charFontSize * GetGlyphAdvanceEm(
-                            resolvedGid, fonts.NotoAdvanceWidths, fonts.NotoUnitsPerEm, fallbackEm: 0.6);
-                    else
-                        startX += charFontSize * 0.6;
+                    if (ch == '^') { superNext = true; subNext = false; }
+                    else { subNext = true; superNext = false; }
+                    continue;
                 }
 
-                startX = bbox.X; // Reset X for next line
-                currentY -= lineHeight;
-                pos += count;
-                linesRendered++;
+                // Apply super/subscript sizing and Y offset for this character only
+                var charFontSize = fontSize;
+                var charY = currentY;
+                if (superNext)
+                {
+                    charFontSize = fontSize * 0.7;
+                    charY = currentY + fontSize * 0.4;
+                    superNext = false;
+                }
+                else if (subNext)
+                {
+                    charFontSize = fontSize * 0.7;
+                    charY = currentY - fontSize * 0.3;
+                    subNext = false;
+                }
+
+                // Route basic ASCII when the primary font is CJK.
+                // CJK fonts map ASCII to full-width glyphs; we want half-width rendering.
+                if (fonts.PrimaryFontIsCjk && ch >= 0x20 && ch <= 0x7E)
+                {
+                    if (ch == ' ')
+                    {
+                        currentX += charFontSize * 0.3;
+                        continue;
+                    }
+
+                    if (fonts.PrimaryGlyphMap?.TryGetValue(ch, out var asciiGid) == true && asciiGid != 0)
+                    {
+                        sb.Append(ContentStreamInterpreter.GenerateTextOperator(
+                            fontId, charFontSize, currentX, charY, asciiGid.ToString("X4")));
+                        currentX += charFontSize * GetGlyphAdvanceEm(
+                            asciiGid, fonts.PrimaryAdvanceWidths, fonts.PrimaryUnitsPerEm, fallbackEm: 0.55);
+                    }
+                    else
+                    {
+                        sb.Append(ContentStreamInterpreter.GenerateTextOperator(
+                            "helv", charFontSize, currentX, charY, ((int)ch).ToString("X2")));
+                        currentX += charFontSize * 0.55;
+                    }
+                    continue;
+                }
+
+                var charFontId = fontId;
+
+                // Check if character needs the Noto font (non-Latin, non-CJK)
+                if (fonts.NotoFontId is not null && NeedsNotoFont(ch))
+                    charFontId = fonts.NotoFontId;
+
+                string hexCid;
+                ushort resolvedGid = 0;
+                if (charFontId == fontId && fonts.PrimaryGlyphMap is not null)
+                {
+                    if (!fonts.PrimaryGlyphMap.TryGetValue(ch, out resolvedGid) || resolvedGid == 0)
+                        continue;
+                    hexCid = resolvedGid.ToString("X4");
+                }
+                else if (charFontId == fonts.NotoFontId && fonts.NotoGlyphMap is not null)
+                {
+                    if (!fonts.NotoGlyphMap.TryGetValue(ch, out resolvedGid) || resolvedGid == 0)
+                        continue;
+                    hexCid = resolvedGid.ToString("X4");
+                }
+                else
+                {
+                    hexCid = ((int)ch).ToString("X4");
+                }
+
+                sb.Append(ContentStreamInterpreter.GenerateTextOperator(
+                    charFontId, charFontSize, currentX, charY, hexCid));
+
+                if (IsCjkCharacter(ch))
+                    currentX += charFontSize;
+                else if (charFontId == fontId && resolvedGid != 0)
+                    currentX += charFontSize * GetGlyphAdvanceEm(
+                        resolvedGid, fonts.PrimaryAdvanceWidths, fonts.PrimaryUnitsPerEm, fallbackEm: 0.6);
+                else if (charFontId == fonts.NotoFontId && resolvedGid != 0)
+                    currentX += charFontSize * GetGlyphAdvanceEm(
+                        resolvedGid, fonts.NotoAdvanceWidths, fonts.NotoUnitsPerEm, fallbackEm: 0.6);
+                else
+                    currentX += charFontSize * 0.6;
             }
+
+            currentY -= lineHeight;
+            linesRendered++;
+
+            // Advance cursor to next line
+            cursor = new LayoutCursor(layoutLine.EndSegment, layoutLine.EndGrapheme);
         }
 
         // Reset color to black after block
@@ -451,30 +437,6 @@ public sealed class MuPdfExportService : IDocumentExportService
     /// </summary>
     private static string SimplifyMathContent(string latex) =>
         LatexFormulaSimplifier.SimplifyMathContent(latex, preserveScriptSignals: true);
-
-    /// <summary>
-    /// Estimates average character width for line wrapping.
-    /// </summary>
-    private static double EstimateAverageCharWidth(string text, double fontSize)
-    {
-        if (string.IsNullOrEmpty(text)) return fontSize * 0.5;
-
-        // Count CJK vs Latin characters for width estimation
-        var cjkCount = 0;
-        var totalCount = 0;
-        foreach (var ch in text)
-        {
-            if (ch > 0x2E7F) cjkCount++; // Rough CJK detection
-            totalCount++;
-        }
-
-        if (totalCount == 0) return fontSize * 0.5;
-
-        var cjkRatio = (double)cjkCount / totalCount;
-        // Corrected formula: ASCII runs use ~0.55 em, CJK use ~1.0 em.
-        // Weighted average = 0.55 + 0.45 × cjkRatio  (was 0.5 + 0.5 × cjkRatio)
-        return fontSize * (0.55 + cjkRatio * 0.45);
-    }
 
     /// <summary>
     /// Checks if a character needs the Noto font (for non-Latin, non-CJK scripts).

--- a/dotnet/src/Easydict.WinUI/Services/DocumentExport/PdfExportService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/DocumentExport/PdfExportService.cs
@@ -2,6 +2,9 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Easydict.TextLayout;
+using Easydict.TextLayout.FontFitting;
+using Easydict.TextLayout.Preparation;
 using Easydict.TranslationService.LongDocument;
 using Easydict.TranslationService.Models;
 using PdfSharpCore.Drawing;
@@ -2410,21 +2413,21 @@ public sealed class PdfExportService : IDocumentExportService
 
     internal static XFont FitFontToRect(XGraphics gfx, string text, XFont baseFont, double width, double height, double lineHeight = 14d)
     {
-        var size = baseFont.Size;
-        while (size >= MinFontSize)
+        var engine = TextLayoutEngine.Instance;
+        var lineHeightMultiplier = lineHeight / baseFont.Size;
+        var request = new FontFitRequest
         {
-            var candidate = new XFont(baseFont.Name, size, baseFont.Style);
-            var lines = WrapTextByWidth(gfx, text, candidate, width).ToList();
-            var maxLines = Math.Max(1, (int)Math.Floor(height / lineHeight));
-            if (lines.Count <= maxLines)
-            {
-                return candidate;
-            }
+            Text = text,
+            StartFontSize = baseFont.Size,
+            MinFontSize = MinFontSize,
+            MaxWidth = width,
+            MaxHeight = height,
+            LineHeightMultiplier = lineHeightMultiplier,
+        };
+        var result = FontFitSolver.Solve(request, engine,
+            fontSize => new XGraphicsMeasurer(gfx, new XFont(baseFont.Name, fontSize, baseFont.Style)));
 
-            size -= 0.5;
-        }
-
-        return new XFont(baseFont.Name, MinFontSize, baseFont.Style);
+        return new XFont(baseFont.Name, result.ChosenFontSize, baseFont.Style);
     }
 
     /// <summary>
@@ -2437,26 +2440,21 @@ public sealed class PdfExportService : IDocumentExportService
             return baseFont;
 
         var widths = lineRects.Select(r => Math.Max(10, r.Width)).ToList();
-        var minHeight = Math.Max(8, lineRects.Min(r => Math.Max(1, r.Height)));
+        var heights = lineRects.Select(r => Math.Max(1, r.Height)).ToList();
 
-        var size = baseFont.Size;
-        while (size >= MinFontSize)
+        var engine = TextLayoutEngine.Instance;
+        var request = new FontFitRequest
         {
-            var candidate = new XFont(baseFont.Name, size, baseFont.Style);
-            if (candidate.Size > minHeight * 0.98)
-            {
-                size -= 0.5;
-                continue;
-            }
+            Text = text,
+            StartFontSize = baseFont.Size,
+            MinFontSize = MinFontSize,
+            LineWidths = widths,
+            LineHeights = heights,
+        };
+        var result = FontFitSolver.Solve(request, engine,
+            fontSize => new XGraphicsMeasurer(gfx, new XFont(baseFont.Name, fontSize, baseFont.Style)));
 
-            var lines = WrapTextByWidths(gfx, text, candidate, widths).ToList();
-            if (lines.Count <= lineRects.Count)
-                return candidate;
-
-            size -= 0.5;
-        }
-
-        return new XFont(baseFont.Name, MinFontSize, baseFont.Style);
+        return new XFont(baseFont.Name, result.ChosenFontSize, baseFont.Style);
     }
 
     internal static IEnumerable<string> WrapText(string text, int maxChars)
@@ -2482,42 +2480,13 @@ public sealed class PdfExportService : IDocumentExportService
 
     internal static IEnumerable<string> WrapTextByWidth(XGraphics gfx, string text, XFont font, double maxWidth)
     {
-        foreach (var paragraph in text.Replace("\r\n", "\n").Split('\n'))
-        {
-            if (string.IsNullOrEmpty(paragraph))
-            {
-                yield return string.Empty;
-                continue;
-            }
-
-            var line = new StringBuilder();
-            var lineWidth = 0.0;
-
-            foreach (var token in TokenizeForWrapping(paragraph))
-            {
-                var tokenWidth = gfx.MeasureString(token, font).Width;
-
-                if (line.Length > 0 && lineWidth + tokenWidth > maxWidth)
-                {
-                    yield return line.ToString();
-                    line.Clear();
-                    lineWidth = 0;
-                }
-
-                // Skip leading spaces at the start of wrapped lines —
-                // aligned with pdf2zh converter.py:488.
-                var t = line.Length == 0 ? token.TrimStart() : token;
-                if (t.Length > 0)
-                {
-                    var tw = line.Length == 0 && t != token ? gfx.MeasureString(t, font).Width : tokenWidth;
-                    line.Append(t);
-                    lineWidth += tw;
-                }
-            }
-
-            if (line.Length > 0)
-                yield return line.ToString();
-        }
+        var engine = TextLayoutEngine.Instance;
+        var measurer = new XGraphicsMeasurer(gfx, font);
+        var prepared = engine.Prepare(
+            new TextPrepareRequest { Text = text, NormalizeWhitespace = true },
+            measurer);
+        var result = engine.LayoutWithLines(prepared, maxWidth);
+        return result.Lines.Select(l => l.Text);
     }
 
     /// <summary>
@@ -2527,105 +2496,16 @@ public sealed class PdfExportService : IDocumentExportService
     internal static IEnumerable<string> WrapTextByWidths(XGraphics gfx, string text, XFont font, IReadOnlyList<double> maxWidths)
     {
         if (maxWidths.Count == 0)
-            yield break;
+            return [];
 
-        var widths = maxWidths.Select(w => Math.Max(10, w)).ToArray();
-        var lineIndex = 0;
-
-        foreach (var paragraph in text.Replace("\r\n", "\n").Split('\n'))
-        {
-            // Preserve explicit blank lines
-            if (paragraph.Length == 0)
-            {
-                yield return string.Empty;
-                lineIndex++;
-                continue;
-            }
-
-            var line = new StringBuilder();
-            var lineWidth = 0.0;
-
-            foreach (var token in TokenizeForWrapping(paragraph))
-            {
-                var maxWidth = widths[Math.Min(lineIndex, widths.Length - 1)];
-                var tokenWidth = gfx.MeasureString(token, font).Width;
-
-                if (line.Length > 0 && lineWidth + tokenWidth > maxWidth)
-                {
-                    yield return line.ToString();
-                    line.Clear();
-                    lineWidth = 0;
-                    lineIndex++;
-                    maxWidth = widths[Math.Min(lineIndex, widths.Length - 1)];
-                }
-
-                // Skip leading spaces at the start of wrapped lines —
-                // aligned with pdf2zh converter.py:488.
-                var t = line.Length == 0 ? token.TrimStart() : token;
-                var tw = line.Length == 0 && t != token ? gfx.MeasureString(t, font).Width : tokenWidth;
-
-                // If the token itself is too wide for an empty line, split it into characters.
-                if (line.Length == 0 && tw > maxWidth && t.Length > 1)
-                {
-                    foreach (var piece in SplitTokenByWidth(gfx, t, font, () => widths[Math.Min(lineIndex, widths.Length - 1)], () => lineIndex++))
-                    {
-                        yield return piece;
-                    }
-
-                    // After splitting, we're at the start of a new line.
-                    continue;
-                }
-
-                if (t.Length > 0)
-                {
-                    line.Append(t);
-                    lineWidth += tw;
-                }
-            }
-
-            if (line.Length > 0)
-            {
-                yield return line.ToString();
-                lineIndex++;
-            }
-        }
-    }
-
-    private static IEnumerable<string> SplitTokenByWidth(
-        XGraphics gfx,
-        string token,
-        XFont font,
-        Func<double> getMaxWidth,
-        Action advanceLine)
-    {
-        var part = new StringBuilder();
-        var partWidth = 0.0;
-
-        foreach (var ch in token)
-        {
-            var maxWidth = getMaxWidth();
-            var chStr = ch.ToString();
-            var chWidth = gfx.MeasureString(chStr, font).Width;
-
-            if (part.Length > 0 && partWidth + chWidth > maxWidth)
-            {
-                yield return part.ToString();
-                part.Clear();
-                partWidth = 0;
-                advanceLine();
-                maxWidth = getMaxWidth();
-            }
-
-            // If even a single character doesn't fit (extremely narrow column), still emit it.
-            part.Append(chStr);
-            partWidth += chWidth;
-        }
-
-        if (part.Length > 0)
-        {
-            yield return part.ToString();
-            advanceLine();
-        }
+        var widths = maxWidths.Select(w => Math.Max(10, w)).ToList();
+        var engine = TextLayoutEngine.Instance;
+        var measurer = new XGraphicsMeasurer(gfx, font);
+        var prepared = engine.Prepare(
+            new TextPrepareRequest { Text = text, NormalizeWhitespace = true },
+            measurer);
+        var result = engine.LayoutWithLines(prepared, widths);
+        return result.Lines.Select(l => l.Text);
     }
 
     /// <summary>
@@ -2754,42 +2634,6 @@ public sealed class PdfExportService : IDocumentExportService
                 return true;
         }
         return false;
-    }
-
-    /// <summary>
-    /// Splits text into wrappable tokens: individual CJK characters and space-delimited Latin words.
-    /// CJK text can break at any character boundary; Latin text breaks at spaces.
-    /// </summary>
-    private static IEnumerable<string> TokenizeForWrapping(string text)
-    {
-        var wordBuffer = new StringBuilder();
-        foreach (var ch in text)
-        {
-            if (IsCjkCharacter(ch))
-            {
-                if (wordBuffer.Length > 0)
-                {
-                    yield return wordBuffer.ToString();
-                    wordBuffer.Clear();
-                }
-                yield return ch.ToString();
-            }
-            else if (ch == ' ')
-            {
-                if (wordBuffer.Length > 0)
-                {
-                    yield return wordBuffer.ToString();
-                    wordBuffer.Clear();
-                }
-                wordBuffer.Append(ch);
-            }
-            else
-            {
-                wordBuffer.Append(ch);
-            }
-        }
-        if (wordBuffer.Length > 0)
-            yield return wordBuffer.ToString();
     }
 
     private static bool IsCjkCharacter(char ch)

--- a/dotnet/src/Easydict.WinUI/Services/DocumentExport/XGraphicsMeasurer.cs
+++ b/dotnet/src/Easydict.WinUI/Services/DocumentExport/XGraphicsMeasurer.cs
@@ -1,0 +1,26 @@
+using Easydict.TextLayout;
+using PdfSharpCore.Drawing;
+
+namespace Easydict.WinUI.Services.DocumentExport;
+
+/// <summary>
+/// Measures text advance widths using PdfSharpCore's XGraphics.MeasureString.
+/// Used by PdfExportService for TextLayout integration.
+/// </summary>
+internal sealed class XGraphicsMeasurer : ITextMeasurer
+{
+    private readonly XGraphics _gfx;
+    private readonly XFont _font;
+
+    public XGraphicsMeasurer(XGraphics gfx, XFont font)
+    {
+        _gfx = gfx;
+        _font = font;
+    }
+
+    public double MeasureSegment(string text) =>
+        _gfx.MeasureString(text, _font).Width;
+
+    public double MeasureGrapheme(string grapheme) =>
+        _gfx.MeasureString(grapheme, _font).Width;
+}

--- a/dotnet/tests/Easydict.TextLayout.Tests/Layout/KinsokuLayoutTests.cs
+++ b/dotnet/tests/Easydict.TextLayout.Tests/Layout/KinsokuLayoutTests.cs
@@ -1,0 +1,225 @@
+using Easydict.TextLayout.Layout;
+using Easydict.TextLayout.Preparation;
+using Easydict.TextLayout.Tests.Helpers;
+using FluentAssertions;
+
+namespace Easydict.TextLayout.Tests.Layout;
+
+/// <summary>
+/// Tests that kinsoku (line-start prohibition) and left-sticky punctuation rules
+/// are enforced during line breaking.
+/// </summary>
+public class KinsokuLayoutTests
+{
+    private readonly TextLayoutEngine _engine = TextLayoutEngine.Instance;
+    private readonly FixedWidthMeasurer _measurer = new();
+
+    private LayoutLinesResult LayoutLines(string text, double maxWidth)
+    {
+        var prepared = _engine.Prepare(new TextPrepareRequest { Text = text }, _measurer);
+        return _engine.LayoutWithLines(prepared, maxWidth);
+    }
+
+    // --- Kinsoku line-start prohibition ---
+
+    [Fact]
+    public void Kinsoku_IdeographicComma_NeverStartsLine()
+    {
+        // "你好世界、" = 你(10) 好(10) 世(10) 界(10) 、(10) = 50
+        // Width = 25: without kinsoku → "你好" / "世界" / "、"
+        // With kinsoku → 、 carried to line 2: "你好" / "世界、"
+        var result = LayoutLines("你好世界、", 25);
+        result.Lines.Should().HaveCount(2);
+        result.Lines[0].Text.Should().Be("你好");
+        // 、 must NOT start line 2 — it should be carried to line with 世界
+        result.Lines[1].Text.Should().StartWith("世界");
+        result.Lines[1].Text.Should().Contain("、");
+    }
+
+    [Fact]
+    public void Kinsoku_IdeographicPeriod_NeverStartsLine()
+    {
+        // "你好。世界" = 你(10) 好(10) 。(close-punct, 10) 世(10) 界(10)
+        // 。 is ClosePunctuation → grouped with 好 via close-punct grouping
+        // Width = 25: "你好。" (30 > 25, but close-punct grouped) / "世界"
+        var result = LayoutLines("你好。世界", 25);
+        // 。 should be on the same line as 好, not starting a new line
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("。");
+        }
+    }
+
+    [Fact]
+    public void Kinsoku_SmallKana_NeverStartsLine()
+    {
+        // "あいっう" = あ(10) い(10) っ(10) う(10) = 40
+        // っ (small tsu) is prohibited line start
+        // Width = 15: without kinsoku → "あ" / "い" / "っ" / "う"
+        // With kinsoku → っ carried: "あ" / "いっ" / "う"
+        var result = LayoutLines("あいっう", 15);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("っ",
+                "small kana っ must not start a line (kinsoku rule)");
+        }
+    }
+
+    [Fact]
+    public void Kinsoku_ProlongedSoundMark_NeverStartsLine()
+    {
+        // "カラー" = カ(10) ラ(10) ー(10) = 30
+        // ー (prolonged sound mark) is prohibited line start
+        // Width = 15: without kinsoku → "カ" / "ラ" / "ー"
+        // With kinsoku → ー carried: "カ" / "ラー"
+        var result = LayoutLines("カラー", 15);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("ー",
+                "prolonged sound mark ー must not start a line (kinsoku rule)");
+        }
+    }
+
+    [Fact]
+    public void Kinsoku_IterationMark_NeverStartsLine()
+    {
+        // "日々の" = 日(10) 々(10) の(10) = 30
+        // 々 (ideographic iteration mark) is prohibited line start
+        // Width = 12: without kinsoku → "日" / "々" / "の"
+        // With kinsoku → 々 carried: "日々" / "の"
+        var result = LayoutLines("日々の", 12);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("々",
+                "iteration mark 々 must not start a line (kinsoku rule)");
+        }
+    }
+
+    [Fact]
+    public void Kinsoku_MiddleDot_NeverStartsLine()
+    {
+        // "カタカナ・ひらがな" — ・ is katakana middle dot, prohibited line start
+        // Width = 35: layout should ensure ・ doesn't start a line
+        var result = LayoutLines("カタカナ・ひらがな", 35);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("・",
+                "katakana middle dot ・ must not start a line (kinsoku rule)");
+        }
+    }
+
+    [Fact]
+    public void Kinsoku_FullwidthExclamation_NeverStartsLine()
+    {
+        // "すごい！ですね" — ！ is fullwidth exclamation
+        // Already handled as ClosePunctuation, but verify it doesn't start a line
+        var result = LayoutLines("すごい！ですね", 25);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("！",
+                "fullwidth exclamation must not start a line");
+        }
+    }
+
+    // --- Left-sticky punctuation ---
+
+    [Fact]
+    public void LeftSticky_AsciiPeriodAfterCjk_StaysAttached()
+    {
+        // "你好世界." = 你(10) 好(10) 世(10) 界(10) .(6) = 46
+        // . (ASCII period) should stick to CJK 界, not start a new line
+        // Width = 25: without left-sticky → "你好" / "世界" / "."
+        // With left-sticky → "你好" / "世界."
+        var result = LayoutLines("你好世界.", 25);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith(".",
+                "ASCII period after CJK must not start a line (left-sticky rule)");
+        }
+    }
+
+    [Fact]
+    public void LeftSticky_AsciiCommaAfterCjk_StaysAttached()
+    {
+        // "你好世界," = 你(10) 好(10) 世(10) 界(10) ,(6) = 46
+        var result = LayoutLines("你好世界,", 25);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith(",",
+                "ASCII comma after CJK must not start a line (left-sticky rule)");
+        }
+    }
+
+    [Fact]
+    public void LeftSticky_AsciiExclamationAfterCjk_StaysAttached()
+    {
+        // "你好世界!" = 你(10) 好(10) 世(10) 界(10) !(6) = 46
+        var result = LayoutLines("你好世界!", 25);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("!",
+                "ASCII exclamation after CJK must not start a line (left-sticky rule)");
+        }
+    }
+
+    [Fact]
+    public void LeftSticky_AfterLatinWord_DoesNotApply()
+    {
+        // Left-sticky should only apply after CJK, not after Latin words
+        // "Hello. World" → normal word-break behavior, period is ClosePunctuation anyway
+        var result = LayoutLines("Hello. World", 40);
+        // This should behave normally — "Hello." fits, no special behavior
+        result.Lines[0].Text.Should().Contain("Hello.");
+    }
+
+    // --- Edge cases ---
+
+    [Fact]
+    public void Kinsoku_WhenLineIsEmpty_EmitsAnywayToAvoidInfiniteLoop()
+    {
+        // If the very first segment on an empty line is kinsoku-prohibited,
+        // we must still emit it to avoid an infinite loop.
+        // "っあ" with width = 8 (< single CJK width of 10)
+        // Both chars must still be emitted, one per line.
+        var result = LayoutLines("っあ", 8);
+        result.Lines.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Kinsoku_RightAngleBracket_ClassifiedAsClosePunctuation()
+    {
+        // 〉 (U+3009) should be ClosePunctuation and grouped with preceding content
+        var result = LayoutLines("〈テスト〉です", 35);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("〉",
+                "right angle bracket must not start a line");
+        }
+    }
+
+    [Fact]
+    public void Kinsoku_ConsecutiveProhibited_AllCarried()
+    {
+        // "あいっっう" — two consecutive っ
+        // Width = 15: should carry both っっ to the line with い
+        var result = LayoutLines("あいっっう", 15);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("っ",
+                "consecutive small kana must not start a line");
+        }
+    }
+
+    [Fact]
+    public void LeftSticky_Ellipsis_AfterCjk_StaysAttached()
+    {
+        // "你好世界…" = 你(10) 好(10) 世(10) 界(10) …(6) = 46
+        // … (horizontal ellipsis U+2026) is left-sticky
+        var result = LayoutLines("你好世界\u2026", 25);
+        foreach (var line in result.Lines)
+        {
+            line.Text.Should().NotStartWith("\u2026",
+                "ellipsis after CJK must not start a line (left-sticky rule)");
+        }
+    }
+}

--- a/dotnet/tests/Easydict.TextLayout.Tests/Segmentation/ScriptClassifierTests.cs
+++ b/dotnet/tests/Easydict.TextLayout.Tests/Segmentation/ScriptClassifierTests.cs
@@ -48,7 +48,10 @@ public class ScriptClassifierTests
     [InlineData('(')]
     [InlineData('[')]
     [InlineData('{')]
+    [InlineData('\u3008')] // LEFT ANGLE BRACKET 〈
+    [InlineData('\u300A')] // LEFT DOUBLE ANGLE BRACKET 《
     [InlineData('\u300C')] // LEFT CORNER BRACKET
+    [InlineData('\u301D')] // REVERSED DOUBLE PRIME QUOTATION MARK 〝
     [InlineData('\uFF08')] // FULLWIDTH LEFT PARENTHESIS
     public void Classify_OpenPunctuation_ReturnsOpenPunctuation(char ch)
     {
@@ -66,7 +69,11 @@ public class ScriptClassifierTests
     [InlineData('?')]
     [InlineData('\u3001')] // IDEOGRAPHIC COMMA
     [InlineData('\u3002')] // IDEOGRAPHIC FULL STOP
+    [InlineData('\u3009')] // RIGHT ANGLE BRACKET 〉
+    [InlineData('\u300B')] // RIGHT DOUBLE ANGLE BRACKET 》
+    [InlineData('\u301F')] // LOW DOUBLE PRIME QUOTATION MARK 〟
     [InlineData('\uFF09')] // FULLWIDTH RIGHT PARENTHESIS
+    [InlineData('\uFF1A')] // FULLWIDTH COLON ：
     public void Classify_ClosePunctuation_ReturnsClosePunctuation(char ch)
     {
         Classify(ch).Should().Be(CharCategory.ClosePunctuation);

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/GlyphAdvanceMeasurerTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/GlyphAdvanceMeasurerTests.cs
@@ -1,0 +1,120 @@
+using Easydict.WinUI.Services.DocumentExport;
+using FluentAssertions;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+[Trait("Category", "WinUI")]
+public class GlyphAdvanceMeasurerTests
+{
+    /// <summary>
+    /// Creates a measurer with a simple glyph map where ASCII chars map to GID = charCode,
+    /// with a fixed advance width per glyph.
+    /// </summary>
+    private static GlyphAdvanceMeasurer CreateMeasurer(
+        double fontSize = 10.0,
+        bool primaryFontIsCjk = false,
+        ushort advanceWidth = 500,
+        ushort unitsPerEm = 1000)
+    {
+        // Build a simple glyph map: ASCII printable chars (0x20-0x7E)
+        var glyphMap = new Dictionary<char, ushort>();
+        var advanceWidths = new Dictionary<ushort, ushort>();
+        for (char c = ' '; c <= '~'; c++)
+        {
+            var gid = (ushort)c;
+            glyphMap[c] = gid;
+            advanceWidths[gid] = advanceWidth;
+        }
+
+        return new GlyphAdvanceMeasurer(
+            primaryGlyphMap: glyphMap,
+            primaryAdvanceWidths: advanceWidths,
+            primaryUnitsPerEm: unitsPerEm,
+            notoGlyphMap: null,
+            notoAdvanceWidths: null,
+            notoUnitsPerEm: 1000,
+            primaryFontIsCjk: primaryFontIsCjk,
+            fontSize: fontSize);
+    }
+
+    [Fact]
+    public void MeasureGrapheme_ScriptSignals_ReturnZero()
+    {
+        var measurer = CreateMeasurer(fontSize: 12.0);
+        measurer.MeasureGrapheme("^").Should().Be(0);
+        measurer.MeasureGrapheme("_").Should().Be(0);
+    }
+
+    [Fact]
+    public void MeasureGrapheme_Space_ReturnsPointThreeEm()
+    {
+        var measurer = CreateMeasurer(fontSize: 10.0);
+        measurer.MeasureGrapheme(" ").Should().BeApproximately(3.0, 0.001); // 10.0 * 0.3
+    }
+
+    [Fact]
+    public void MeasureGrapheme_CjkCharacter_ReturnsFullEm()
+    {
+        var measurer = CreateMeasurer(fontSize: 12.0);
+        measurer.MeasureGrapheme("\u4E2D").Should().Be(12.0); // CJK char = 1.0 em
+    }
+
+    [Fact]
+    public void MeasureGrapheme_LatinChar_UsesGlyphAdvance()
+    {
+        // advanceWidth=500, unitsPerEm=1000 → 0.5 em → 5.0 at fontSize 10
+        var measurer = CreateMeasurer(fontSize: 10.0, advanceWidth: 500, unitsPerEm: 1000);
+        measurer.MeasureGrapheme("A").Should().BeApproximately(5.0, 0.001);
+    }
+
+    [Fact]
+    public void MeasureSegment_MixedText_SumsCharWidths()
+    {
+        var measurer = CreateMeasurer(fontSize: 10.0, advanceWidth: 500, unitsPerEm: 1000);
+        // "AB" = 5.0 + 5.0 = 10.0
+        measurer.MeasureSegment("AB").Should().BeApproximately(10.0, 0.001);
+    }
+
+    [Fact]
+    public void MeasureSegment_WithScriptSignals_SkipsSignalWidth()
+    {
+        var measurer = CreateMeasurer(fontSize: 10.0, advanceWidth: 500, unitsPerEm: 1000);
+        // "A^B" → A(5.0) + ^(0) + B(5.0) = 10.0
+        measurer.MeasureSegment("A^B").Should().BeApproximately(10.0, 0.001);
+    }
+
+    [Fact]
+    public void MeasureGrapheme_AsciiWithCjkPrimaryFont_UsesHalfWidthAdvance()
+    {
+        // When primary font is CJK, ASCII should use the primary glyph map's advance
+        var measurer = CreateMeasurer(fontSize: 10.0, primaryFontIsCjk: true, advanceWidth: 500, unitsPerEm: 1000);
+        measurer.MeasureGrapheme("A").Should().BeApproximately(5.0, 0.001);
+    }
+
+    [Fact]
+    public void MeasureGrapheme_SpaceWithCjkPrimaryFont_ReturnsPointThreeEm()
+    {
+        var measurer = CreateMeasurer(fontSize: 10.0, primaryFontIsCjk: true);
+        measurer.MeasureGrapheme(" ").Should().BeApproximately(3.0, 0.001);
+    }
+
+    [Fact]
+    public void MeasureGrapheme_FallbackWhenNoGlyphMap()
+    {
+        var measurer = new GlyphAdvanceMeasurer(
+            primaryGlyphMap: null,
+            primaryAdvanceWidths: null,
+            primaryUnitsPerEm: 1000,
+            notoGlyphMap: null,
+            notoAdvanceWidths: null,
+            notoUnitsPerEm: 1000,
+            primaryFontIsCjk: false,
+            fontSize: 10.0);
+
+        // Latin char without glyph map → fallback 0.6 em = 6.0
+        measurer.MeasureGrapheme("A").Should().BeApproximately(6.0, 0.001);
+        // CJK char → 1.0 em = 10.0
+        measurer.MeasureGrapheme("\u4E2D").Should().Be(10.0);
+    }
+}


### PR DESCRIPTION
Replace ad-hoc line-breaking logic in both MuPdfExportService and
PdfExportService with the shared TextLayout engine. MuPdfExportService
now uses LayoutNextLine() for incremental content stream generation
with proper glyph-metric-based measurement (GlyphAdvanceMeasurer).
PdfExportService uses LayoutWithLines() and FontFitSolver for text
wrapping and font fitting via XGraphicsMeasurer.

https://claude.ai/code/session_014LFB2nnbFdHLLB1MKmHMHk