### PR TITLE
fix: address kanban TODO issues for window/hotkey UX

### DIFF
--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Easydict.WinUI.Services;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
@@ -11,6 +12,12 @@ namespace Easydict.WinUI
     /// </summary>
     public partial class App : Application
     {
+        [DllImport("user32.dll")]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
         private Window? _window;
         private TrayIconService? _trayIconService;
         private HotkeyService? _hotkeyService;
@@ -464,7 +471,16 @@ namespace Easydict.WinUI
 
             _window?.DispatcherQueue.TryEnqueue(() =>
             {
-                ShowAndActivateWindow();
+                // Toggle behavior (issue #123): if window is foreground, hide it.
+                // If visible-but-background, raise it (#129). Else show it.
+                if (IsMainWindowVisible && IsMainWindowForeground)
+                {
+                    HideWindow();
+                }
+                else
+                {
+                    ShowAndActivateWindow();
+                }
             });
         }
 
@@ -507,10 +523,18 @@ namespace Easydict.WinUI
                 {
                     if (!string.IsNullOrWhiteSpace(text))
                     {
+                        // Selected text takes precedence — always show with the new text.
                         MiniWindowService.Instance.ShowWithText(text);
+                    }
+                    else if (MiniWindowService.Instance.IsVisible
+                        && MiniWindowService.Instance.IsForeground)
+                    {
+                        // Toggle behavior (issue #123): hotkey re-press hides foreground window.
+                        MiniWindowService.Instance.Hide();
                     }
                     else
                     {
+                        // Show or raise from background (#129).
                         MiniWindowService.Instance.Show();
                     }
                 });
@@ -535,10 +559,18 @@ namespace Easydict.WinUI
                 {
                     if (!string.IsNullOrWhiteSpace(text))
                     {
+                        // Selected text takes precedence — always show with the new text.
                         FixedWindowService.Instance.ShowWithText(text);
+                    }
+                    else if (FixedWindowService.Instance.IsVisible
+                        && FixedWindowService.Instance.IsForeground)
+                    {
+                        // Toggle behavior (issue #123): hotkey re-press hides foreground window.
+                        FixedWindowService.Instance.Hide();
                     }
                     else
                     {
+                        // Show or raise from background (#129).
                         FixedWindowService.Instance.Show();
                     }
                 });
@@ -756,9 +788,47 @@ namespace Easydict.WinUI
         {
             if (_window == null) return;
 
-            // Show and activate the window
+            // Show the window
             _appWindow?.Show();
+
+            // Try to bring window to front using multiple methods
+            try
+            {
+                _appWindow?.MoveInZOrderAtTop();
+            }
+            catch (System.Runtime.InteropServices.COMException ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"App: MoveInZOrderAtTop failed: {ex.Message}");
+            }
+
+            // Use Win32 SetForegroundWindow to forcefully bring window to front
+            // (Activate() alone does not raise an already-visible-but-background window)
+            var hWnd = WindowNative.GetWindowHandle(_window);
+            var foregroundSet = SetForegroundWindow(hWnd);
+            if (!foregroundSet)
+            {
+                System.Diagnostics.Debug.WriteLine("App: SetForegroundWindow failed; relying on Activate()");
+            }
+
             _window.Activate();
+        }
+
+        /// <summary>
+        /// Returns true if the main window is currently visible.
+        /// </summary>
+        private bool IsMainWindowVisible => _appWindow?.IsVisible ?? false;
+
+        /// <summary>
+        /// Returns true if the main window is currently the foreground window.
+        /// </summary>
+        private bool IsMainWindowForeground
+        {
+            get
+            {
+                if (_window == null) return false;
+                var hWnd = WindowNative.GetWindowHandle(_window);
+                return GetForegroundWindow() == hWnd;
+            }
         }
 
         private void HideWindow()

--- a/dotnet/src/Easydict.WinUI/Models/ServiceCheckItem.cs
+++ b/dotnet/src/Easydict.WinUI/Models/ServiceCheckItem.cs
@@ -12,6 +12,7 @@ public class ServiceCheckItem : INotifyPropertyChanged
     private bool _isChecked;
     private bool _enabledQuery = true;
     private bool _isAvailable = true;
+    private bool _isReorderModeEnabled;
 
     /// <summary>
     /// The service identifier (e.g., "google", "deepl").
@@ -76,6 +77,23 @@ public class ServiceCheckItem : INotifyPropertyChanged
             if (_isAvailable != value)
             {
                 _isAvailable = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether the settings page is currently in explicit reorder mode.
+    /// When false, the per-row move controls stay hidden to keep the list tidy.
+    /// </summary>
+    public bool IsReorderModeEnabled
+    {
+        get => _isReorderModeEnabled;
+        set
+        {
+            if (_isReorderModeEnabled != value)
+            {
+                _isReorderModeEnabled = value;
                 OnPropertyChanged();
             }
         }

--- a/dotnet/src/Easydict.WinUI/Services/FixedWindowService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/FixedWindowService.cs
@@ -53,6 +53,11 @@ public sealed class FixedWindowService : IDisposable
     public bool IsVisible => _fixedWindow?.IsVisible ?? false;
 
     /// <summary>
+    /// Gets whether the fixed window is currently the foreground window.
+    /// </summary>
+    public bool IsForeground => _fixedWindow?.IsForeground ?? false;
+
+    /// <summary>
     /// Toggle fixed window visibility (show if hidden, hide if visible).
     /// </summary>
     public void Toggle()

--- a/dotnet/src/Easydict.WinUI/Services/HotkeyService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/HotkeyService.cs
@@ -83,50 +83,92 @@ public sealed class HotkeyService : IDisposable
         var settings = SettingsService.Instance;
 
         // Register Show Window hotkey (default: Ctrl+Alt+T)
-        RegisterHotkeyFromSetting(HOTKEY_ID_SHOW, settings.ShowWindowHotkey, "SHOW");
-
-        // Register Translate Selection hotkey (default: Ctrl+Alt+D)
-        RegisterHotkeyFromSetting(HOTKEY_ID_TRANSLATE_SELECTION, settings.TranslateSelectionHotkey, "TRANSLATE");
-
-        // Register Show Mini Window hotkey (default: Ctrl+Alt+M)
-        var miniResult = HotkeyParser.Parse(settings.ShowMiniWindowHotkey);
-        if (miniResult.IsValid)
+        if (settings.EnableShowWindowHotkey)
         {
-            var result = RegisterHotKey(_hwnd, HOTKEY_ID_SHOW_MINI, miniResult.Modifiers | MOD_NOREPEAT, miniResult.VirtualKey);
-            System.Diagnostics.Debug.WriteLine($"[Hotkey] RegisterHotKey MINI ({settings.ShowMiniWindowHotkey}): {result}, Error: {Marshal.GetLastWin32Error()}");
-
-            // Register Toggle Mini hotkey (base + Shift)
-            var toggleMini = HotkeyParser.AddShiftModifier(miniResult);
-            var toggleResult = RegisterHotKey(_hwnd, HOTKEY_ID_TOGGLE_MINI, toggleMini.Modifiers | MOD_NOREPEAT, toggleMini.VirtualKey);
-            System.Diagnostics.Debug.WriteLine($"[Hotkey] RegisterHotKey TOGGLE_MINI ({settings.ShowMiniWindowHotkey}+Shift): {toggleResult}, Error: {Marshal.GetLastWin32Error()}");
+            RegisterHotkeyFromSetting(HOTKEY_ID_SHOW, settings.ShowWindowHotkey, "SHOW");
         }
         else
         {
-            System.Diagnostics.Debug.WriteLine($"[Hotkey] Failed to parse ShowMiniWindowHotkey '{settings.ShowMiniWindowHotkey}': {miniResult.ErrorMessage}");
+            System.Diagnostics.Debug.WriteLine("[Hotkey] SHOW hotkey skipped (disabled in settings)");
+        }
+
+        // Register Translate Selection hotkey (default: Ctrl+Alt+D)
+        if (settings.EnableTranslateSelectionHotkey)
+        {
+            RegisterHotkeyFromSetting(HOTKEY_ID_TRANSLATE_SELECTION, settings.TranslateSelectionHotkey, "TRANSLATE");
+        }
+        else
+        {
+            System.Diagnostics.Debug.WriteLine("[Hotkey] TRANSLATE hotkey skipped (disabled in settings)");
+        }
+
+        // Register Show Mini Window hotkey (default: Ctrl+Alt+M)
+        if (settings.EnableShowMiniWindowHotkey)
+        {
+            var miniResult = HotkeyParser.Parse(settings.ShowMiniWindowHotkey);
+            if (miniResult.IsValid)
+            {
+                var result = RegisterHotKey(_hwnd, HOTKEY_ID_SHOW_MINI, miniResult.Modifiers | MOD_NOREPEAT, miniResult.VirtualKey);
+                System.Diagnostics.Debug.WriteLine($"[Hotkey] RegisterHotKey MINI ({settings.ShowMiniWindowHotkey}): {result}, Error: {Marshal.GetLastWin32Error()}");
+
+                // Register Toggle Mini hotkey (base + Shift)
+                var toggleMini = HotkeyParser.AddShiftModifier(miniResult);
+                var toggleResult = RegisterHotKey(_hwnd, HOTKEY_ID_TOGGLE_MINI, toggleMini.Modifiers | MOD_NOREPEAT, toggleMini.VirtualKey);
+                System.Diagnostics.Debug.WriteLine($"[Hotkey] RegisterHotKey TOGGLE_MINI ({settings.ShowMiniWindowHotkey}+Shift): {toggleResult}, Error: {Marshal.GetLastWin32Error()}");
+            }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine($"[Hotkey] Failed to parse ShowMiniWindowHotkey '{settings.ShowMiniWindowHotkey}': {miniResult.ErrorMessage}");
+            }
+        }
+        else
+        {
+            System.Diagnostics.Debug.WriteLine("[Hotkey] MINI hotkey skipped (disabled in settings)");
         }
 
         // Register Show Fixed Window hotkey (default: Ctrl+Alt+F)
-        var fixedResult = HotkeyParser.Parse(settings.ShowFixedWindowHotkey);
-        if (fixedResult.IsValid)
+        if (settings.EnableShowFixedWindowHotkey)
         {
-            var result = RegisterHotKey(_hwnd, HOTKEY_ID_SHOW_FIXED, fixedResult.Modifiers | MOD_NOREPEAT, fixedResult.VirtualKey);
-            System.Diagnostics.Debug.WriteLine($"[Hotkey] RegisterHotKey FIXED ({settings.ShowFixedWindowHotkey}): {result}, Error: {Marshal.GetLastWin32Error()}");
+            var fixedResult = HotkeyParser.Parse(settings.ShowFixedWindowHotkey);
+            if (fixedResult.IsValid)
+            {
+                var result = RegisterHotKey(_hwnd, HOTKEY_ID_SHOW_FIXED, fixedResult.Modifiers | MOD_NOREPEAT, fixedResult.VirtualKey);
+                System.Diagnostics.Debug.WriteLine($"[Hotkey] RegisterHotKey FIXED ({settings.ShowFixedWindowHotkey}): {result}, Error: {Marshal.GetLastWin32Error()}");
 
-            // Register Toggle Fixed hotkey (base + Shift)
-            var toggleFixed = HotkeyParser.AddShiftModifier(fixedResult);
-            var toggleResult = RegisterHotKey(_hwnd, HOTKEY_ID_TOGGLE_FIXED, toggleFixed.Modifiers | MOD_NOREPEAT, toggleFixed.VirtualKey);
-            System.Diagnostics.Debug.WriteLine($"[Hotkey] RegisterHotKey TOGGLE_FIXED ({settings.ShowFixedWindowHotkey}+Shift): {toggleResult}, Error: {Marshal.GetLastWin32Error()}");
+                // Register Toggle Fixed hotkey (base + Shift)
+                var toggleFixed = HotkeyParser.AddShiftModifier(fixedResult);
+                var toggleResult = RegisterHotKey(_hwnd, HOTKEY_ID_TOGGLE_FIXED, toggleFixed.Modifiers | MOD_NOREPEAT, toggleFixed.VirtualKey);
+                System.Diagnostics.Debug.WriteLine($"[Hotkey] RegisterHotKey TOGGLE_FIXED ({settings.ShowFixedWindowHotkey}+Shift): {toggleResult}, Error: {Marshal.GetLastWin32Error()}");
+            }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine($"[Hotkey] Failed to parse ShowFixedWindowHotkey '{settings.ShowFixedWindowHotkey}': {fixedResult.ErrorMessage}");
+            }
         }
         else
         {
-            System.Diagnostics.Debug.WriteLine($"[Hotkey] Failed to parse ShowFixedWindowHotkey '{settings.ShowFixedWindowHotkey}': {fixedResult.ErrorMessage}");
+            System.Diagnostics.Debug.WriteLine("[Hotkey] FIXED hotkey skipped (disabled in settings)");
         }
 
         // Register OCR Translate hotkey (default: Ctrl+Alt+S)
-        RegisterHotkeyFromSetting(HOTKEY_ID_OCR_TRANSLATE, settings.OcrTranslateHotkey, "OCR_TRANSLATE");
+        if (settings.EnableOcrTranslateHotkey)
+        {
+            RegisterHotkeyFromSetting(HOTKEY_ID_OCR_TRANSLATE, settings.OcrTranslateHotkey, "OCR_TRANSLATE");
+        }
+        else
+        {
+            System.Diagnostics.Debug.WriteLine("[Hotkey] OCR_TRANSLATE hotkey skipped (disabled in settings)");
+        }
 
         // Register Silent OCR hotkey (default: Ctrl+Alt+Shift+S)
-        RegisterHotkeyFromSetting(HOTKEY_ID_SILENT_OCR, settings.SilentOcrHotkey, "SILENT_OCR");
+        if (settings.EnableSilentOcrHotkey)
+        {
+            RegisterHotkeyFromSetting(HOTKEY_ID_SILENT_OCR, settings.SilentOcrHotkey, "SILENT_OCR");
+        }
+        else
+        {
+            System.Diagnostics.Debug.WriteLine("[Hotkey] SILENT_OCR hotkey skipped (disabled in settings)");
+        }
 
         _isInitialized = true;
         System.Diagnostics.Debug.WriteLine("[Hotkey] Hotkey service initialized.");

--- a/dotnet/src/Easydict.WinUI/Services/MiniWindowService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/MiniWindowService.cs
@@ -64,6 +64,11 @@ public sealed class MiniWindowService : IDisposable
     public bool IsVisible => _miniWindow?.IsVisible ?? false;
 
     /// <summary>
+    /// Gets whether the mini window is currently the foreground window.
+    /// </summary>
+    public bool IsForeground => _miniWindow?.IsForeground ?? false;
+
+    /// <summary>
     /// Called by MiniWindow when the user switches query modes.
     /// Updates CurrentQueryMode and fires QueryModeChanged.
     /// </summary>

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -191,6 +191,19 @@ public sealed class SettingsService
     public string OcrTranslateHotkey { get; set; } = "Ctrl+Alt+S";
     public string SilentOcrHotkey { get; set; } = "Ctrl+Alt+Shift+S";
 
+    // Per-hotkey enable flags. When false, the corresponding RegisterHotKey call is skipped at startup.
+    public bool EnableShowWindowHotkey { get; set; } = true;
+    public bool EnableTranslateSelectionHotkey { get; set; } = true;
+    public bool EnableShowMiniWindowHotkey { get; set; } = true;
+    public bool EnableShowFixedWindowHotkey { get; set; } = true;
+    public bool EnableOcrTranslateHotkey { get; set; } = true;
+    public bool EnableSilentOcrHotkey { get; set; } = true;
+
+    /// <summary>
+    /// When true, ServiceResultItem panels collapse entirely when the service returned no result.
+    /// </summary>
+    public bool HideEmptyServiceResults { get; set; } = true;
+
     /// <summary>
     /// Preferred OCR recognition language. "auto" uses the system profile languages.
     /// Otherwise a BCP-47 tag like "zh-Hans-CN", "en-US", "ja".
@@ -583,6 +596,13 @@ public sealed class SettingsService
         TranslateSelectionHotkey = GetValue(nameof(TranslateSelectionHotkey), "Ctrl+Alt+D");
         OcrTranslateHotkey = GetValue(nameof(OcrTranslateHotkey), "Ctrl+Alt+S");
         SilentOcrHotkey = GetValue(nameof(SilentOcrHotkey), "Ctrl+Alt+Shift+S");
+        EnableShowWindowHotkey = GetValue(nameof(EnableShowWindowHotkey), true);
+        EnableTranslateSelectionHotkey = GetValue(nameof(EnableTranslateSelectionHotkey), true);
+        EnableShowMiniWindowHotkey = GetValue(nameof(EnableShowMiniWindowHotkey), true);
+        EnableShowFixedWindowHotkey = GetValue(nameof(EnableShowFixedWindowHotkey), true);
+        EnableOcrTranslateHotkey = GetValue(nameof(EnableOcrTranslateHotkey), true);
+        EnableSilentOcrHotkey = GetValue(nameof(EnableSilentOcrHotkey), true);
+        HideEmptyServiceResults = GetValue(nameof(HideEmptyServiceResults), true);
         OcrLanguage = GetValue(nameof(OcrLanguage), "auto");
         AlwaysOnTop = GetValue(nameof(AlwaysOnTop), false);
         UILanguage = GetValue(nameof(UILanguage), "");
@@ -745,6 +765,13 @@ public sealed class SettingsService
         _settings[nameof(TranslateSelectionHotkey)] = TranslateSelectionHotkey;
         _settings[nameof(OcrTranslateHotkey)] = OcrTranslateHotkey;
         _settings[nameof(SilentOcrHotkey)] = SilentOcrHotkey;
+        _settings[nameof(EnableShowWindowHotkey)] = EnableShowWindowHotkey;
+        _settings[nameof(EnableTranslateSelectionHotkey)] = EnableTranslateSelectionHotkey;
+        _settings[nameof(EnableShowMiniWindowHotkey)] = EnableShowMiniWindowHotkey;
+        _settings[nameof(EnableShowFixedWindowHotkey)] = EnableShowFixedWindowHotkey;
+        _settings[nameof(EnableOcrTranslateHotkey)] = EnableOcrTranslateHotkey;
+        _settings[nameof(EnableSilentOcrHotkey)] = EnableSilentOcrHotkey;
+        _settings[nameof(HideEmptyServiceResults)] = HideEmptyServiceResults;
         _settings[nameof(OcrLanguage)] = OcrLanguage;
         _settings[nameof(AlwaysOnTop)] = AlwaysOnTop;
         _settings[nameof(UILanguage)] = UILanguage;

--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -914,4 +914,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>أسماء العمليات المراد استثناؤها من ترجمة تحديد الماوس، مفصولة بفواصل. مثال: "code" لـ VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>إعادة الترتيب</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>تم</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -458,4 +458,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>Procesnavne der skal ekskluderes fra musemarkerings-oversættelse, adskilt med kommaer. Eksempel: "code" for VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>Omarranger</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>Færdig</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -1031,4 +1031,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>Prozessnamen, die von der Mausauswahl-Übersetzung ausgeschlossen werden sollen, durch Kommas getrennt. Beispiel: "code" für VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>Neu anordnen</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>Fertig</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -1114,4 +1114,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>Process names to exclude from mouse selection translate, separated by commas. Example: "code" for VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>Reorder</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>Done</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -1031,4 +1031,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>Noms de processus à exclure de la traduction par sélection, séparés par des virgules. Exemple : "code" pour VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>Réorganiser</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>Terminer</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -458,4 +458,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>माउस चयन अनुवाद से बाहर रखने के लिए प्रक्रिया नाम, अल्पविराम से अलग करें। उदाहरण: VS Code के लिए "code"।</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>पुन: क्रमित करें</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>पूर्ण</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -860,4 +860,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>Nama proses yang dikecualikan dari terjemahan pilihan mouse, dipisahkan dengan koma. Contoh: "code" untuk VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>Urutkan Ulang</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>Selesai</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -906,4 +906,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>Nomi dei processi da escludere dalla traduzione con selezione mouse, separati da virgole. Esempio: "code" per VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>Riordina</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>Fine</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -1073,4 +1073,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>マウス選択翻訳から除外するプロセス名をカンマ区切りで入力。例：VS Code は "code"。</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>並べ替え</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>完了</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -1073,4 +1073,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>마우스 선택 번역에서 제외할 프로세스 이름을 쉼표로 구분하여 입력. 예: VS Code는 "code".</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>순서 변경</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>완료</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -458,4 +458,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>Nama proses untuk dikecualikan daripada terjemahan pilihan tetikus, dipisahkan dengan koma. Contoh: "code" untuk VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>Susun Semula</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>Selesai</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -868,4 +868,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>ชื่อโปรเซสที่ต้องการยกเว้นจากการแปลเมื่อเลือกข้อความ คั่นด้วยเครื่องหมายจุลภาค ตัวอย่าง: "code" สำหรับ VS Code</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>จัดลำดับ</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>เสร็จสิ้น</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -914,4 +914,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>Tên tiến trình cần loại trừ khỏi dịch chọn chuột, phân cách bằng dấu phẩy. Ví dụ: "code" cho VS Code.</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>Sắp xếp lại</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>Xong</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -1114,4 +1114,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>排除划词翻译的进程名称，用逗号分隔。示例："code" 代表 VS Code。</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>排序</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>完成排序</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -1073,4 +1073,10 @@
   <data name="MouseSelectionExcludedAppsDescription.Text" xml:space="preserve">
     <value>排除劃詞翻譯的程序名稱，用逗號分隔。範例："code" 代表 VS Code。</value>
   </data>
+  <data name="EnabledServicesReorderButton" xml:space="preserve">
+    <value>排序</value>
+  </data>
+  <data name="EnabledServicesDoneReorderingButton" xml:space="preserve">
+    <value>完成排序</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
@@ -121,131 +121,140 @@
                 Padding="8,6,8,8"
                 Visibility="Visible">
                 <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
+                    <ScrollViewer
+                        x:Name="ResultContentScrollViewer"
+                        MaxHeight="800"
+                        VerticalScrollBarVisibility="Auto"
+                        HorizontalScrollBarVisibility="Disabled"
+                        VerticalScrollMode="Auto"
+                        HorizontalScrollMode="Disabled"
+                        PointerWheelChanged="OnResultContentScrollViewerPointerWheelChanged">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
 
-                    <!-- Pending Query Hint (for manual-query services not yet queried) -->
-                    <TextBlock
-                        x:Name="PendingQueryText"
-                        Grid.Row="0"
-                        Text="Click header to query"
-                        FontStyle="Italic"
-                        FontSize="12"
-                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                        Visibility="Collapsed" />
-
-                    <!-- Phonetic Transcription Badges -->
-                    <StackPanel
-                        x:Name="PhoneticPanel"
-                        AutomationProperties.AutomationId="PhoneticPanel"
-                        Grid.Row="1"
-                        Orientation="Horizontal"
-                        Spacing="6"
-                        Margin="0,0,0,4"
-                        Visibility="Collapsed">
-                    </StackPanel>
-
-                    <!-- Dictionary Definitions and Examples -->
-                    <StackPanel
-                        x:Name="DictionaryPanel"
-                        AutomationProperties.AutomationId="DictionaryPanel"
-                        Grid.Row="2"
-                        Spacing="2"
-                        Margin="0,0,0,4"
-                        Visibility="Collapsed">
-                    </StackPanel>
-
-                    <!-- Translation Result -->
-                    <TextBlock
-                        x:Name="ResultText"
-                        Grid.Row="3"
-                        TextWrapping="Wrap"
-                        IsTextSelectionEnabled="True"
-                        Foreground="{ThemeResource QueryTextBrush}"
-                        FontSize="13"
-                        />
-
-                    <!-- Dictionary HTML Rendering (WebView2, for MDX with MDD resources) -->
-                    <WebView2
-                        x:Name="DictWebView"
-                        Grid.Row="3"
-                        DefaultBackgroundColor="Transparent"
-                        Visibility="Collapsed" />
-
-                    <!-- Error Message -->
-                    <TextBlock
-                        x:Name="ErrorText"
-                        Grid.Row="4"
-                        TextWrapping="Wrap"
-                        IsTextSelectionEnabled="True"
-                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                        FontSize="12"
-                        Visibility="Collapsed" />
-
-                    <!-- Grammar Correction Result (visible only in grammar mode) -->
-                    <StackPanel
-                        x:Name="GrammarResultPanel"
-                        Grid.Row="4"
-                        Spacing="8"
-                        Visibility="Collapsed">
-
-                        <!-- Corrected text (primary result, same style as ResultText) -->
-                        <TextBlock
-                            x:Name="CorrectedText"
-                            TextWrapping="Wrap"
-                            IsTextSelectionEnabled="True"
-                            Foreground="{ThemeResource QueryTextBrush}"
-                            FontSize="13" />
-
-                        <!-- Original text (secondary, muted) -->
-                        <StackPanel Spacing="2">
+                            <!-- Pending Query Hint (for manual-query services not yet queried) -->
                             <TextBlock
-                                x:Name="OriginalLabel"
-                                Text="Original:"
-                                FontSize="11"
-                                Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
-                            <TextBlock
-                                x:Name="OriginalText"
-                                TextWrapping="Wrap"
-                                IsTextSelectionEnabled="True"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                FontSize="12" />
-                        </StackPanel>
-
-                        <!-- Explanation of changes -->
-                        <StackPanel x:Name="ExplanationPanel" Spacing="2" Visibility="Collapsed">
-                            <TextBlock
-                                x:Name="ChangesLabel"
-                                Text="Changes:"
-                                FontSize="11"
-                                Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
-                            <TextBlock
-                                x:Name="ExplanationText"
-                                TextWrapping="Wrap"
-                                IsTextSelectionEnabled="True"
+                                x:Name="PendingQueryText"
+                                Grid.Row="0"
+                                Text="Click header to query"
+                                FontStyle="Italic"
                                 FontSize="12"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        </StackPanel>
+                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                Visibility="Collapsed" />
 
-                        <!-- No corrections needed -->
-                        <TextBlock
-                            x:Name="NoCorrectionsText"
-                            Text="No grammar issues found."
-                            Visibility="Collapsed"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            FontSize="12" />
-                    </StackPanel>
+                            <!-- Phonetic Transcription Badges -->
+                            <StackPanel
+                                x:Name="PhoneticPanel"
+                                AutomationProperties.AutomationId="PhoneticPanel"
+                                Grid.Row="1"
+                                Orientation="Horizontal"
+                                Spacing="6"
+                                Margin="0,0,0,4"
+                                Visibility="Collapsed">
+                            </StackPanel>
+
+                            <!-- Dictionary Definitions and Examples -->
+                            <StackPanel
+                                x:Name="DictionaryPanel"
+                                AutomationProperties.AutomationId="DictionaryPanel"
+                                Grid.Row="2"
+                                Spacing="2"
+                                Margin="0,0,0,4"
+                                Visibility="Collapsed">
+                            </StackPanel>
+
+                            <!-- Translation Result -->
+                            <TextBlock
+                                x:Name="ResultText"
+                                Grid.Row="3"
+                                TextWrapping="Wrap"
+                                IsTextSelectionEnabled="True"
+                                Foreground="{ThemeResource QueryTextBrush}"
+                                FontSize="13"
+                                />
+
+                            <!-- Dictionary HTML Rendering (WebView2, for MDX with MDD resources) -->
+                            <WebView2
+                                x:Name="DictWebView"
+                                Grid.Row="3"
+                                DefaultBackgroundColor="Transparent"
+                                Visibility="Collapsed" />
+
+                            <!-- Error Message -->
+                            <TextBlock
+                                x:Name="ErrorText"
+                                Grid.Row="4"
+                                TextWrapping="Wrap"
+                                IsTextSelectionEnabled="True"
+                                Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                FontSize="12"
+                                Visibility="Collapsed" />
+
+                            <!-- Grammar Correction Result (visible only in grammar mode) -->
+                            <StackPanel
+                                x:Name="GrammarResultPanel"
+                                Grid.Row="4"
+                                Spacing="8"
+                                Visibility="Collapsed">
+
+                                <!-- Corrected text (primary result, same style as ResultText) -->
+                                <TextBlock
+                                    x:Name="CorrectedText"
+                                    TextWrapping="Wrap"
+                                    IsTextSelectionEnabled="True"
+                                    Foreground="{ThemeResource QueryTextBrush}"
+                                    FontSize="13" />
+
+                                <!-- Original text (secondary, muted) -->
+                                <StackPanel Spacing="2">
+                                    <TextBlock
+                                        x:Name="OriginalLabel"
+                                        Text="Original:"
+                                        FontSize="11"
+                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                                    <TextBlock
+                                        x:Name="OriginalText"
+                                        TextWrapping="Wrap"
+                                        IsTextSelectionEnabled="True"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        FontSize="12" />
+                                </StackPanel>
+
+                                <!-- Explanation of changes -->
+                                <StackPanel x:Name="ExplanationPanel" Spacing="2" Visibility="Collapsed">
+                                    <TextBlock
+                                        x:Name="ChangesLabel"
+                                        Text="Changes:"
+                                        FontSize="11"
+                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                                    <TextBlock
+                                        x:Name="ExplanationText"
+                                        TextWrapping="Wrap"
+                                        IsTextSelectionEnabled="True"
+                                        FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                </StackPanel>
+
+                                <!-- No corrections needed -->
+                                <TextBlock
+                                    x:Name="NoCorrectionsText"
+                                    Text="No grammar issues found."
+                                    Visibility="Collapsed"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    FontSize="12" />
+                            </StackPanel>
+                        </Grid>
+                    </ScrollViewer>
 
                     <!-- Action Buttons (floating overlay, top-right corner) -->
                     <StackPanel
                         x:Name="ActionButtons"
-                        Grid.Row="0"
-                        Grid.RowSpan="5"
                         Height="27"
                         Orientation="Horizontal"
                         HorizontalAlignment="Right"

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
@@ -15,8 +15,8 @@
         PointerExited="OnControlPointerExited">
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="30" />
-                <RowDefinition Height="Auto" />
+                <RowDefinition Height="30"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <!-- Header Bar (30 DIPs, matches macOS EZResultViewMiniHeight) -->
@@ -30,12 +30,12 @@
                 PointerExited="OnHeaderBarPointerExited">
                 <Grid Padding="8,0">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
                     <!-- Service Icon -->
@@ -45,7 +45,7 @@
                         Width="16"
                         Height="16"
                         Margin="0,0,6,0"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center"/>
 
                     <!-- Service Name -->
                     <TextBlock
@@ -54,7 +54,7 @@
                         FontSize="12"
                         FontWeight="SemiBold"
                         VerticalAlignment="Center"
-                        Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                        Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
 
                     <!-- Status Text (timing/error) -->
                     <TextBlock
@@ -64,7 +64,7 @@
                         Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"
-                        Margin="8,0" />
+                        Margin="8,0"/>
 
                     <!-- Loading Ring -->
                     <ProgressRing
@@ -74,7 +74,7 @@
                         Height="14"
                         IsActive="False"
                         Visibility="Collapsed"
-                        Margin="0,0,4,0" />
+                        Margin="0,0,4,0"/>
 
                     <!-- Error Icon -->
                     <FontIcon
@@ -85,7 +85,7 @@
                         Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                         Visibility="Collapsed"
                         Margin="0,0,4,0"
-                        ToolTipService.ToolTip="Translation error" />
+                        ToolTipService.ToolTip="Translation error"/>
 
                     <!-- Retry Button (visible on error) -->
                     <Button
@@ -100,7 +100,9 @@
                         Padding="0"
                         VerticalAlignment="Center"
                         Visibility="Collapsed">
-                        <FontIcon Glyph="&#xE72C;" FontSize="12" Foreground="{ThemeResource ActionButtonIconBrush}" />
+                        <FontIcon Glyph="&#xE72C;"
+                                FontSize="12"
+                                Foreground="{ThemeResource ActionButtonIconBrush}"/>
                     </Button>
 
                     <!-- Expand/Collapse Arrow -->
@@ -110,7 +112,7 @@
                         Glyph="&#xE70D;"
                         FontSize="10"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center"/>
                 </Grid>
             </Border>
 
@@ -124,18 +126,18 @@
                     <ScrollViewer
                         x:Name="ResultContentScrollViewer"
                         MaxHeight="800"
-                        VerticalScrollBarVisibility="Auto"
+                        VerticalScrollBarVisibility="Visible"
                         HorizontalScrollBarVisibility="Disabled"
                         VerticalScrollMode="Auto"
                         HorizontalScrollMode="Disabled"
                         PointerWheelChanged="OnResultContentScrollViewerPointerWheelChanged">
                         <Grid>
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
                             <!-- Pending Query Hint (for manual-query services not yet queried) -->
@@ -146,7 +148,7 @@
                                 FontStyle="Italic"
                                 FontSize="12"
                                 Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                                Visibility="Collapsed" />
+                                Visibility="Collapsed"/>
 
                             <!-- Phonetic Transcription Badges -->
                             <StackPanel
@@ -176,15 +178,14 @@
                                 TextWrapping="Wrap"
                                 IsTextSelectionEnabled="True"
                                 Foreground="{ThemeResource QueryTextBrush}"
-                                FontSize="13"
-                                />
+                                FontSize="13"/>
 
                             <!-- Dictionary HTML Rendering (WebView2, for MDX with MDD resources) -->
                             <WebView2
                                 x:Name="DictWebView"
                                 Grid.Row="3"
                                 DefaultBackgroundColor="Transparent"
-                                Visibility="Collapsed" />
+                                Visibility="Collapsed"/>
 
                             <!-- Error Message -->
                             <TextBlock
@@ -194,7 +195,7 @@
                                 IsTextSelectionEnabled="True"
                                 Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                 FontSize="12"
-                                Visibility="Collapsed" />
+                                Visibility="Collapsed"/>
 
                             <!-- Grammar Correction Result (visible only in grammar mode) -->
                             <StackPanel
@@ -209,7 +210,7 @@
                                     TextWrapping="Wrap"
                                     IsTextSelectionEnabled="True"
                                     Foreground="{ThemeResource QueryTextBrush}"
-                                    FontSize="13" />
+                                    FontSize="13"/>
 
                                 <!-- Original text (secondary, muted) -->
                                 <StackPanel Spacing="2">
@@ -217,28 +218,30 @@
                                         x:Name="OriginalLabel"
                                         Text="Original:"
                                         FontSize="11"
-                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
                                     <TextBlock
                                         x:Name="OriginalText"
                                         TextWrapping="Wrap"
                                         IsTextSelectionEnabled="True"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                        FontSize="12" />
+                                        FontSize="12"/>
                                 </StackPanel>
 
                                 <!-- Explanation of changes -->
-                                <StackPanel x:Name="ExplanationPanel" Spacing="2" Visibility="Collapsed">
+                                <StackPanel x:Name="ExplanationPanel"
+                                        Spacing="2"
+                                        Visibility="Collapsed">
                                     <TextBlock
                                         x:Name="ChangesLabel"
                                         Text="Changes:"
                                         FontSize="11"
-                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
                                     <TextBlock
                                         x:Name="ExplanationText"
                                         TextWrapping="Wrap"
                                         IsTextSelectionEnabled="True"
                                         FontSize="12"
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                                 </StackPanel>
 
                                 <!-- No corrections needed -->
@@ -247,7 +250,7 @@
                                     Text="No grammar issues found."
                                     Visibility="Collapsed"
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    FontSize="12" />
+                                    FontSize="12"/>
                             </StackPanel>
                         </Grid>
                     </ScrollViewer>
@@ -274,7 +277,10 @@
                             Height="24"
                             Padding="0"
                             Visibility="Collapsed">
-                            <FontIcon x:Name="ReplaceIcon" Glyph="&#xE8AC;" FontSize="12" Foreground="{ThemeResource ActionButtonIconBrush}" />
+                            <FontIcon x:Name="ReplaceIcon"
+                                    Glyph="&#xE8AC;"
+                                    FontSize="12"
+                                    Foreground="{ThemeResource ActionButtonIconBrush}"/>
                         </Button>
 
                         <!-- TTS Play Button -->
@@ -287,7 +293,10 @@
                             Width="24"
                             Height="24"
                             Padding="0">
-                            <FontIcon x:Name="PlayIcon" Glyph="&#xE768;" FontSize="12" Foreground="{ThemeResource ActionButtonIconBrush}" />
+                            <FontIcon x:Name="PlayIcon"
+                                    Glyph="&#xE768;"
+                                    FontSize="12"
+                                    Foreground="{ThemeResource ActionButtonIconBrush}"/>
                         </Button>
 
                         <!-- Copy Button -->
@@ -300,7 +309,10 @@
                             Width="24"
                             Height="24"
                             Padding="0">
-                            <FontIcon x:Name="CopyIcon" Glyph="&#xE8C8;" FontSize="12" Foreground="{ThemeResource ActionButtonIconBrush}" />
+                            <FontIcon x:Name="CopyIcon"
+                                    Glyph="&#xE8C8;"
+                                    FontSize="12"
+                                    Foreground="{ThemeResource ActionButtonIconBrush}"/>
                         </Button>
                     </StackPanel>
                 </Grid>

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1203,6 +1203,24 @@ public sealed partial class ServiceResultItem : UserControl
                         max-width: 100%;
                         overflow-x: hidden;
                     }
+                    h1, h2, h3, h4, h5, h6 {
+                        margin: 0 0 10px;
+                        line-height: 1.2;
+                    }
+                    ol, ul {
+                        margin: 8px 0 12px;
+                        padding-left: 1.35em;
+                    }
+                    li {
+                        margin: 4px 0;
+                    }
+                    [class*="phon"], [class*="pron"], [class*="ipa"] {
+                        letter-spacing: 0.01em;
+                        line-height: 1.35;
+                    }
+                    [class*="meaning"], [class*="def"], [class*="sense"], [class*="gloss"] {
+                        line-height: 1.55;
+                    }
                     img, svg, table { max-width: 100% !important; height: auto; }
                     pre { white-space: pre-wrap; overflow-wrap: anywhere; }
                     a { color: {{(isDark ? "#569cd6" : "#0066cc")}}; }

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -320,7 +320,7 @@ public sealed partial class ServiceResultItem : UserControl
             else if (!string.IsNullOrEmpty(_serviceResult.Result.RawHtml))
             {
                 // Rich HTML from MDX dictionary with MDD resources — render in WebView2
-                ResultText.Visibility = Visibility.Collapsed;
+                ShowRawHtmlPlainTextFallback(_serviceResult.Result, resultTextBrush);
                 PhoneticPanel.Visibility = Visibility.Collapsed;
                 DictionaryPanel.Visibility = Visibility.Collapsed;
                 ErrorText.Visibility = Visibility.Collapsed;
@@ -377,6 +377,22 @@ public sealed partial class ServiceResultItem : UserControl
             DictWebView.Visibility = Visibility.Collapsed;
             ActionButtons.Visibility = Visibility.Collapsed;
         }
+    }
+
+    private void ShowRawHtmlPlainTextFallback(TranslationResult result, Brush? foreground = null)
+    {
+        DictWebView.Visibility = Visibility.Collapsed;
+        DictWebView.Height = 0;
+
+        ResultText.Text = result.TranslatedText;
+        if (foreground != null)
+        {
+            ResultText.Foreground = foreground;
+        }
+
+        ResultText.Visibility = string.IsNullOrWhiteSpace(ResultText.Text)
+            ? Visibility.Collapsed
+            : Visibility.Visible;
     }
 
     private void UpdateGrammarUI()
@@ -1129,6 +1145,7 @@ public sealed partial class ServiceResultItem : UserControl
     {
         try
         {
+            DictWebView.Height = 1;
             DictWebView.Visibility = Visibility.Visible;
 
             if (!_webViewInitialized)
@@ -1293,9 +1310,10 @@ public sealed partial class ServiceResultItem : UserControl
         catch (Exception ex)
         {
             Debug.WriteLine($"[ServiceResultItem] WebView2 rendering failed: {ex.Message}");
-            // Fallback to plain text
-            DictWebView.Visibility = Visibility.Collapsed;
-            ResultText.Visibility = Visibility.Visible;
+            if (_serviceResult?.Result != null)
+            {
+                ShowRawHtmlPlainTextFallback(_serviceResult.Result);
+            }
         }
     }
 
@@ -1343,7 +1361,15 @@ public sealed partial class ServiceResultItem : UserControl
 
     private async void OnDictWebViewNavigationCompleted(WebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
     {
-        if (!args.IsSuccess) return;
+        if (!args.IsSuccess)
+        {
+            Debug.WriteLine($"[ServiceResultItem] WebView2 navigation failed: {args.WebErrorStatus}");
+            if (_serviceResult?.Result != null)
+            {
+                ShowRawHtmlPlainTextFallback(_serviceResult.Result);
+            }
+            return;
+        }
 
         try
         {
@@ -1359,17 +1385,31 @@ public sealed partial class ServiceResultItem : UserControl
                 {
                     sender.DispatcherQueue.TryEnqueue(() =>
                     {
+                        ResultText.Visibility = Visibility.Collapsed;
+                        sender.Visibility = Visibility.Visible;
                         if (Math.Abs(sender.Height - targetHeight) > 1)
                         {
                             sender.Height = targetHeight;
                         }
                     });
                 }
+
+                return;
+            }
+
+            Debug.WriteLine("[ServiceResultItem] WebView2 measured zero height; falling back to plain text");
+            if (_serviceResult?.Result != null)
+            {
+                ShowRawHtmlPlainTextFallback(_serviceResult.Result);
             }
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"[ServiceResultItem] Failed to auto-size WebView2: {ex.Message}");
+            if (_serviceResult?.Result != null)
+            {
+                ShowRawHtmlPlainTextFallback(_serviceResult.Result);
+            }
         }
     }
 

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1182,17 +1182,29 @@ public sealed partial class ServiceResultItem : UserControl
                 <head>
                 <meta charset="utf-8">
                 <style>
+                    html {
+                        margin: 0;
+                        padding: 0;
+                        max-width: 100%;
+                        overflow-x: hidden;
+                    }
                     body {
                         margin: 4px 0;
-                        padding: 0;
+                        padding: 0 8px 12px;
                         font-family: -apple-system, 'Segoe UI', sans-serif;
                         font-size: 13px;
+                        line-height: 1.45;
                         color: {{textColor}};
                         background-color: {{bgColor}};
                         word-wrap: break-word;
                         overflow-wrap: break-word;
+                        -webkit-font-smoothing: antialiased;
+                        text-rendering: optimizeLegibility;
+                        max-width: 100%;
+                        overflow-x: hidden;
                     }
-                    img { max-width: 100%; height: auto; }
+                    img, svg, table { max-width: 100% !important; height: auto; }
+                    pre { white-space: pre-wrap; overflow-wrap: anywhere; }
                     a { color: {{(isDark ? "#569cd6" : "#0066cc")}}; }
                 </style>
                 </head>

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1187,6 +1187,8 @@ public sealed partial class ServiceResultItem : UserControl
                         padding: 0;
                         max-width: 100%;
                         overflow-x: hidden;
+                        overflow-y: hidden;
+                        height: auto;
                     }
                     body {
                         margin: 4px 0;
@@ -1202,6 +1204,9 @@ public sealed partial class ServiceResultItem : UserControl
                         text-rendering: optimizeLegibility;
                         max-width: 100%;
                         overflow-x: hidden;
+                        overflow-y: hidden;
+                        max-height: none;
+                        height: auto;
                     }
                     h1, h2, h3, h4, h5, h6 {
                         margin: 0 0 10px;
@@ -1224,6 +1229,17 @@ public sealed partial class ServiceResultItem : UserControl
                     img, svg, table { max-width: 100% !important; height: auto; }
                     pre { white-space: pre-wrap; overflow-wrap: anywhere; }
                     a { color: {{(isDark ? "#569cd6" : "#0066cc")}}; }
+                    [style*="overflow-y"],
+                    [style*="overflow:"],
+                    [style*="max-height"],
+                    [class*="scroll"],
+                    [class*="Scroll"],
+                    [id*="scroll"],
+                    [id*="Scroll"] {
+                        overflow-y: visible !important;
+                        max-height: none !important;
+                        height: auto !important;
+                    }
                 </style>
                 </head>
                 <body>{{processedHtml}}</body>
@@ -1289,10 +1305,11 @@ public sealed partial class ServiceResultItem : UserControl
 
         try
         {
-            // Let the outer result ScrollViewer own the overflow behavior so wheel
-            // input can chain into the parent results list at the top/bottom edge,
-            // even when dictionary HTML ships with its own nested vertical scrollers.
-            var heightStr = await NormalizeDictionaryVerticalOverflowAsync(sender);
+            // Let the browser settle the CSS-first overflow normalization before
+            // measuring content height for the host ScrollViewer.
+            await Task.Delay(50);
+
+            var heightStr = await MeasureDictionaryHeightAsync(sender);
             if (int.TryParse(heightStr.Trim('"'), out var height) && height > 0)
             {
                 sender.Height = height + 8;
@@ -1340,7 +1357,7 @@ public sealed partial class ServiceResultItem : UserControl
         e.Handled = true;
     }
 
-    private static async Task<string> NormalizeDictionaryVerticalOverflowAsync(WebView2 sender)
+    private static async Task<string> MeasureDictionaryHeightAsync(WebView2 sender)
     {
         return await sender.CoreWebView2.ExecuteScriptAsync(
             """
@@ -1349,26 +1366,6 @@ public sealed partial class ServiceResultItem : UserControl
                 const body = document.body;
                 if (!root || !body) {
                     return "0";
-                }
-
-                root.style.overflowY = 'hidden';
-                root.style.height = 'auto';
-                body.style.overflowY = 'hidden';
-                body.style.maxHeight = 'none';
-                body.style.height = 'auto';
-
-                for (const element of document.querySelectorAll('*')) {
-                    const style = window.getComputedStyle(element);
-                    const hasVerticalScroller =
-                        (style.overflowY === 'auto' || style.overflowY === 'scroll')
-                        && element.scrollHeight > element.clientHeight + 1;
-                    if (!hasVerticalScroller) {
-                        continue;
-                    }
-
-                    element.style.overflowY = 'visible';
-                    element.style.maxHeight = 'none';
-                    element.style.height = 'auto';
                 }
 
                 return Math.max(

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1260,8 +1260,9 @@ public sealed partial class ServiceResultItem : UserControl
         try
         {
             // Let the outer result ScrollViewer own the overflow behavior so wheel
-            // input can chain into the parent results list at the top/bottom edge.
-            var heightStr = await sender.CoreWebView2.ExecuteScriptAsync("document.body.scrollHeight.toString()");
+            // input can chain into the parent results list at the top/bottom edge,
+            // even when dictionary HTML ships with its own nested vertical scrollers.
+            var heightStr = await NormalizeDictionaryVerticalOverflowAsync(sender);
             if (int.TryParse(heightStr.Trim('"'), out var height) && height > 0)
             {
                 sender.Height = height + 8;
@@ -1307,6 +1308,47 @@ public sealed partial class ServiceResultItem : UserControl
 
         outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
         e.Handled = true;
+    }
+
+    private static async Task<string> NormalizeDictionaryVerticalOverflowAsync(WebView2 sender)
+    {
+        return await sender.CoreWebView2.ExecuteScriptAsync(
+            """
+            (() => {
+                const root = document.documentElement;
+                const body = document.body;
+                if (!root || !body) {
+                    return "0";
+                }
+
+                root.style.overflowY = 'hidden';
+                root.style.height = 'auto';
+                body.style.overflowY = 'hidden';
+                body.style.maxHeight = 'none';
+                body.style.height = 'auto';
+
+                for (const element of document.querySelectorAll('*')) {
+                    const style = window.getComputedStyle(element);
+                    const hasVerticalScroller =
+                        (style.overflowY === 'auto' || style.overflowY === 'scroll')
+                        && element.scrollHeight > element.clientHeight + 1;
+                    if (!hasVerticalScroller) {
+                        continue;
+                    }
+
+                    element.style.overflowY = 'visible';
+                    element.style.maxHeight = 'none';
+                    element.style.height = 'auto';
+                }
+
+                return Math.max(
+                    body.scrollHeight,
+                    body.offsetHeight,
+                    root.scrollHeight,
+                    root.offsetHeight
+                ).toString();
+            })()
+            """);
     }
 
     private static ScrollViewer? FindAncestorScrollViewer(DependencyObject? start)

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1279,12 +1279,17 @@ public sealed partial class ServiceResultItem : UserControl
                                 node = node.parentElement;
                             }
 
-                            return document.scrollingElement || document.documentElement;
+                            return null;
                         };
 
                         window.addEventListener('wheel', event => {
                             const scrollable = findScrollableContainer(event.target);
                             if (!scrollable) {
+                                window.chrome?.webview?.postMessage({
+                                    type: 'dict-wheel-passthrough',
+                                    deltaY: event.deltaY
+                                });
+                                event.preventDefault();
                                 return;
                             }
 
@@ -1420,7 +1425,7 @@ public sealed partial class ServiceResultItem : UserControl
             using var document = JsonDocument.Parse(args.WebMessageAsJson);
             var root = document.RootElement;
             if (!root.TryGetProperty("type", out var typeElement) ||
-                typeElement.GetString() != "dict-wheel-boundary" ||
+                (typeElement.GetString() is not "dict-wheel-boundary" and not "dict-wheel-passthrough") ||
                 !root.TryGetProperty("deltaY", out var deltaElement))
             {
                 return;
@@ -1436,18 +1441,18 @@ public sealed partial class ServiceResultItem : UserControl
                 return;
             }
 
-            var outerScrollViewer = FindAncestorScrollViewer(DictWebView);
-            if (outerScrollViewer == null)
+            var hostScrollViewer = ResultContentScrollViewer ?? FindAncestorScrollViewer(DictWebView);
+            if (hostScrollViewer == null)
             {
                 return;
             }
 
             var targetOffset = Math.Clamp(
-                outerScrollViewer.VerticalOffset + deltaY,
+                hostScrollViewer.VerticalOffset + deltaY,
                 0,
-                outerScrollViewer.ScrollableHeight);
+                hostScrollViewer.ScrollableHeight);
 
-            outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
+            hostScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
         }
         catch (Exception ex)
         {

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1312,7 +1312,17 @@ public sealed partial class ServiceResultItem : UserControl
             var heightStr = await MeasureDictionaryHeightAsync(sender);
             if (int.TryParse(heightStr.Trim('"'), out var height) && height > 0)
             {
-                sender.Height = height + 8;
+                var targetHeight = height + 8;
+                if (Math.Abs(sender.Height - targetHeight) > 1)
+                {
+                    sender.DispatcherQueue.TryEnqueue(() =>
+                    {
+                        if (Math.Abs(sender.Height - targetHeight) > 1)
+                        {
+                            sender.Height = targetHeight;
+                        }
+                    });
+                }
             }
         }
         catch (Exception ex)

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1259,17 +1259,70 @@ public sealed partial class ServiceResultItem : UserControl
 
         try
         {
-            // Get content height and resize WebView2 to fit
+            // Let the outer result ScrollViewer own the overflow behavior so wheel
+            // input can chain into the parent results list at the top/bottom edge.
             var heightStr = await sender.CoreWebView2.ExecuteScriptAsync("document.body.scrollHeight.toString()");
             if (int.TryParse(heightStr.Trim('"'), out var height) && height > 0)
             {
-                sender.Height = Math.Min(height + 8, 800); // Cap at 800px
+                sender.Height = height + 8;
             }
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"[ServiceResultItem] Failed to auto-size WebView2: {ex.Message}");
         }
+    }
+
+    private void OnResultContentScrollViewerPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not ScrollViewer innerScrollViewer)
+        {
+            return;
+        }
+
+        var delta = e.GetCurrentPoint(innerScrollViewer).Properties.MouseWheelDelta;
+        if (delta == 0)
+        {
+            return;
+        }
+
+        var atTop = innerScrollViewer.VerticalOffset <= 0;
+        var atBottom = innerScrollViewer.VerticalOffset >= innerScrollViewer.ScrollableHeight;
+        var shouldBubbleToOuter = (delta > 0 && atTop) || (delta < 0 && atBottom);
+        if (!shouldBubbleToOuter)
+        {
+            return;
+        }
+
+        var outerScrollViewer = FindAncestorScrollViewer(innerScrollViewer);
+        if (outerScrollViewer == null)
+        {
+            return;
+        }
+
+        var targetOffset = Math.Clamp(
+            outerScrollViewer.VerticalOffset - delta,
+            0,
+            outerScrollViewer.ScrollableHeight);
+
+        outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
+        e.Handled = true;
+    }
+
+    private static ScrollViewer? FindAncestorScrollViewer(DependencyObject? start)
+    {
+        var current = VisualTreeHelper.GetParent(start);
+        while (current != null)
+        {
+            if (current is ScrollViewer scrollViewer)
+            {
+                return scrollViewer;
+            }
+
+            current = VisualTreeHelper.GetParent(current);
+        }
+
+        return null;
     }
 
     private static string GetMimeType(string path)

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1442,17 +1442,7 @@ public sealed partial class ServiceResultItem : UserControl
             }
 
             var hostScrollViewer = ResultContentScrollViewer ?? FindAncestorScrollViewer(DictWebView);
-            if (hostScrollViewer == null)
-            {
-                return;
-            }
-
-            var targetOffset = Math.Clamp(
-                hostScrollViewer.VerticalOffset + deltaY,
-                0,
-                hostScrollViewer.ScrollableHeight);
-
-            hostScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
+            TryScrollViewerChain(hostScrollViewer, deltaY);
         }
         catch (Exception ex)
         {
@@ -1481,19 +1471,8 @@ public sealed partial class ServiceResultItem : UserControl
             return;
         }
 
-        var outerScrollViewer = FindAncestorScrollViewer(innerScrollViewer);
-        if (outerScrollViewer == null)
-        {
-            return;
-        }
-
-        var targetOffset = Math.Clamp(
-            outerScrollViewer.VerticalOffset - delta,
-            0,
-            outerScrollViewer.ScrollableHeight);
-
-        outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
-        e.Handled = true;
+        var offsetDelta = -delta;
+        e.Handled = TryScrollViewerChain(FindAncestorScrollViewer(innerScrollViewer), offsetDelta);
     }
 
     private static async Task<string> MeasureDictionaryHeightAsync(WebView2 sender)
@@ -1531,6 +1510,33 @@ public sealed partial class ServiceResultItem : UserControl
         }
 
         return null;
+    }
+
+    private static bool TryScrollViewerChain(ScrollViewer? startScrollViewer, double offsetDelta)
+    {
+        if (startScrollViewer == null || Math.Abs(offsetDelta) < double.Epsilon)
+        {
+            return false;
+        }
+
+        var currentScrollViewer = startScrollViewer;
+        while (currentScrollViewer != null)
+        {
+            var targetOffset = Math.Clamp(
+                currentScrollViewer.VerticalOffset + offsetDelta,
+                0,
+                currentScrollViewer.ScrollableHeight);
+
+            if (Math.Abs(targetOffset - currentScrollViewer.VerticalOffset) > 0.5)
+            {
+                currentScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
+                return true;
+            }
+
+            currentScrollViewer = FindAncestorScrollViewer(currentScrollViewer);
+        }
+
+        return false;
     }
 
     private static string GetMimeType(string path)

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -194,9 +194,9 @@ public sealed partial class ServiceResultItem : UserControl
             return;
         }
 
-        // Hide entire control when the service returned no result and the user has
-        // opted to hide empty results. Header + content collapse together so the
-        // surrounding ItemsControl skips layout for this row entirely.
+        // Keep the service row visible for no-result dictionary queries, but force
+        // it collapsed so the header can still show the "No result" status without
+        // expanding the full empty payload.
         var hideEmpty = SettingsService.Instance.HideEmptyServiceResults
             && !_serviceResult.IsLoading
             && !_serviceResult.IsStreaming
@@ -204,12 +204,7 @@ public sealed partial class ServiceResultItem : UserControl
             && _serviceResult.Result?.ResultKind == TranslationResultKind.NoResult;
         if (hideEmpty)
         {
-            this.Visibility = Visibility.Collapsed;
-            return;
-        }
-        if (this.Visibility == Visibility.Collapsed)
-        {
-            this.Visibility = Visibility.Visible;
+            _serviceResult.IsExpanded = false;
         }
 
         // Service info

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -194,6 +194,24 @@ public sealed partial class ServiceResultItem : UserControl
             return;
         }
 
+        // Hide entire control when the service returned no result and the user has
+        // opted to hide empty results. Header + content collapse together so the
+        // surrounding ItemsControl skips layout for this row entirely.
+        var hideEmpty = SettingsService.Instance.HideEmptyServiceResults
+            && !_serviceResult.IsLoading
+            && !_serviceResult.IsStreaming
+            && !_serviceResult.HasError
+            && _serviceResult.Result?.ResultKind == TranslationResultKind.NoResult;
+        if (hideEmpty)
+        {
+            this.Visibility = Visibility.Collapsed;
+            return;
+        }
+        if (this.Visibility == Visibility.Collapsed)
+        {
+            this.Visibility = Visibility.Visible;
+        }
+
         // Service info
         ServiceNameText.Text = _serviceResult.ServiceDisplayName;
 

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Easydict.TranslationService;
 using Easydict.TranslationService.Models;
@@ -62,6 +63,7 @@ public sealed partial class ServiceResultItem : UserControl
             if (_webViewInitialized && DictWebView.CoreWebView2 != null)
             {
                 DictWebView.CoreWebView2.WebResourceRequested -= OnWebResourceRequested;
+                DictWebView.CoreWebView2.WebMessageReceived -= OnDictWebViewWebMessageReceived;
 
                 try
                 {
@@ -1137,10 +1139,12 @@ public sealed partial class ServiceResultItem : UserControl
                 DictWebView.CoreWebView2.Settings.AreDevToolsEnabled = false;
                 DictWebView.CoreWebView2.Settings.IsScriptEnabled = true;
                 DictWebView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+                DictWebView.CoreWebView2.Settings.IsWebMessageEnabled = true;
 
                 // Register resource request filter for MDD resources
                 DictWebView.CoreWebView2.AddWebResourceRequestedFilter("https://dictassets/*", CoreWebView2WebResourceContext.All);
                 DictWebView.CoreWebView2.WebResourceRequested += OnWebResourceRequested;
+                DictWebView.CoreWebView2.WebMessageReceived += OnDictWebViewWebMessageReceived;
                 DictWebView.NavigationCompleted += OnDictWebViewNavigationCompleted;
             }
 
@@ -1241,6 +1245,44 @@ public sealed partial class ServiceResultItem : UserControl
                         height: auto !important;
                     }
                 </style>
+                <script>
+                    (() => {
+                        const findScrollableContainer = (start) => {
+                            let node = start instanceof Element ? start : null;
+                            while (node && node !== document.body) {
+                                const style = window.getComputedStyle(node);
+                                const overflowY = style.overflowY || style.overflow;
+                                const canScroll =
+                                    (overflowY === 'auto' || overflowY === 'scroll')
+                                    && node.scrollHeight > node.clientHeight + 1;
+                                if (canScroll) {
+                                    return node;
+                                }
+
+                                node = node.parentElement;
+                            }
+
+                            return document.scrollingElement || document.documentElement;
+                        };
+
+                        window.addEventListener('wheel', event => {
+                            const scrollable = findScrollableContainer(event.target);
+                            if (!scrollable) {
+                                return;
+                            }
+
+                            const atTop = scrollable.scrollTop <= 0;
+                            const atBottom = scrollable.scrollTop + scrollable.clientHeight >= scrollable.scrollHeight - 1;
+                            if ((event.deltaY < 0 && atTop) || (event.deltaY > 0 && atBottom)) {
+                                window.chrome?.webview?.postMessage({
+                                    type: 'dict-wheel-boundary',
+                                    deltaY: event.deltaY
+                                });
+                                event.preventDefault();
+                            }
+                        }, { passive: false, capture: true });
+                    })();
+                </script>
                 </head>
                 <body>{{processedHtml}}</body>
                 </html>
@@ -1328,6 +1370,48 @@ public sealed partial class ServiceResultItem : UserControl
         catch (Exception ex)
         {
             Debug.WriteLine($"[ServiceResultItem] Failed to auto-size WebView2: {ex.Message}");
+        }
+    }
+
+    private void OnDictWebViewWebMessageReceived(CoreWebView2 sender, CoreWebView2WebMessageReceivedEventArgs args)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(args.WebMessageAsJson);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("type", out var typeElement) ||
+                typeElement.GetString() != "dict-wheel-boundary" ||
+                !root.TryGetProperty("deltaY", out var deltaElement))
+            {
+                return;
+            }
+
+            var deltaY = deltaElement.ValueKind switch
+            {
+                JsonValueKind.Number when deltaElement.TryGetDouble(out var value) => value,
+                _ => 0
+            };
+            if (Math.Abs(deltaY) < double.Epsilon)
+            {
+                return;
+            }
+
+            var outerScrollViewer = FindAncestorScrollViewer(DictWebView);
+            if (outerScrollViewer == null)
+            {
+                return;
+            }
+
+            var targetOffset = Math.Clamp(
+                outerScrollViewer.VerticalOffset + deltaY,
+                0,
+                outerScrollViewer.ScrollableHeight);
+
+            outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[ServiceResultItem] Failed to relay WebView wheel boundary: {ex.Message}");
         }
     }
 

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
@@ -15,7 +15,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
@@ -9,21 +9,25 @@
     mc:Ignorable="d"
     Title="Easydict ᵇᵉᵗᵃ Fixed">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="8">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            Padding="8">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Header with Close button (no Pin - always on top) - also serves as drag region -->
-        <Grid x:Name="TitleBarRegion" Grid.Row="0" Margin="0,0,0,4" Background="Transparent">
+        <Grid x:Name="TitleBarRegion"
+                Grid.Row="0"
+                Margin="0,0,0,4"
+                Background="Transparent">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <TextBlock
@@ -33,7 +37,7 @@
                 FontWeight="SemiBold"
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                 VerticalAlignment="Center"
-                Margin="4,0,0,0" />
+                Margin="4,0,0,0"/>
 
             <Button
                 x:Name="CloseButton"
@@ -45,7 +49,8 @@
                 Width="28"
                 Height="28"
                 Padding="0">
-                <FontIcon Glyph="&#xE8BB;" FontSize="14" />
+                <FontIcon Glyph="&#xE8BB;"
+                        FontSize="14"/>
             </Button>
         </Grid>
 
@@ -65,16 +70,17 @@
                 AcceptsReturn="True"
                 TextWrapping="Wrap"
                 ScrollViewer.VerticalScrollBarVisibility="Auto"
-                PreviewKeyDown="OnInputKeyDown" />
+                PreviewKeyDown="OnInputKeyDown"/>
         </Border>
 
         <!-- Language Bar -->
-        <Grid Grid.Row="2" Margin="0,0,0,4">
+        <Grid Grid.Row="2"
+                Margin="0,0,0,4">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <ComboBox
@@ -90,13 +96,15 @@
                 x:Name="SwapButton"
                 Grid.Column="1"
                 Click="OnSwapClicked"
-                Width="28" Height="28"
+                Width="28"
+                    Height="28"
                 Padding="0"
                 Background="Transparent"
                 BorderThickness="0"
                 ToolTipService.ToolTip="Swap languages"
                 Margin="4,0">
-                <FontIcon Glyph="&#xE8AB;" FontSize="12" />
+                <FontIcon Glyph="&#xE8AB;"
+                        FontSize="12"/>
             </Button>
 
             <ComboBox
@@ -123,14 +131,15 @@
                     <ProgressRing
                         x:Name="LoadingRing"
                         IsActive="False"
-                        Width="14" Height="14"
+                        Width="14"
+                            Height="14"
                         Foreground="White"
-                        Visibility="Collapsed" />
+                        Visibility="Collapsed"/>
                     <FontIcon
                         x:Name="TranslateIcon"
                         Glyph="&#xE8C1;"
                         FontSize="14"
-                        Foreground="White" />
+                        Foreground="White"/>
                 </Grid>
             </Button>
         </Grid>
@@ -143,16 +152,16 @@
             FontSize="10"
             Foreground="{ThemeResource BlueAccentBrush}"
             Margin="0,0,0,2"
-            Visibility="Collapsed" />
+            Visibility="Collapsed"/>
 
         <!-- Multi-Service Results -->
         <ScrollViewer
             Grid.Row="4"
-            VerticalScrollBarVisibility="Auto">
+            VerticalScrollBarVisibility="Visible">
             <ItemsControl x:Name="ResultsPanel">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <StackPanel Orientation="Vertical" />
+                        <StackPanel Orientation="Vertical"/>
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
             </ItemsControl>
@@ -166,6 +175,6 @@
             FontSize="10"
             Foreground="{ThemeResource TextFillColorTertiaryBrush}"
             HorizontalAlignment="Right"
-            Margin="0,4,0,0" />
+            Margin="0,4,0,0"/>
     </Grid>
 </Window>

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text;
 using Easydict.TranslationService;
 using Easydict.TranslationService.Models;
@@ -20,6 +21,12 @@ namespace Easydict.WinUI.Views;
 /// </summary>
 public sealed partial class FixedWindow : Window
 {
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
     private LanguageDetectionService? _detectionService;
     // Owned by StartQueryAsync() - only that method creates and disposes via its finally block.
     // Other code may Cancel() but must NOT Dispose().
@@ -1115,6 +1122,25 @@ public sealed partial class FixedWindow : Window
     {
         _isClosing = false;
         _appWindow?.Show();
+
+        // Try to bring window to front using multiple methods
+        try
+        {
+            _appWindow?.MoveInZOrderAtTop();
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"FixedWindow: MoveInZOrderAtTop failed: {ex.Message}");
+        }
+
+        // Use Win32 SetForegroundWindow to forcefully bring window to front
+        var hWnd = WindowNative.GetWindowHandle(this);
+        var foregroundSet = SetForegroundWindow(hWnd);
+        if (!foregroundSet)
+        {
+            System.Diagnostics.Debug.WriteLine("FixedWindow: SetForegroundWindow failed; relying on Activate()");
+        }
+
         this.Activate();
         InputTextBox.Focus(FocusState.Programmatic);
 
@@ -1135,6 +1161,25 @@ public sealed partial class FixedWindow : Window
     /// Check if window is currently visible.
     /// </summary>
     public bool IsVisible => _appWindow?.IsVisible ?? false;
+
+    /// <summary>
+    /// Check if this window is currently the foreground window.
+    /// </summary>
+    public bool IsForeground
+    {
+        get
+        {
+            try
+            {
+                var hWnd = WindowNative.GetWindowHandle(this);
+                return GetForegroundWindow() == hWnd;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
 
     /// <summary>
     /// Refresh service result controls when settings change.

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
@@ -131,7 +131,7 @@
         <!-- Quick Translate Content -->
         <ScrollViewer x:Name="QuickTranslateContent"
                       Grid.Row="1"
-                      VerticalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Visible"
                       HorizontalScrollBarVisibility="Disabled">
             <Grid Padding="4">
                 <VisualStateManager.VisualStateGroups>

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -15,7 +15,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -9,22 +9,26 @@
     mc:Ignorable="d"
     Title="Easydict ᵇᵉᵗᵃ Mini">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="8">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            Padding="8">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Header with Pin and Close buttons - also serves as drag region -->
-        <Grid x:Name="TitleBarRegion" Grid.Row="0" Margin="0,0,0,4" Background="Transparent">
+        <Grid x:Name="TitleBarRegion"
+                Grid.Row="0"
+                Margin="0,0,0,4"
+                Background="Transparent">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <ToggleButton
@@ -37,7 +41,9 @@
                 Width="28"
                 Height="28"
                 Padding="0">
-                <FontIcon x:Name="PinIcon" Glyph="&#xE718;" FontSize="14" />
+                <FontIcon x:Name="PinIcon"
+                        Glyph="&#xE718;"
+                        FontSize="14"/>
             </ToggleButton>
 
             <TextBlock
@@ -47,7 +53,7 @@
                 FontWeight="SemiBold"
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                 HorizontalAlignment="Center"
-                VerticalAlignment="Center" />
+                VerticalAlignment="Center"/>
 
             <Button
                 x:Name="CloseButton"
@@ -59,7 +65,8 @@
                 Width="28"
                 Height="28"
                 Padding="0">
-                <FontIcon Glyph="&#xE8BB;" FontSize="14" />
+                <FontIcon Glyph="&#xE8BB;"
+                        FontSize="14"/>
             </Button>
         </Grid>
 
@@ -79,30 +86,38 @@
                 AcceptsReturn="True"
                 TextWrapping="Wrap"
                 ScrollViewer.VerticalScrollBarVisibility="Auto"
-                PreviewKeyDown="OnInputKeyDown" />
+                PreviewKeyDown="OnInputKeyDown"/>
         </Border>
 
         <!-- Mode + Language Bar -->
-        <Grid Grid.Row="2" Margin="0,0,0,4">
+        <Grid Grid.Row="2"
+                Margin="0,0,0,4">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />  <!-- Mode Toggle -->
-                <ColumnDefinition Width="*" />     <!-- Source Language -->
-                <ColumnDefinition Width="Auto" />  <!-- Swap Button -->
-                <ColumnDefinition Width="*" />     <!-- Target Language -->
-                <ColumnDefinition Width="Auto" />  <!-- Translate Button -->
+                <ColumnDefinition Width="Auto"/>
+                <!-- Mode Toggle -->
+                <ColumnDefinition Width="*"/>
+                <!-- Source Language -->
+                <ColumnDefinition Width="Auto"/>
+                <!-- Swap Button -->
+                <ColumnDefinition Width="*"/>
+                <!-- Target Language -->
+                <ColumnDefinition Width="Auto"/>
+                <!-- Translate Button -->
             </Grid.ColumnDefinitions>
 
             <!-- Query Mode Toggle -->
             <Button x:Name="QueryModeButton"
                     Grid.Column="0"
-                    Width="32" Height="32"
+                    Width="32"
+                    Height="32"
                     Padding="0"
                     VerticalAlignment="Center"
                     Click="OnQueryModeButtonClick"
                     Background="Transparent"
                     BorderThickness="0"
                     Margin="0,0,4,0">
-                <TextBlock x:Name="QueryModeEmoji" FontSize="18" />
+                <TextBlock x:Name="QueryModeEmoji"
+                        FontSize="18"/>
             </Button>
 
             <ComboBox
@@ -118,13 +133,15 @@
                 x:Name="SwapButton"
                 Grid.Column="2"
                 Click="OnSwapClicked"
-                Width="28" Height="28"
+                Width="28"
+                    Height="28"
                 Padding="0"
                 Background="Transparent"
                 BorderThickness="0"
                 ToolTipService.ToolTip="Swap languages"
                 Margin="4,0">
-                <FontIcon Glyph="&#xE8AB;" FontSize="12" />
+                <FontIcon Glyph="&#xE8AB;"
+                        FontSize="12"/>
             </Button>
 
             <ComboBox
@@ -151,14 +168,15 @@
                     <ProgressRing
                         x:Name="LoadingRing"
                         IsActive="False"
-                        Width="14" Height="14"
+                        Width="14"
+                            Height="14"
                         Foreground="White"
-                        Visibility="Collapsed" />
+                        Visibility="Collapsed"/>
                     <FontIcon
                         x:Name="TranslateIcon"
                         Glyph="&#xE8C1;"
                         FontSize="14"
-                        Foreground="White" />
+                        Foreground="White"/>
                 </Grid>
             </Button>
         </Grid>
@@ -171,16 +189,16 @@
             FontSize="10"
             Foreground="{ThemeResource BlueAccentBrush}"
             Margin="0,0,0,2"
-            Visibility="Collapsed" />
+            Visibility="Collapsed"/>
 
         <!-- Multi-Service Results -->
         <ScrollViewer
             Grid.Row="4"
-            VerticalScrollBarVisibility="Auto">
+            VerticalScrollBarVisibility="Visible">
             <ItemsControl x:Name="ResultsPanel">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <StackPanel Orientation="Vertical" />
+                        <StackPanel Orientation="Vertical"/>
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
             </ItemsControl>
@@ -194,6 +212,6 @@
             FontSize="10"
             Foreground="{ThemeResource TextFillColorTertiaryBrush}"
             HorizontalAlignment="Right"
-            Margin="0,4,0,0" />
+            Margin="0,4,0,0"/>
     </Grid>
 </Window>

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -1560,6 +1560,25 @@ public sealed partial class MiniWindow : Window
     public bool IsVisible => _appWindow?.IsVisible ?? false;
 
     /// <summary>
+    /// Check if this window is currently the foreground window.
+    /// </summary>
+    public bool IsForeground
+    {
+        get
+        {
+            try
+            {
+                var hWnd = WindowNative.GetWindowHandle(this);
+                return GetForegroundWindow() == hWnd;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
     /// Refresh service result controls when settings change.
     /// </summary>
     public void RefreshServiceResults()

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -10,17 +10,17 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Page.Resources>
-        <local:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
-        <local:BoolToOpacityConverter x:Key="BoolToOpacityConverter" />
-        <local:BoolToCompactMarginConverter x:Key="BoolToCompactMarginConverter" />
-        <local:BoolToCompactFontSizeConverter x:Key="BoolToCompactFontSizeConverter" />
-        <local:BoolToItalicFontStyleConverter x:Key="BoolToItalicFontStyleConverter" />
+        <local:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <local:BoolToOpacityConverter x:Key="BoolToOpacityConverter"/>
+        <local:BoolToCompactMarginConverter x:Key="BoolToCompactMarginConverter"/>
+        <local:BoolToCompactFontSizeConverter x:Key="BoolToCompactFontSizeConverter"/>
+        <local:BoolToItalicFontStyleConverter x:Key="BoolToItalicFontStyleConverter"/>
     </Page.Resources>
 
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
         <!-- Loading overlay (visible initially, hidden after init) -->
@@ -29,1020 +29,1710 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Spacing="12">
-            <ProgressRing IsActive="True" Width="32" Height="32" />
+            <ProgressRing IsActive="True"
+                    Width="32"
+                    Height="32"/>
         </StackPanel>
 
-        <ScrollViewer x:Name="MainScrollViewer" Grid.Column="1" Padding="24" ViewChanged="OnScrollViewChanged" Visibility="Collapsed">
-            <StackPanel Spacing="24" MaxWidth="800">
-            <!-- Header -->
-            <Grid x:Name="HeaderSection">
-                <StackPanel Orientation="Horizontal" Spacing="12">
-                    <Button Click="OnBackClick" Style="{StaticResource AccentButtonStyle}" Padding="8">
-                        <FontIcon Glyph="&#xE72B;" FontSize="16" />
-                    </Button>
-                    <TextBlock x:Name="SettingsHeaderText" Text="Settings" FontSize="28" FontWeight="SemiBold" VerticalAlignment="Center" />
-                </StackPanel>
-            </Grid>
-
-            <!-- Language Preferences -->
-            <StackPanel x:Name="LanguagePreferencesSection" Spacing="12">
-                <TextBlock x:Name="LanguagePreferencesHeaderText" Text="Language Preferences" FontSize="18" FontWeight="SemiBold" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="16">
-                        <!-- First Language -->
-                        <ComboBox
-                            x:Name="FirstLanguageCombo"
-                            Header="First Language"
-                            Width="250"
-                            HorizontalAlignment="Left">
-                            <!-- Populated dynamically in code-behind -->
-                        </ComboBox>
-
-                        <!-- Second Language -->
-                        <ComboBox
-                            x:Name="SecondLanguageCombo"
-                            Header="Second Language"
-                            Width="250"
-                            HorizontalAlignment="Left">
-                            <!-- Populated dynamically in code-behind -->
-                        </ComboBox>
-
-                        <!-- Explanation -->
-                        <TextBlock
-                            x:Name="LanguagePreferencesDescriptionText"
-                            TextWrapping="Wrap"
-                            FontSize="12"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Margin="0,4,0,0">
-                            <Run Text="When detected language matches your First Language, translation target will be your Second Language, and vice versa." />
-                        </TextBlock>
-
-                        <!-- Auto-Select Toggle -->
-                        <ToggleSwitch
-                            x:Name="AutoSelectTargetToggle"
-                            Header="Automatically select target language based on detected source"
-                            IsOn="True" />
+        <ScrollViewer x:Name="MainScrollViewer"
+                Grid.Column="1"
+                Padding="24"
+                ViewChanged="OnScrollViewChanged"
+                Visibility="Collapsed">
+            <StackPanel Spacing="24"
+                    MaxWidth="800">
+                <!-- Header -->
+                <Grid x:Name="HeaderSection">
+                    <StackPanel Orientation="Horizontal"
+                            Spacing="12">
+                        <Button Click="OnBackClick"
+                                Style="{StaticResource AccentButtonStyle}"
+                                Padding="8">
+                            <FontIcon Glyph="&#xE72B;"
+                                    FontSize="16"/>
+                        </Button>
+                        <TextBlock x:Name="SettingsHeaderText"
+                                Text="Settings"
+                                FontSize="28"
+                                FontWeight="SemiBold"
+                                VerticalAlignment="Center"/>
                     </StackPanel>
-                </Border>
+                </Grid>
 
-                <!-- Available Languages -->
-                <Expander x:Name="AvailableLanguagesExpander" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <TextBlock x:Name="AvailableLanguagesHeaderText" Text="Available Languages" FontWeight="SemiBold" />
-                    </Expander.Header>
-                    <StackPanel Spacing="8" Padding="4">
-                        <TextBlock x:Name="AvailableLanguagesDescText"
-                                   Text="Select languages available in source/target pickers. At least 2 required."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <ItemsRepeater x:Name="LanguageCheckboxGrid">
-                            <ItemsRepeater.Layout>
-                                <UniformGridLayout MinItemWidth="180" MinColumnSpacing="8" MinRowSpacing="4"
-                                                   ItemsStretch="Fill" MaximumRowsOrColumns="4" />
-                            </ItemsRepeater.Layout>
-                        </ItemsRepeater>
-                    </StackPanel>
-                </Expander>
-            </StackPanel>
+                <!-- Language Preferences -->
+                <StackPanel x:Name="LanguagePreferencesSection"
+                        Spacing="12">
+                    <TextBlock x:Name="LanguagePreferencesHeaderText"
+                            Text="Language Preferences"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
 
-            <!-- Enabled Services for Each Window -->
-            <StackPanel x:Name="EnabledServicesSection" Spacing="12">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <TextBlock x:Name="EnabledServicesHeaderText" Text="Enabled Services" FontSize="18" FontWeight="SemiBold" />
-                    <FontIcon x:Name="EnabledServicesHelpIcon" Glyph="&#xE897;" FontSize="14"
-                              Foreground="{ThemeResource TextFillColorTertiaryBrush}" VerticalAlignment="Center" />
-                </StackPanel>
-                <TextBlock x:Name="EnabledServicesDescriptionText" Text="Select which translation services to display in each window. Multiple services will run in parallel."
-                           FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button x:Name="ImportMdxDictionaryButton"
-                            Content="Import MDX Dictionary"
-                            Click="OnImportMdxDictionaryClicked"
-                            Padding="10,4" />
-                    <TextBlock x:Name="ImportedMdxSummaryText"
-                               Text="No MDX dictionaries imported"
-                               VerticalAlignment="Center"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                </StackPanel>
-
-                <!-- International Services Toggle -->
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="12,8">
-                    <StackPanel Spacing="4">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock x:Name="EnableInternationalServicesHeaderText"
-                                       Text="Enable International Services"
-                                       FontSize="13"
-                                       VerticalAlignment="Center" />
-                            <ToggleSwitch x:Name="EnableInternationalServicesToggle"
-                                          Grid.Column="1"
-                                          Toggled="OnEnableInternationalServicesToggled"
-                                          MinWidth="0"
-                                          VerticalAlignment="Center" />
-                        </Grid>
-                        <TextBlock x:Name="EnableInternationalServicesDescriptionText"
-                                   Text="Some services require international network access."
-                                   FontSize="11"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   TextWrapping="Wrap" />
-                    </StackPanel>
-                </Border>
-
-                <!-- Main Window Services -->
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="12">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBlock x:Name="MainWindowHeaderText" Text="Main Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
-                            <Button x:Name="MainWindowReorderModeButton"
-                                    Click="OnToggleMainWindowReorderModeClicked"
-                                    Padding="8,2"
-                                    VerticalAlignment="Center" />
-                        </StackPanel>
-                        <ItemsControl x:Name="MainWindowServicesPanel">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid Margin="{Binding IsAvailable, Converter={StaticResource BoolToCompactMarginConverter}}" Opacity="{Binding IsAvailable, Converter={StaticResource BoolToOpacityConverter}}">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <CheckBox
-                                            Content="{Binding DisplayName}"
-                                            FontSize="{Binding IsAvailable, Converter={StaticResource BoolToCompactFontSizeConverter}}"
-                                            FontStyle="{Binding IsUnconfigured, Converter={StaticResource BoolToItalicFontStyleConverter}}"
-                                            Tag="{Binding ServiceId}"
-                                            IsChecked="{Binding IsChecked, Mode=TwoWay}"
-                                            IsEnabled="{Binding IsAvailable}" />
-                                        <ToggleSwitch
-                                            Grid.Column="1"
-                                            IsOn="{Binding EnabledQuery, Mode=TwoWay}"
-                                            Loaded="OnServiceToggleSwitchLoaded"
-                                            Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            IsEnabled="{Binding IsAvailable}"
-                                            MinWidth="0"
-                                            Margin="8,0,0,0" />
-                                        <Button
-                                            Grid.Column="2"
-                                            Click="OnMoveMainServiceUp"
-                                            Tag="{Binding ServiceId}"
-                                            ToolTipService.ToolTip="Move up"
-                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            Width="32" Height="28" Padding="0"
-                                            Margin="4,0,0,0">
-                                            <FontIcon Glyph="&#xE70E;" FontSize="12" />
-                                        </Button>
-                                        <Button
-                                            Grid.Column="3"
-                                            Click="OnMoveMainServiceDown"
-                                            Tag="{Binding ServiceId}"
-                                            ToolTipService.ToolTip="Move down"
-                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            Width="32" Height="28" Padding="0"
-                                            Margin="2,0,0,0">
-                                            <FontIcon Glyph="&#xE70D;" FontSize="12" />
-                                        </Button>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
-                </Border>
-
-                <!-- Mini Window Services -->
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="12">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBlock x:Name="MiniWindowHeaderText" Text="Mini Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
-                            <Button x:Name="MiniWindowReorderModeButton"
-                                    Click="OnToggleMiniWindowReorderModeClicked"
-                                    Padding="8,2"
-                                    VerticalAlignment="Center" />
-                        </StackPanel>
-                        <ItemsControl x:Name="MiniWindowServicesPanel">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid Margin="{Binding IsAvailable, Converter={StaticResource BoolToCompactMarginConverter}}" Opacity="{Binding IsAvailable, Converter={StaticResource BoolToOpacityConverter}}">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <CheckBox
-                                            Content="{Binding DisplayName}"
-                                            FontSize="{Binding IsAvailable, Converter={StaticResource BoolToCompactFontSizeConverter}}"
-                                            FontStyle="{Binding IsUnconfigured, Converter={StaticResource BoolToItalicFontStyleConverter}}"
-                                            Tag="{Binding ServiceId}"
-                                            IsChecked="{Binding IsChecked, Mode=TwoWay}"
-                                            IsEnabled="{Binding IsAvailable}" />
-                                        <ToggleSwitch
-                                            Grid.Column="1"
-                                            IsOn="{Binding EnabledQuery, Mode=TwoWay}"
-                                            Loaded="OnServiceToggleSwitchLoaded"
-                                            Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            IsEnabled="{Binding IsAvailable}"
-                                            MinWidth="0"
-                                            Margin="8,0,0,0" />
-                                        <Button
-                                            Grid.Column="2"
-                                            Click="OnMoveMiniServiceUp"
-                                            Tag="{Binding ServiceId}"
-                                            ToolTipService.ToolTip="Move up"
-                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            Width="32" Height="28" Padding="0"
-                                            Margin="4,0,0,0">
-                                            <FontIcon Glyph="&#xE70E;" FontSize="12" />
-                                        </Button>
-                                        <Button
-                                            Grid.Column="3"
-                                            Click="OnMoveMiniServiceDown"
-                                            Tag="{Binding ServiceId}"
-                                            ToolTipService.ToolTip="Move down"
-                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            Width="32" Height="28" Padding="0"
-                                            Margin="2,0,0,0">
-                                            <FontIcon Glyph="&#xE70D;" FontSize="12" />
-                                        </Button>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
-                </Border>
-
-                <!-- Fixed Window Services -->
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="12">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBlock x:Name="FixedWindowHeaderText" Text="Fixed Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
-                            <Button x:Name="FixedWindowReorderModeButton"
-                                    Click="OnToggleFixedWindowReorderModeClicked"
-                                    Padding="8,2"
-                                    VerticalAlignment="Center" />
-                        </StackPanel>
-                        <ItemsControl x:Name="FixedWindowServicesPanel">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid Margin="{Binding IsAvailable, Converter={StaticResource BoolToCompactMarginConverter}}" Opacity="{Binding IsAvailable, Converter={StaticResource BoolToOpacityConverter}}">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <CheckBox
-                                            Content="{Binding DisplayName}"
-                                            FontSize="{Binding IsAvailable, Converter={StaticResource BoolToCompactFontSizeConverter}}"
-                                            FontStyle="{Binding IsUnconfigured, Converter={StaticResource BoolToItalicFontStyleConverter}}"
-                                            Tag="{Binding ServiceId}"
-                                            IsChecked="{Binding IsChecked, Mode=TwoWay}"
-                                            IsEnabled="{Binding IsAvailable}" />
-                                        <ToggleSwitch
-                                            Grid.Column="1"
-                                            IsOn="{Binding EnabledQuery, Mode=TwoWay}"
-                                            Loaded="OnServiceToggleSwitchLoaded"
-                                            Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            IsEnabled="{Binding IsAvailable}"
-                                            MinWidth="0"
-                                            Margin="8,0,0,0" />
-                                        <Button
-                                            Grid.Column="2"
-                                            Click="OnMoveFixedServiceUp"
-                                            Tag="{Binding ServiceId}"
-                                            ToolTipService.ToolTip="Move up"
-                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            Width="32" Height="28" Padding="0"
-                                            Margin="4,0,0,0">
-                                            <FontIcon Glyph="&#xE70E;" FontSize="12" />
-                                        </Button>
-                                        <Button
-                                            Grid.Column="3"
-                                            Click="OnMoveFixedServiceDown"
-                                            Tag="{Binding ServiceId}"
-                                            ToolTipService.ToolTip="Move down"
-                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
-                                            Width="32" Height="28" Padding="0"
-                                            Margin="2,0,0,0">
-                                            <FontIcon Glyph="&#xE70D;" FontSize="12" />
-                                        </Button>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
-                </Border>
-            </StackPanel>
-
-            <!-- Service Configuration -->
-            <StackPanel x:Name="ServiceConfigurationSection" Spacing="12">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <TextBlock x:Name="ServiceConfigurationHeaderText" Text="Service Configuration" FontSize="18" FontWeight="SemiBold" />
-                    <FontIcon x:Name="ServiceConfigHelpIcon" Glyph="&#xE897;" FontSize="14"
-                              Foreground="{ThemeResource TextFillColorTertiaryBrush}" VerticalAlignment="Center" />
-                </StackPanel>
-                <TextBlock x:Name="ServiceConfigurationDescriptionText" Text="Configure API keys, endpoints, and models for each translation service."
-                           FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-
-                <!-- DeepL -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="DeepL" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="DeepLStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="DeepLKeyBox" Header="API Key (Optional)" Width="350" PlaceholderText="Enter your DeepL API key" HorizontalAlignment="Left" />
-                        <CheckBox x:Name="DeepLFreeCheck" Content="Use Free API (no API key required for web translation)" />
-                        <TextBlock Text="Leave API key empty to use free web translation. Pro API key gives higher limits."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestDeepLButton" Content="Test" Click="OnTestDeepL" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- OpenAI -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="OpenAI" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="OpenAIStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="OpenAIKeyBox" Header="API Key" Width="350" PlaceholderText="sk-..." HorizontalAlignment="Left" />
-                        <TextBox x:Name="OpenAIEndpointBox" Header="Endpoint (Optional)" Width="450"
-                                 PlaceholderText="https://api.openai.com/v1/chat/completions" HorizontalAlignment="Left" />
-                        <ComboBox x:Name="OpenAIModelCombo" Header="Model" Width="280" IsEditable="True">
-                            <ComboBoxItem Content="gpt-4o-mini" Tag="gpt-4o-mini" />
-                            <ComboBoxItem Content="gpt-4o" Tag="gpt-4o" />
-                            <ComboBoxItem Content="gpt-4-turbo" Tag="gpt-4-turbo" />
-                            <ComboBoxItem Content="gpt-3.5-turbo" Tag="gpt-3.5-turbo" />
-                        </ComboBox>
-                        <TextBlock Text="You can type a custom model name directly."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <Button x:Name="TestOpenAIButton" Content="Test" Click="OnTestOpenAI" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- DeepSeek -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="DeepSeek" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="DeepSeekStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="DeepSeekKeyBox" Header="API Key" Width="350" PlaceholderText="sk-..." HorizontalAlignment="Left" />
-                        <ComboBox x:Name="DeepSeekModelCombo" Header="Model" Width="280" IsEditable="True">
-                            <ComboBoxItem Content="deepseek-chat" Tag="deepseek-chat" />
-                            <ComboBoxItem Content="deepseek-reasoner" Tag="deepseek-reasoner" />
-                        </ComboBox>
-                        <TextBlock Text="Get your API key from platform.deepseek.com. You can type a custom model name."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestDeepSeekButton" Content="Test" Click="OnTestDeepSeek" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Groq -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="Groq" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="GroqStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="GroqKeyBox" Header="API Key" Width="350" PlaceholderText="gsk_..." HorizontalAlignment="Left" />
-                        <ComboBox x:Name="GroqModelCombo" Header="Model" Width="280" IsEditable="True">
-                            <ComboBoxItem Content="llama-3.3-70b-versatile" Tag="llama-3.3-70b-versatile" />
-                            <ComboBoxItem Content="llama-3.1-8b-instant" Tag="llama-3.1-8b-instant" />
-                            <ComboBoxItem Content="qwen/qwen-3-32b" Tag="qwen/qwen-3-32b" />
-                        </ComboBox>
-                        <TextBlock Text="Groq provides fast inference. Get your API key from console.groq.com. You can type a custom model name."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestGroqButton" Content="Test" Click="OnTestGroq" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Zhipu (智谱) -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="Zhipu (智谱)" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="ZhipuStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="ZhipuKeyBox" Header="API Key" Width="350" PlaceholderText="Enter your Zhipu API key" HorizontalAlignment="Left" />
-                        <ComboBox x:Name="ZhipuModelCombo" Header="Model" Width="280" IsEditable="True">
-                            <ComboBoxItem Content="glm-4.5-flash" Tag="glm-4.5-flash" />
-                            <ComboBoxItem Content="glm-4-flash-250414" Tag="glm-4-flash-250414" />
-                            <ComboBoxItem Content="glm-4.7" Tag="glm-4.7" />
-                            <ComboBoxItem Content="glm-4.5-air" Tag="glm-4.5-air" />
-                        </ComboBox>
-                        <TextBlock Text="Get your API key from open.bigmodel.cn. You can type a custom model name."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestZhipuButton" Content="Test" Click="OnTestZhipu" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- GitHub Models -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="GitHub Models" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="GitHubModelsStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="GitHubModelsTokenBox" Header="GitHub Token" Width="350" PlaceholderText="ghp_..." HorizontalAlignment="Left" />
-                        <ComboBox x:Name="GitHubModelsModelCombo" Header="Model" Width="280" IsEditable="True">
-                            <ComboBoxItem Content="gpt-4.1" Tag="gpt-4.1" />
-                            <ComboBoxItem Content="gpt-4.1-mini" Tag="gpt-4.1-mini" />
-                            <ComboBoxItem Content="gpt-4.1-nano" Tag="gpt-4.1-nano" />
-                            <ComboBoxItem Content="gpt-4o" Tag="gpt-4o" />
-                            <ComboBoxItem Content="gpt-4o-mini" Tag="gpt-4o-mini" />
-                            <ComboBoxItem Content="deepseek-v3-0324" Tag="deepseek-v3-0324" />
-                        </ComboBox>
-                        <TextBlock Text="Use your GitHub personal access token. Get one from github.com/settings/tokens. You can type a custom model name."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestGitHubModelsButton" Content="Test" Click="OnTestGitHubModels" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Gemini -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="Gemini" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="GeminiStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="GeminiKeyBox" Header="API Key" Width="350" PlaceholderText="Enter your Gemini API key" HorizontalAlignment="Left" />
-                        <ComboBox x:Name="GeminiModelCombo" Header="Model" Width="280" IsEditable="True">
-                            <ComboBoxItem Content="gemini-2.5-flash" Tag="gemini-2.5-flash" />
-                            <ComboBoxItem Content="gemini-2.5-flash-lite" Tag="gemini-2.5-flash-lite" />
-                            <ComboBoxItem Content="gemini-2.5-pro" Tag="gemini-2.5-pro" />
-                            <ComboBoxItem Content="gemini-2.0-flash" Tag="gemini-2.0-flash" />
-                            <ComboBoxItem Content="gemini-1.5-flash" Tag="gemini-1.5-flash" />
-                            <ComboBoxItem Content="gemini-1.5-pro" Tag="gemini-1.5-pro" />
-                            <ComboBoxItem Content="gemini-3-flash-preview" Tag="gemini-3-flash-preview" />
-                            <ComboBoxItem Content="gemini-3-pro-preview" Tag="gemini-3-pro-preview" />
-                        </ComboBox>
-                        <TextBlock Text="Get your API key from aistudio.google.com. You can type a custom model name."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestGeminiButton" Content="Test" Click="OnTestGemini" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Custom OpenAI Compatible -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="Custom OpenAI Compatible" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="CustomOpenAIStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <TextBox x:Name="CustomOpenAIEndpointBox" Header="Endpoint (Required)" Width="450"
-                                 PlaceholderText="https://your-api.example.com/v1/chat/completions" HorizontalAlignment="Left" />
-                        <PasswordBox x:Name="CustomOpenAIKeyBox" Header="API Key (Optional)" Width="350" PlaceholderText="Enter API key if required" HorizontalAlignment="Left" />
-                        <TextBox x:Name="CustomOpenAIModelBox" Header="Model" Width="200"
-                                 PlaceholderText="gpt-3.5-turbo" HorizontalAlignment="Left" />
-                        <TextBlock Text="Configure any OpenAI-compatible API endpoint (e.g., local LLM servers, other AI providers)."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestCustomOpenAIButton" Content="Test" Click="OnTestCustomOpenAI" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Ollama (Local) -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="Ollama (Local LLM)" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="OllamaStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <TextBox x:Name="OllamaEndpointBox" Header="Endpoint" Width="450"
-                                 PlaceholderText="http://localhost:11434/v1/chat/completions" HorizontalAlignment="Left" />
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <ComboBox x:Name="OllamaModelCombo" Header="Model" Width="200" IsEditable="True" />
-                            <Button x:Name="RefreshOllamaButton" Content="Refresh" Click="OnRefreshOllamaModels"
-                                    VerticalAlignment="Bottom" Padding="12,6" />
-                            <Button x:Name="TestOllamaButton" Content="Test" Click="OnTestOllama"
-                                    VerticalAlignment="Bottom" Padding="8,4" />
-                        </StackPanel>
-                        <TextBlock Text="Ollama must be running locally. Click Refresh to load available models."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Built-in AI -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="Built-in AI" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="BuiltInStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <InfoBar x:Name="BuiltInAIHintBar"
-                                 IsOpen="True" IsClosable="False" Severity="Informational"
-                                 Title="Hint"
-                                 Message="The built-in key has limited free quota and is not guaranteed to always be available. For stable use, get your own free API key." />
-                        <ComboBox x:Name="BuiltInModelCombo" Header="Model" Width="280" IsEditable="True">
-                            <ComboBoxItem Content="glm-4-flash-250414 (GLM)" Tag="glm-4-flash-250414" />
-                            <ComboBoxItem Content="glm-4-flash (GLM)" Tag="glm-4-flash" />
-                            <ComboBoxItem Content="llama-3.3-70b-versatile (Groq)" Tag="llama-3.3-70b-versatile" />
-                            <ComboBoxItem Content="llama-3.1-8b-instant (Groq)" Tag="llama-3.1-8b-instant" />
-                        </ComboBox>
-                        <PasswordBox x:Name="BuiltInApiKeyBox" Header="API Key (Optional)" Width="350"
-                                     PlaceholderText="Leave empty to use built-in key" HorizontalAlignment="Left" />
-                        <TextBlock x:Name="BuiltInDescriptionText"
-                                   Text="Uses GLM (Zhipu AI) or Groq free models. You can provide your own API key from open.bigmodel.cn (GLM) or console.groq.com (Groq)."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestBuiltInButton" Content="Test" Click="OnTestBuiltIn" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Doubao (豆包) -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="Doubao (豆包)" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="DoubaoStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="DoubaoKeyBox" Header="API Key" Width="350" PlaceholderText="Enter your Doubao API key" HorizontalAlignment="Left" />
-                        <TextBox x:Name="DoubaoEndpointBox" Header="Endpoint" Width="450"
-                                 PlaceholderText="https://ark.cn-beijing.volces.com/api/v3/responses" HorizontalAlignment="Left" />
-                        <TextBox x:Name="DoubaoModelBox" Header="Model" Width="300"
-                                 PlaceholderText="doubao-seed-translation-250915" HorizontalAlignment="Left" />
-                        <TextBlock Text="ByteDance's Doubao translation service. Get your API key from console.volcengine.com"
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestDoubaoButton" Content="Test" Click="OnTestDoubao" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Caiyun (彩云小译) -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="Caiyun (彩云小译)" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="CaiyunStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="CaiyunKeyBox" Header="API Key" Width="350" PlaceholderText="Enter your Caiyun API key" HorizontalAlignment="Left" />
-                        <TextBlock Text="Get your API key from fanyi.caiyunapp.com"
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <Button x:Name="TestCaiyunButton" Content="Test" Click="OnTestCaiyun" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- NiuTrans (小牛翻译) -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <Grid>
-                            <TextBlock Text="NiuTrans (小牛翻译)" FontWeight="SemiBold" HorizontalAlignment="Left" />
-                            <TextBlock x:Name="NiuTransStatusText" Text="✅" FontWeight="SemiBold"
-                                       Foreground="Green" HorizontalAlignment="Right" Margin="0,0,8,0"
-                                       Visibility="Collapsed" />
-                        </Grid>
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="NiuTransKeyBox" Header="API Key" Width="350" PlaceholderText="Enter your NiuTrans API key" HorizontalAlignment="Left" />
-                        <TextBlock Text="NiuTrans supports 450+ language pairs. Get your API key from niutrans.com"
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <Button x:Name="TestNiuTransButton" Content="Test" Click="OnTestNiuTrans" Padding="8,4" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Youdao (有道翻译) -->
-                <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <Expander.Header>
-                        <TextBlock Text="Youdao (有道翻译)" FontWeight="SemiBold" />
-                    </Expander.Header>
-                    <StackPanel Spacing="12" Padding="0,8">
-                        <PasswordBox x:Name="YoudaoAppKeyBox" Header="App Key" Width="350" PlaceholderText="Enter your Youdao App Key" HorizontalAlignment="Left" />
-                        <PasswordBox x:Name="YoudaoAppSecretBox" Header="App Secret" Width="350" PlaceholderText="Enter your Youdao App Secret" HorizontalAlignment="Left" />
-                        <ToggleSwitch x:Name="YoudaoUseOfficialApiToggle" Header="Use Official API" />
-                        <TextBlock Text="Youdao provides phonetic transcriptions for English words. Without API keys, uses free web dictionary. With API keys, enables official API for higher limits. Get API keys from ai.youdao.com"
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                    </StackPanel>
-                </Expander>
-
-                <!-- Imported MDX Dictionaries (dynamically populated) -->
-                <StackPanel x:Name="ImportedMdxConfigPanel" Spacing="8" />
-
-                <!-- Google Translate & Linguee (No configuration needed) -->
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="8">
-                        <TextBlock x:Name="FreeServicesHeaderText" Text="Free Services (No Configuration Required)" FontWeight="SemiBold" />
-                        <TextBlock x:Name="FreeServicesDescriptionText" Text="Google Translate and Linguee Dictionary work out of the box without API keys."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                    </StackPanel>
-                </Border>
-            </StackPanel>
-
-            <!-- Layout Detection (Long Document) -->
-            <StackPanel x:Name="LayoutDetectionSection" Spacing="12">
-                <TextBlock x:Name="LayoutDetectionHeaderText" Text="Layout Detection" FontSize="18" FontWeight="SemiBold" />
-                <TextBlock x:Name="LayoutDetectionDescriptionText"
-                           Text="ML-based layout detection for long document translation. Improves accuracy for academic papers with figures, tables, and formulas."
-                           FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="16">
-                        <ComboBox x:Name="LayoutDetectionModeCombo" Header="Detection Mode" Width="300">
-                            <ComboBoxItem x:Name="LayoutDetectionAutoItem" Content="Auto (Recommended)" Tag="Auto" />
-                            <ComboBoxItem x:Name="LayoutDetectionOnnxItem" Content="Local ONNX Model" Tag="OnnxLocal" />
-                            <ComboBoxItem x:Name="LayoutDetectionVisionItem" Content="Vision LLM" Tag="VisionLLM" />
-                            <ComboBoxItem x:Name="LayoutDetectionHeuristicItem" Content="Heuristic Only" Tag="Heuristic" />
-                        </ComboBox>
-
-                        <!-- ONNX Model Download -->
-                        <StackPanel x:Name="OnnxModelPanel" Spacing="8">
-                            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                                <TextBlock x:Name="OnnxModelStatusText" Text="ONNX Model: Not Downloaded" VerticalAlignment="Center" />
-                                <FontIcon x:Name="OnnxModelStatusIcon" Glyph="&#xE946;" FontSize="14" Visibility="Collapsed"
-                                          Foreground="{ThemeResource SystemFillColorSuccessBrush}" VerticalAlignment="Center" />
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Button x:Name="DownloadOnnxModelButton" Content="Download Model (~75MB)" Click="OnDownloadOnnxModelClick" />
-                                <Button x:Name="DeleteOnnxModelButton" Content="Delete" Click="OnDeleteOnnxModelClick" Visibility="Collapsed" />
-                            </StackPanel>
-                            <ProgressBar x:Name="OnnxDownloadProgress" Visibility="Collapsed" Minimum="0" Maximum="100" />
-                            <TextBlock x:Name="OnnxDownloadProgressText" Visibility="Collapsed"
-                                       FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        </StackPanel>
-
-                        <!-- Vision LLM Service Selection (visible when VisionLLM mode selected) -->
-                        <StackPanel x:Name="VisionLLMPanel" Spacing="8" Visibility="Collapsed">
-                            <ComboBox x:Name="VisionLayoutServiceCombo" Header="Vision Service" Width="300">
-                                <ComboBoxItem Content="OpenAI (GPT-4o)" Tag="openai" />
-                                <ComboBoxItem Content="Gemini" Tag="gemini" />
-                                <ComboBoxItem Content="Custom OpenAI" Tag="custom_openai" />
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="16">
+                            <!-- First Language -->
+                            <ComboBox
+                                x:Name="FirstLanguageCombo"
+                                Header="First Language"
+                                Width="250"
+                                HorizontalAlignment="Left">
+                                <!-- Populated dynamically in code-behind -->
                             </ComboBox>
-                            <TextBlock Text="Requires a configured API key for the selected service."
-                                       FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+
+                            <!-- Second Language -->
+                            <ComboBox
+                                x:Name="SecondLanguageCombo"
+                                Header="Second Language"
+                                Width="250"
+                                HorizontalAlignment="Left">
+                                <!-- Populated dynamically in code-behind -->
+                            </ComboBox>
+
+                            <!-- Explanation -->
+                            <TextBlock
+                                x:Name="LanguagePreferencesDescriptionText"
+                                TextWrapping="Wrap"
+                                FontSize="12"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Margin="0,4,0,0">
+                            <Run Text="When detected language matches your First Language, translation target will be your Second Language, and vice versa."/>
+                            </TextBlock>
+
+                            <!-- Auto-Select Toggle -->
+                            <ToggleSwitch
+                                x:Name="AutoSelectTargetToggle"
+                                Header="Automatically select target language based on detected source"
+                                IsOn="True"/>
                         </StackPanel>
-                    </StackPanel>
-                </Border>
-            </StackPanel>
+                    </Border>
 
-            <!-- CJK Font -->
-            <StackPanel x:Name="CjkFontSection" Spacing="12">
-                <TextBlock x:Name="CjkFontHeaderText" Text="CJK Font" FontSize="18" FontWeight="SemiBold" />
-                <TextBlock x:Name="CjkFontDescriptionText"
-                           Text="Download CJK fonts for proper Chinese, Japanese, and Korean text rendering in PDF output."
-                           FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="16">
-                        <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button x:Name="CjkFontDownloadButton" Content="Download CJK Font" Click="OnCjkFontDownloadClick" />
-                            <Button x:Name="CjkFontDeleteButton" Content="Delete" Click="OnCjkFontDeleteClick" />
+                    <!-- Available Languages -->
+                    <Expander x:Name="AvailableLanguagesExpander"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <TextBlock x:Name="AvailableLanguagesHeaderText"
+                                    Text="Available Languages"
+                                    FontWeight="SemiBold"/>
+                        </Expander.Header>
+                        <StackPanel Spacing="8"
+                                Padding="4">
+                            <TextBlock x:Name="AvailableLanguagesDescText"
+                                       Text="Select languages available in source/target pickers. At least 2 required."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <ItemsRepeater x:Name="LanguageCheckboxGrid">
+                                <ItemsRepeater.Layout>
+                                    <UniformGridLayout MinItemWidth="180"
+                                            MinColumnSpacing="8"
+                                            MinRowSpacing="4"
+                                                       ItemsStretch="Fill"
+                                            MaximumRowsOrColumns="4"/>
+                                </ItemsRepeater.Layout>
+                            </ItemsRepeater>
                         </StackPanel>
-                        <ProgressBar x:Name="CjkFontProgressBar" Visibility="Collapsed" Minimum="0" Maximum="100" />
-                        <TextBlock x:Name="CjkFontStatusText" Text="" FontSize="12"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                        <TextBlock x:Name="CjkFontNoteText"
-                                   Text="Downloads Noto Sans CJK (~16MB per language). Required for CJK text in PDF overlay rendering."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+                    </Expander>
+                </StackPanel>
+
+                <!-- Enabled Services for Each Window -->
+                <StackPanel x:Name="EnabledServicesSection"
+                        Spacing="12">
+                    <StackPanel Orientation="Horizontal"
+                            Spacing="8">
+                        <TextBlock x:Name="EnabledServicesHeaderText"
+                                Text="Enabled Services"
+                                FontSize="18"
+                                FontWeight="SemiBold"/>
+                        <FontIcon x:Name="EnabledServicesHelpIcon"
+                                Glyph="&#xE897;"
+                                FontSize="14"
+                                  Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                VerticalAlignment="Center"/>
                     </StackPanel>
-                </Border>
-            </StackPanel>
+                    <TextBlock x:Name="EnabledServicesDescriptionText"
+                            Text="Select which translation services to display in each window. Multiple services will run in parallel."
+                               FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            TextWrapping="Wrap"/>
 
-            <!-- Formula Detection -->
-            <StackPanel x:Name="FormulaDetectionSection" Spacing="12">
-                <TextBlock x:Name="FormulaDetectionHeaderText" Text="Formula Detection" FontSize="18" FontWeight="SemiBold" />
-                <TextBlock x:Name="FormulaDetectionDescriptionText"
-                           Text="Advanced formula detection uses font names and Unicode math characters to protect formulas from translation."
-                           FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="16">
-                        <TextBox x:Name="FormulaFontPatternBox" Header="Font Pattern (Regex)"
-                                 Width="450" PlaceholderText="e.g. CMSY|CMMI|Symbol|Mathematica"
-                                 HorizontalAlignment="Left" TextChanged="OnFormulaPatternChanged" />
-                        <TextBox x:Name="FormulaCharPatternBox" Header="Character Pattern (Regex)"
-                                 Width="450" PlaceholderText="e.g. [\u2200-\u22FF\u0370-\u03FF]"
-                                 HorizontalAlignment="Left" TextChanged="OnFormulaPatternChanged" />
-                        <TextBlock x:Name="FormulaDetectionNoteText"
-                                   Text="Leave empty to use built-in patterns. Font pattern matches PDF font names (Level 2). Character pattern matches Unicode ranges (Level 3)."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+                    <StackPanel Orientation="Horizontal"
+                            Spacing="8">
+                        <Button x:Name="ImportMdxDictionaryButton"
+                                Content="Import MDX Dictionary"
+                                Click="OnImportMdxDictionaryClicked"
+                                Padding="10,4"/>
+                        <TextBlock x:Name="ImportedMdxSummaryText"
+                                   Text="No MDX dictionaries imported"
+                                   VerticalAlignment="Center"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     </StackPanel>
-                </Border>
-            </StackPanel>
 
-            <!-- Translation Cache -->
-            <StackPanel x:Name="TranslationCacheSection" Spacing="12">
-                <TextBlock x:Name="TranslationCacheHeaderText" Text="Translation Cache" FontSize="18" FontWeight="SemiBold" />
-                <TextBlock x:Name="TranslationCacheDescriptionText"
-                           Text="Cache translated segments locally to speed up repeated translations and save API costs."
-                           FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="16">
-                        <ToggleSwitch x:Name="TranslationCacheToggle" Header="Enable Translation Cache"
-                                      Toggled="OnTranslationCacheToggled" />
-                        <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button x:Name="ClearCacheButton" Content="Clear Cache" Click="OnClearCacheClick" />
-                            <TextBlock x:Name="CacheStatusText" Text="" VerticalAlignment="Center"
-                                       FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        </StackPanel>
-                        <TextBlock x:Name="TranslationCacheNoteText"
-                                   Text="Cached translations are stored locally in SQLite. Clear cache if translations become stale."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                    </StackPanel>
-                </Border>
-            </StackPanel>
-
-            <!-- Custom LLM Prompt -->
-            <StackPanel x:Name="CustomPromptSection" Spacing="12">
-                <TextBlock x:Name="CustomPromptHeaderText" Text="Custom Translation Prompt" FontSize="18" FontWeight="SemiBold" />
-                <TextBlock x:Name="CustomPromptDescriptionText"
-                           Text="Add custom instructions for LLM-based translation services (OpenAI, DeepSeek, Gemini, etc.)."
-                           FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="16">
-                        <TextBox x:Name="CustomPromptBox" Header="Additional Instructions"
-                                 Width="450" Height="120" AcceptsReturn="True" TextWrapping="Wrap"
-                                 PlaceholderText="e.g. You are translating a medical research paper. Preserve all LaTeX commands and scientific terminology."
-                                 HorizontalAlignment="Left" TextChanged="OnCustomPromptChanged" />
-                        <TextBlock x:Name="CustomPromptNoteText"
-                                   Text="These instructions are appended to the system prompt for LLM services. Has no effect on non-LLM services (Google, DeepL, etc.)."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                    </StackPanel>
-                </Border>
-            </StackPanel>
-
-            <!-- HTTP Proxy -->
-            <StackPanel x:Name="HttpProxySection" Spacing="12">
-                <TextBlock x:Name="HttpProxyHeaderText" Text="HTTP Proxy" FontSize="18" FontWeight="SemiBold" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="16">
-                        <ToggleSwitch x:Name="ProxyEnabledToggle" Header="Use HTTP Proxy" />
-                        <TextBox x:Name="ProxyUriBox" Header="Proxy URL" Width="300"
-                                 PlaceholderText="http://127.0.0.1:7890" />
-                        <ToggleSwitch x:Name="ProxyBypassLocalToggle" Header="Bypass proxy for localhost" IsOn="True" />
-                        <TextBlock Text="Proxy changes take effect after app restart. Localhost bypass ensures Ollama works without proxy."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-                    </StackPanel>
-                </Border>
-            </StackPanel>
-
-            <!-- Behavior -->
-            <StackPanel x:Name="BehaviorSection" Spacing="12">
-                <TextBlock x:Uid="BehaviorHeader" Text="Behavior" FontSize="18" FontWeight="SemiBold" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="12">
-                        <!-- App Theme -->
-                        <ComboBox
-                            x:Name="AppThemeCombo"
-                            Header="App Theme"
-                            Width="250"
-                            SelectionChanged="OnAppThemeChanged"
-                            HorizontalAlignment="Left">
-                            <ComboBoxItem Content="System" Tag="System" />
-                            <ComboBoxItem Content="Light" Tag="Light" />
-                            <ComboBoxItem Content="Dark" Tag="Dark" />
-                        </ComboBox>
-                        <TextBlock
-                            x:Name="AppThemeDescriptionText"
-                            Text="Choose how Easydict appears. Select System to follow Windows theme."
-                            FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-
-                        <!-- UI Language -->
-                        <ComboBox
-                            x:Name="UILanguageCombo"
-                            x:Uid="UILanguageCombo"
-                            Header="UI Language"
-                            Width="250"
-                            SelectionChanged="OnUILanguageChanged"
-                            HorizontalAlignment="Left">
-                            <ComboBoxItem x:Uid="UILangEnglishItem" Content="English" Tag="en-US" />
-                            <ComboBoxItem x:Uid="UILangChineseItem" Content="简体中文" Tag="zh-CN" />
-                            <ComboBoxItem x:Uid="UILangTraditionalChineseItem" Content="繁體中文" Tag="zh-TW" />
-                            <ComboBoxItem x:Uid="UILangJapaneseItem" Content="日本語" Tag="ja-JP" />
-                            <ComboBoxItem x:Uid="UILangKoreanItem" Content="한국어" Tag="ko-KR" />
-                            <ComboBoxItem x:Uid="UILangFrenchItem" Content="Français" Tag="fr-FR" />
-                            <ComboBoxItem x:Uid="UILangGermanItem" Content="Deutsch" Tag="de-DE" />
-                            <ComboBoxItem x:Uid="UILangVietnameseItem" Content="Tiếng Việt" Tag="vi-VN" />
-                            <ComboBoxItem x:Uid="UILangThaiItem" Content="ไทย" Tag="th-TH" />
-                            <ComboBoxItem x:Uid="UILangArabicItem" Content="العربية" Tag="ar-SA" />
-                            <ComboBoxItem x:Uid="UILangIndonesianItem" Content="Bahasa Indonesia" Tag="id-ID" />
-                            <ComboBoxItem x:Uid="UILangItalianItem" Content="Italiano" Tag="it-IT" />
-                            <ComboBoxItem x:Uid="UILangMalayItem" Content="Bahasa Melayu" Tag="ms-MY" />
-                            <ComboBoxItem x:Uid="UILangHindiItem" Content="हिन्दी" Tag="hi-IN" />
-                            <ComboBoxItem x:Uid="UILangDanishItem" Content="Dansk" Tag="da-DK" />
-                        </ComboBox>
-                        <TextBlock x:Uid="UILanguageDescription"
-                                   Text="Select the display language for the application interface. Restart required."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
-
-                        <ToggleSwitch x:Name="MinimizeToTrayToggle" x:Uid="MinimizeToTrayToggle" Header="Minimize to system tray" />
-                        <ToggleSwitch x:Name="MinimizeToTrayOnStartupToggle" x:Uid="MinimizeToTrayOnStartupToggle" Header="Start minimized to tray" />
-                        <ToggleSwitch x:Name="ClipboardMonitorToggle" x:Uid="ClipboardMonitorToggle" Header="Monitor clipboard for text" />
-                        <ToggleSwitch x:Name="MouseSelectionTranslateToggle" x:Uid="MouseSelectionTranslateToggle" Header="Mouse selection translate" />
-                        <StackPanel x:Name="MouseSelectionExcludedAppsPanel" Spacing="4" Margin="44,0,0,0"
-                                    Visibility="Collapsed">
-                            <TextBox x:Name="MouseSelectionExcludedAppsBox"
-                                     x:Uid="MouseSelectionExcludedAppsBox"
-                                     Header="Excluded apps"
-                                     PlaceholderText="code, slack, discord"
-                                     Width="350"
-                                     HorizontalAlignment="Left" />
-                            <TextBlock x:Uid="MouseSelectionExcludedAppsDescription"
-                                       Text="Process names to exclude, separated by commas."
+                    <!-- International Services Toggle -->
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="12,8">
+                        <StackPanel Spacing="4">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock x:Name="EnableInternationalServicesHeaderText"
+                                           Text="Enable International Services"
+                                           FontSize="13"
+                                           VerticalAlignment="Center"/>
+                                <ToggleSwitch x:Name="EnableInternationalServicesToggle"
+                                              Grid.Column="1"
+                                              Toggled="OnEnableInternationalServicesToggled"
+                                              MinWidth="0"
+                                              VerticalAlignment="Center"/>
+                            </Grid>
+                            <TextBlock x:Name="EnableInternationalServicesDescriptionText"
+                                       Text="Some services require international network access."
                                        FontSize="11"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       TextWrapping="Wrap"
-                                       MaxWidth="350"
-                                       HorizontalAlignment="Left" />
+                                       TextWrapping="Wrap"/>
                         </StackPanel>
-                        <ToggleSwitch x:Name="AlwaysOnTopToggle" x:Uid="AlwaysOnTopToggle" Header="Always on top" />
-                        <ToggleSwitch x:Name="LaunchAtStartupToggle" x:Uid="LaunchAtStartupToggle" Header="Launch at Windows startup" />
-                        <ToggleSwitch x:Name="HideEmptyServiceResultsToggle" Header="Hide dictionaries with no result" />
-                    </StackPanel>
-                </Border>
-            </StackPanel>
+                    </Border>
 
-            <!-- Hotkeys -->
-            <StackPanel x:Name="HotkeysSection" Spacing="12">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <TextBlock x:Name="HotkeysHeaderText" Text="Hotkeys" FontSize="18" FontWeight="SemiBold" />
-                    <FontIcon x:Name="HotkeysHelpIcon" Glyph="&#xE897;" FontSize="14"
-                              Foreground="{ThemeResource TextFillColorTertiaryBrush}" VerticalAlignment="Center" />
+                    <!-- Main Window Services -->
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="12">
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                                <TextBlock x:Name="MainWindowHeaderText"
+                                        Text="Main Window"
+                                        FontWeight="SemiBold"
+                                        FontSize="14"
+                                        VerticalAlignment="Center"/>
+                                <Button x:Name="MainWindowReorderModeButton"
+                                        Click="OnToggleMainWindowReorderModeClicked"
+                                        Padding="8,2"
+                                        VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <ItemsControl x:Name="MainWindowServicesPanel">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="{Binding IsAvailable, Converter={StaticResource BoolToCompactMarginConverter}}"
+                                                Opacity="{Binding IsAvailable, Converter={StaticResource BoolToOpacityConverter}}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <CheckBox
+                                                Content="{Binding DisplayName}"
+                                                FontSize="{Binding IsAvailable, Converter={StaticResource BoolToCompactFontSizeConverter}}"
+                                                FontStyle="{Binding IsUnconfigured, Converter={StaticResource BoolToItalicFontStyleConverter}}"
+                                                Tag="{Binding ServiceId}"
+                                                IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                                IsEnabled="{Binding IsAvailable}"/>
+                                            <ToggleSwitch
+                                                Grid.Column="1"
+                                                IsOn="{Binding EnabledQuery, Mode=TwoWay}"
+                                                Loaded="OnServiceToggleSwitchLoaded"
+                                                Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                IsEnabled="{Binding IsAvailable}"
+                                                MinWidth="0"
+                                                Margin="8,0,0,0"/>
+                                            <Button
+                                                Grid.Column="2"
+                                                Click="OnMoveMainServiceUp"
+                                                Tag="{Binding ServiceId}"
+                                                ToolTipService.ToolTip="Move up"
+                                                Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                Width="32"
+                                                    Height="28"
+                                                    Padding="0"
+                                                Margin="4,0,0,0">
+                                                <FontIcon Glyph="&#xE70E;"
+                                                        FontSize="12"/>
+                                            </Button>
+                                            <Button
+                                                Grid.Column="3"
+                                                Click="OnMoveMainServiceDown"
+                                                Tag="{Binding ServiceId}"
+                                                ToolTipService.ToolTip="Move down"
+                                                Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                Width="32"
+                                                    Height="28"
+                                                    Padding="0"
+                                                Margin="2,0,0,0">
+                                                <FontIcon Glyph="&#xE70D;"
+                                                        FontSize="12"/>
+                                            </Button>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Mini Window Services -->
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="12">
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                                <TextBlock x:Name="MiniWindowHeaderText"
+                                        Text="Mini Window"
+                                        FontWeight="SemiBold"
+                                        FontSize="14"
+                                        VerticalAlignment="Center"/>
+                                <Button x:Name="MiniWindowReorderModeButton"
+                                        Click="OnToggleMiniWindowReorderModeClicked"
+                                        Padding="8,2"
+                                        VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <ItemsControl x:Name="MiniWindowServicesPanel">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="{Binding IsAvailable, Converter={StaticResource BoolToCompactMarginConverter}}"
+                                                Opacity="{Binding IsAvailable, Converter={StaticResource BoolToOpacityConverter}}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <CheckBox
+                                                Content="{Binding DisplayName}"
+                                                FontSize="{Binding IsAvailable, Converter={StaticResource BoolToCompactFontSizeConverter}}"
+                                                FontStyle="{Binding IsUnconfigured, Converter={StaticResource BoolToItalicFontStyleConverter}}"
+                                                Tag="{Binding ServiceId}"
+                                                IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                                IsEnabled="{Binding IsAvailable}"/>
+                                            <ToggleSwitch
+                                                Grid.Column="1"
+                                                IsOn="{Binding EnabledQuery, Mode=TwoWay}"
+                                                Loaded="OnServiceToggleSwitchLoaded"
+                                                Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                IsEnabled="{Binding IsAvailable}"
+                                                MinWidth="0"
+                                                Margin="8,0,0,0"/>
+                                            <Button
+                                                Grid.Column="2"
+                                                Click="OnMoveMiniServiceUp"
+                                                Tag="{Binding ServiceId}"
+                                                ToolTipService.ToolTip="Move up"
+                                                Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                Width="32"
+                                                    Height="28"
+                                                    Padding="0"
+                                                Margin="4,0,0,0">
+                                                <FontIcon Glyph="&#xE70E;"
+                                                        FontSize="12"/>
+                                            </Button>
+                                            <Button
+                                                Grid.Column="3"
+                                                Click="OnMoveMiniServiceDown"
+                                                Tag="{Binding ServiceId}"
+                                                ToolTipService.ToolTip="Move down"
+                                                Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                Width="32"
+                                                    Height="28"
+                                                    Padding="0"
+                                                Margin="2,0,0,0">
+                                                <FontIcon Glyph="&#xE70D;"
+                                                        FontSize="12"/>
+                                            </Button>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Fixed Window Services -->
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="12">
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                                <TextBlock x:Name="FixedWindowHeaderText"
+                                        Text="Fixed Window"
+                                        FontWeight="SemiBold"
+                                        FontSize="14"
+                                        VerticalAlignment="Center"/>
+                                <Button x:Name="FixedWindowReorderModeButton"
+                                        Click="OnToggleFixedWindowReorderModeClicked"
+                                        Padding="8,2"
+                                        VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <ItemsControl x:Name="FixedWindowServicesPanel">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="{Binding IsAvailable, Converter={StaticResource BoolToCompactMarginConverter}}"
+                                                Opacity="{Binding IsAvailable, Converter={StaticResource BoolToOpacityConverter}}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <CheckBox
+                                                Content="{Binding DisplayName}"
+                                                FontSize="{Binding IsAvailable, Converter={StaticResource BoolToCompactFontSizeConverter}}"
+                                                FontStyle="{Binding IsUnconfigured, Converter={StaticResource BoolToItalicFontStyleConverter}}"
+                                                Tag="{Binding ServiceId}"
+                                                IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                                IsEnabled="{Binding IsAvailable}"/>
+                                            <ToggleSwitch
+                                                Grid.Column="1"
+                                                IsOn="{Binding EnabledQuery, Mode=TwoWay}"
+                                                Loaded="OnServiceToggleSwitchLoaded"
+                                                Visibility="{Binding IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                IsEnabled="{Binding IsAvailable}"
+                                                MinWidth="0"
+                                                Margin="8,0,0,0"/>
+                                            <Button
+                                                Grid.Column="2"
+                                                Click="OnMoveFixedServiceUp"
+                                                Tag="{Binding ServiceId}"
+                                                ToolTipService.ToolTip="Move up"
+                                                Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                Width="32"
+                                                    Height="28"
+                                                    Padding="0"
+                                                Margin="4,0,0,0">
+                                                <FontIcon Glyph="&#xE70E;"
+                                                        FontSize="12"/>
+                                            </Button>
+                                            <Button
+                                                Grid.Column="3"
+                                                Click="OnMoveFixedServiceDown"
+                                                Tag="{Binding ServiceId}"
+                                                ToolTipService.ToolTip="Move down"
+                                                Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                Width="32"
+                                                    Height="28"
+                                                    Padding="0"
+                                                Margin="2,0,0,0">
+                                                <FontIcon Glyph="&#xE70D;"
+                                                        FontSize="12"/>
+                                            </Button>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
                 </StackPanel>
 
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="16">
-                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
-                            <TextBox x:Name="ShowHotkeyBox" Header="Show Window" Width="200" PlaceholderText="Ctrl+Alt+T" />
-                            <ToggleSwitch x:Name="ShowHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
-                            <TextBox x:Name="TranslateHotkeyBox" Header="Translate Selection" Width="200" PlaceholderText="Ctrl+Alt+D" />
-                            <ToggleSwitch x:Name="TranslateHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
-                            <TextBox x:Name="ShowMiniHotkeyBox" Header="Show Mini Window" Width="200" PlaceholderText="Ctrl+Alt+M" />
-                            <ToggleSwitch x:Name="ShowMiniHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
-                            <TextBox x:Name="ShowFixedHotkeyBox" Header="Show Fixed Window" Width="200" PlaceholderText="Ctrl+Alt+F" />
-                            <ToggleSwitch x:Name="ShowFixedHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
-                            <TextBox x:Name="OcrTranslateHotkeyBox" Header="OCR Screenshot Translate" Width="200" PlaceholderText="Ctrl+Alt+S" />
-                            <ToggleSwitch x:Name="OcrTranslateHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
-                            <TextBox x:Name="SilentOcrHotkeyBox" Header="Silent OCR" Width="200" PlaceholderText="Ctrl+Alt+Shift+S" />
-                            <ToggleSwitch x:Name="SilentOcrHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
-                        </StackPanel>
-                        <TextBlock x:Name="HotkeysDescriptionText" Text="Note: Restart app to apply hotkey changes. Toggle hotkeys use the same key with Shift added (e.g., Ctrl+Alt+Shift+M)."
-                                   FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
+                <!-- Service Configuration -->
+                <StackPanel x:Name="ServiceConfigurationSection"
+                        Spacing="12">
+                    <StackPanel Orientation="Horizontal"
+                            Spacing="8">
+                        <TextBlock x:Name="ServiceConfigurationHeaderText"
+                                Text="Service Configuration"
+                                FontSize="18"
+                                FontWeight="SemiBold"/>
+                        <FontIcon x:Name="ServiceConfigHelpIcon"
+                                Glyph="&#xE897;"
+                                FontSize="14"
+                                  Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                VerticalAlignment="Center"/>
                     </StackPanel>
-                </Border>
-            </StackPanel>
+                    <TextBlock x:Name="ServiceConfigurationDescriptionText"
+                            Text="Configure API keys, endpoints, and models for each translation service."
+                               FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
 
-            <!-- About -->
-            <StackPanel x:Name="AboutSection" Spacing="12">
-                <TextBlock x:Name="AboutHeaderText" Text="About" FontSize="18" FontWeight="SemiBold" />
-
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
-                    <StackPanel Spacing="8">
-                        <TextBlock FontWeight="SemiBold" Text="Easydict for Windows ᵇᵉᵗᵃ" />
-                        <TextBlock x:Name="VersionText" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <HyperlinkButton Content="GitHub Repository" NavigateUri="https://github.com/xiaocang/easydict_win32" />
-                        <HyperlinkButton x:Name="IssueFeedbackLink" Content="Issue Feedback" NavigateUri="https://github.com/xiaocang/easydict_win32/issues/new/choose" />
-
-                        <StackPanel Orientation="Horizontal" Spacing="4">
-                            <TextBlock Text="Inspired by" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" VerticalAlignment="Center" />
-                            <HyperlinkButton Content="Easydict for macOS" NavigateUri="https://github.com/tisfeng/Easydict" FontSize="12" Padding="0" />
+                    <!-- DeepL -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="DeepL"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="DeepLStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="DeepLKeyBox"
+                                    Header="API Key (Optional)"
+                                    Width="350"
+                                    PlaceholderText="Enter your DeepL API key"
+                                    HorizontalAlignment="Left"/>
+                            <CheckBox x:Name="DeepLFreeCheck"
+                                    Content="Use Free API (no API key required for web translation)"/>
+                            <TextBlock Text="Leave API key empty to use free web translation. Pro API key gives higher limits."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestDeepLButton"
+                                    Content="Test"
+                                    Click="OnTestDeepL"
+                                    Padding="8,4"/>
                         </StackPanel>
+                    </Expander>
 
-                        <TextBlock Text="License: GPL-3.0" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    <!-- OpenAI -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="OpenAI"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="OpenAIStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="OpenAIKeyBox"
+                                    Header="API Key"
+                                    Width="350"
+                                    PlaceholderText="sk-..."
+                                    HorizontalAlignment="Left"/>
+                            <TextBox x:Name="OpenAIEndpointBox"
+                                    Header="Endpoint (Optional)"
+                                    Width="450"
+                                     PlaceholderText="https://api.openai.com/v1/chat/completions"
+                                    HorizontalAlignment="Left"/>
+                            <ComboBox x:Name="OpenAIModelCombo"
+                                    Header="Model"
+                                    Width="280"
+                                    IsEditable="True">
+                                <ComboBoxItem Content="gpt-4o-mini"
+                                        Tag="gpt-4o-mini"/>
+                                <ComboBoxItem Content="gpt-4o"
+                                        Tag="gpt-4o"/>
+                                <ComboBoxItem Content="gpt-4-turbo"
+                                        Tag="gpt-4-turbo"/>
+                                <ComboBoxItem Content="gpt-3.5-turbo"
+                                        Tag="gpt-3.5-turbo"/>
+                            </ComboBox>
+                            <TextBlock Text="You can type a custom model name directly."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            <Button x:Name="TestOpenAIButton"
+                                    Content="Test"
+                                    Click="OnTestOpenAI"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- DeepSeek -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="DeepSeek"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="DeepSeekStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="DeepSeekKeyBox"
+                                    Header="API Key"
+                                    Width="350"
+                                    PlaceholderText="sk-..."
+                                    HorizontalAlignment="Left"/>
+                            <ComboBox x:Name="DeepSeekModelCombo"
+                                    Header="Model"
+                                    Width="280"
+                                    IsEditable="True">
+                                <ComboBoxItem Content="deepseek-chat"
+                                        Tag="deepseek-chat"/>
+                                <ComboBoxItem Content="deepseek-reasoner"
+                                        Tag="deepseek-reasoner"/>
+                            </ComboBox>
+                            <TextBlock Text="Get your API key from platform.deepseek.com. You can type a custom model name."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestDeepSeekButton"
+                                    Content="Test"
+                                    Click="OnTestDeepSeek"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Groq -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="Groq"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="GroqStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="GroqKeyBox"
+                                    Header="API Key"
+                                    Width="350"
+                                    PlaceholderText="gsk_..."
+                                    HorizontalAlignment="Left"/>
+                            <ComboBox x:Name="GroqModelCombo"
+                                    Header="Model"
+                                    Width="280"
+                                    IsEditable="True">
+                                <ComboBoxItem Content="llama-3.3-70b-versatile"
+                                        Tag="llama-3.3-70b-versatile"/>
+                                <ComboBoxItem Content="llama-3.1-8b-instant"
+                                        Tag="llama-3.1-8b-instant"/>
+                                <ComboBoxItem Content="qwen/qwen-3-32b"
+                                        Tag="qwen/qwen-3-32b"/>
+                            </ComboBox>
+                            <TextBlock Text="Groq provides fast inference. Get your API key from console.groq.com. You can type a custom model name."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestGroqButton"
+                                    Content="Test"
+                                    Click="OnTestGroq"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Zhipu (智谱) -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="Zhipu (智谱)"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="ZhipuStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="ZhipuKeyBox"
+                                    Header="API Key"
+                                    Width="350"
+                                    PlaceholderText="Enter your Zhipu API key"
+                                    HorizontalAlignment="Left"/>
+                            <ComboBox x:Name="ZhipuModelCombo"
+                                    Header="Model"
+                                    Width="280"
+                                    IsEditable="True">
+                                <ComboBoxItem Content="glm-4.5-flash"
+                                        Tag="glm-4.5-flash"/>
+                                <ComboBoxItem Content="glm-4-flash-250414"
+                                        Tag="glm-4-flash-250414"/>
+                                <ComboBoxItem Content="glm-4.7"
+                                        Tag="glm-4.7"/>
+                                <ComboBoxItem Content="glm-4.5-air"
+                                        Tag="glm-4.5-air"/>
+                            </ComboBox>
+                            <TextBlock Text="Get your API key from open.bigmodel.cn. You can type a custom model name."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestZhipuButton"
+                                    Content="Test"
+                                    Click="OnTestZhipu"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- GitHub Models -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="GitHub Models"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="GitHubModelsStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="GitHubModelsTokenBox"
+                                    Header="GitHub Token"
+                                    Width="350"
+                                    PlaceholderText="ghp_..."
+                                    HorizontalAlignment="Left"/>
+                            <ComboBox x:Name="GitHubModelsModelCombo"
+                                    Header="Model"
+                                    Width="280"
+                                    IsEditable="True">
+                                <ComboBoxItem Content="gpt-4.1"
+                                        Tag="gpt-4.1"/>
+                                <ComboBoxItem Content="gpt-4.1-mini"
+                                        Tag="gpt-4.1-mini"/>
+                                <ComboBoxItem Content="gpt-4.1-nano"
+                                        Tag="gpt-4.1-nano"/>
+                                <ComboBoxItem Content="gpt-4o"
+                                        Tag="gpt-4o"/>
+                                <ComboBoxItem Content="gpt-4o-mini"
+                                        Tag="gpt-4o-mini"/>
+                                <ComboBoxItem Content="deepseek-v3-0324"
+                                        Tag="deepseek-v3-0324"/>
+                            </ComboBox>
+                            <TextBlock Text="Use your GitHub personal access token. Get one from github.com/settings/tokens. You can type a custom model name."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestGitHubModelsButton"
+                                    Content="Test"
+                                    Click="OnTestGitHubModels"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Gemini -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="Gemini"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="GeminiStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="GeminiKeyBox"
+                                    Header="API Key"
+                                    Width="350"
+                                    PlaceholderText="Enter your Gemini API key"
+                                    HorizontalAlignment="Left"/>
+                            <ComboBox x:Name="GeminiModelCombo"
+                                    Header="Model"
+                                    Width="280"
+                                    IsEditable="True">
+                                <ComboBoxItem Content="gemini-2.5-flash"
+                                        Tag="gemini-2.5-flash"/>
+                                <ComboBoxItem Content="gemini-2.5-flash-lite"
+                                        Tag="gemini-2.5-flash-lite"/>
+                                <ComboBoxItem Content="gemini-2.5-pro"
+                                        Tag="gemini-2.5-pro"/>
+                                <ComboBoxItem Content="gemini-2.0-flash"
+                                        Tag="gemini-2.0-flash"/>
+                                <ComboBoxItem Content="gemini-1.5-flash"
+                                        Tag="gemini-1.5-flash"/>
+                                <ComboBoxItem Content="gemini-1.5-pro"
+                                        Tag="gemini-1.5-pro"/>
+                                <ComboBoxItem Content="gemini-3-flash-preview"
+                                        Tag="gemini-3-flash-preview"/>
+                                <ComboBoxItem Content="gemini-3-pro-preview"
+                                        Tag="gemini-3-pro-preview"/>
+                            </ComboBox>
+                            <TextBlock Text="Get your API key from aistudio.google.com. You can type a custom model name."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestGeminiButton"
+                                    Content="Test"
+                                    Click="OnTestGemini"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Custom OpenAI Compatible -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="Custom OpenAI Compatible"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="CustomOpenAIStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <TextBox x:Name="CustomOpenAIEndpointBox"
+                                    Header="Endpoint (Required)"
+                                    Width="450"
+                                     PlaceholderText="https://your-api.example.com/v1/chat/completions"
+                                    HorizontalAlignment="Left"/>
+                            <PasswordBox x:Name="CustomOpenAIKeyBox"
+                                    Header="API Key (Optional)"
+                                    Width="350"
+                                    PlaceholderText="Enter API key if required"
+                                    HorizontalAlignment="Left"/>
+                            <TextBox x:Name="CustomOpenAIModelBox"
+                                    Header="Model"
+                                    Width="200"
+                                     PlaceholderText="gpt-3.5-turbo"
+                                    HorizontalAlignment="Left"/>
+                            <TextBlock Text="Configure any OpenAI-compatible API endpoint (e.g., local LLM servers, other AI providers)."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestCustomOpenAIButton"
+                                    Content="Test"
+                                    Click="OnTestCustomOpenAI"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Ollama (Local) -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="Ollama (Local LLM)"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="OllamaStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <TextBox x:Name="OllamaEndpointBox"
+                                    Header="Endpoint"
+                                    Width="450"
+                                     PlaceholderText="http://localhost:11434/v1/chat/completions"
+                                    HorizontalAlignment="Left"/>
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                                <ComboBox x:Name="OllamaModelCombo"
+                                        Header="Model"
+                                        Width="200"
+                                        IsEditable="True"/>
+                                <Button x:Name="RefreshOllamaButton"
+                                        Content="Refresh"
+                                        Click="OnRefreshOllamaModels"
+                                        VerticalAlignment="Bottom"
+                                        Padding="12,6"/>
+                                <Button x:Name="TestOllamaButton"
+                                        Content="Test"
+                                        Click="OnTestOllama"
+                                        VerticalAlignment="Bottom"
+                                        Padding="8,4"/>
+                            </StackPanel>
+                            <TextBlock Text="Ollama must be running locally. Click Refresh to load available models."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Built-in AI -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="Built-in AI"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="BuiltInStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <InfoBar x:Name="BuiltInAIHintBar"
+                                     IsOpen="True"
+                                    IsClosable="False"
+                                    Severity="Informational"
+                                     Title="Hint"
+                                     Message="The built-in key has limited free quota and is not guaranteed to always be available. For stable use, get your own free API key."/>
+                            <ComboBox x:Name="BuiltInModelCombo"
+                                    Header="Model"
+                                    Width="280"
+                                    IsEditable="True">
+                                <ComboBoxItem Content="glm-4-flash-250414 (GLM)"
+                                        Tag="glm-4-flash-250414"/>
+                                <ComboBoxItem Content="glm-4-flash (GLM)"
+                                        Tag="glm-4-flash"/>
+                                <ComboBoxItem Content="llama-3.3-70b-versatile (Groq)"
+                                        Tag="llama-3.3-70b-versatile"/>
+                                <ComboBoxItem Content="llama-3.1-8b-instant (Groq)"
+                                        Tag="llama-3.1-8b-instant"/>
+                            </ComboBox>
+                            <PasswordBox x:Name="BuiltInApiKeyBox"
+                                    Header="API Key (Optional)"
+                                    Width="350"
+                                         PlaceholderText="Leave empty to use built-in key"
+                                    HorizontalAlignment="Left"/>
+                            <TextBlock x:Name="BuiltInDescriptionText"
+                                       Text="Uses GLM (Zhipu AI) or Groq free models. You can provide your own API key from open.bigmodel.cn (GLM) or console.groq.com (Groq)."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestBuiltInButton"
+                                    Content="Test"
+                                    Click="OnTestBuiltIn"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Doubao (豆包) -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="Doubao (豆包)"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="DoubaoStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="DoubaoKeyBox"
+                                    Header="API Key"
+                                    Width="350"
+                                    PlaceholderText="Enter your Doubao API key"
+                                    HorizontalAlignment="Left"/>
+                            <TextBox x:Name="DoubaoEndpointBox"
+                                    Header="Endpoint"
+                                    Width="450"
+                                     PlaceholderText="https://ark.cn-beijing.volces.com/api/v3/responses"
+                                    HorizontalAlignment="Left"/>
+                            <TextBox x:Name="DoubaoModelBox"
+                                    Header="Model"
+                                    Width="300"
+                                     PlaceholderText="doubao-seed-translation-250915"
+                                    HorizontalAlignment="Left"/>
+                            <TextBlock Text="ByteDance's Doubao translation service. Get your API key from console.volcengine.com"
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestDoubaoButton"
+                                    Content="Test"
+                                    Click="OnTestDoubao"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Caiyun (彩云小译) -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="Caiyun (彩云小译)"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="CaiyunStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="CaiyunKeyBox"
+                                    Header="API Key"
+                                    Width="350"
+                                    PlaceholderText="Enter your Caiyun API key"
+                                    HorizontalAlignment="Left"/>
+                            <TextBlock Text="Get your API key from fanyi.caiyunapp.com"
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            <Button x:Name="TestCaiyunButton"
+                                    Content="Test"
+                                    Click="OnTestCaiyun"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- NiuTrans (小牛翻译) -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <Grid>
+                                <TextBlock Text="NiuTrans (小牛翻译)"
+                                        FontWeight="SemiBold"
+                                        HorizontalAlignment="Left"/>
+                                <TextBlock x:Name="NiuTransStatusText"
+                                        Text="✅"
+                                        FontWeight="SemiBold"
+                                           Foreground="Green"
+                                        HorizontalAlignment="Right"
+                                        Margin="0,0,8,0"
+                                           Visibility="Collapsed"/>
+                            </Grid>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="NiuTransKeyBox"
+                                    Header="API Key"
+                                    Width="350"
+                                    PlaceholderText="Enter your NiuTrans API key"
+                                    HorizontalAlignment="Left"/>
+                            <TextBlock Text="NiuTrans supports 450+ language pairs. Get your API key from niutrans.com"
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <Button x:Name="TestNiuTransButton"
+                                    Content="Test"
+                                    Click="OnTestNiuTrans"
+                                    Padding="8,4"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Youdao (有道翻译) -->
+                    <Expander HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Expander.Header>
+                            <TextBlock Text="Youdao (有道翻译)"
+                                    FontWeight="SemiBold"/>
+                        </Expander.Header>
+                        <StackPanel Spacing="12"
+                                Padding="0,8">
+                            <PasswordBox x:Name="YoudaoAppKeyBox"
+                                    Header="App Key"
+                                    Width="350"
+                                    PlaceholderText="Enter your Youdao App Key"
+                                    HorizontalAlignment="Left"/>
+                            <PasswordBox x:Name="YoudaoAppSecretBox"
+                                    Header="App Secret"
+                                    Width="350"
+                                    PlaceholderText="Enter your Youdao App Secret"
+                                    HorizontalAlignment="Left"/>
+                            <ToggleSwitch x:Name="YoudaoUseOfficialApiToggle"
+                                    Header="Use Official API"/>
+                            <TextBlock Text="Youdao provides phonetic transcriptions for English words. Without API keys, uses free web dictionary. With API keys, enables official API for higher limits. Get API keys from ai.youdao.com"
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Expander>
+
+                    <!-- Imported MDX Dictionaries (dynamically populated) -->
+                    <StackPanel x:Name="ImportedMdxConfigPanel"
+                            Spacing="8"/>
+
+                    <!-- Google Translate & Linguee (No configuration needed) -->
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="8">
+                            <TextBlock x:Name="FreeServicesHeaderText"
+                                    Text="Free Services (No Configuration Required)"
+                                    FontWeight="SemiBold"/>
+                            <TextBlock x:Name="FreeServicesDescriptionText"
+                                    Text="Google Translate and Linguee Dictionary work out of the box without API keys."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Layout Detection (Long Document) -->
+                <StackPanel x:Name="LayoutDetectionSection"
+                        Spacing="12">
+                    <TextBlock x:Name="LayoutDetectionHeaderText"
+                            Text="Layout Detection"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
+                    <TextBlock x:Name="LayoutDetectionDescriptionText"
+                               Text="ML-based layout detection for long document translation. Improves accuracy for academic papers with figures, tables, and formulas."
+                               FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            TextWrapping="Wrap"/>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="16">
+                            <ComboBox x:Name="LayoutDetectionModeCombo"
+                                    Header="Detection Mode"
+                                    Width="300">
+                                <ComboBoxItem x:Name="LayoutDetectionAutoItem"
+                                        Content="Auto (Recommended)"
+                                        Tag="Auto"/>
+                                <ComboBoxItem x:Name="LayoutDetectionOnnxItem"
+                                        Content="Local ONNX Model"
+                                        Tag="OnnxLocal"/>
+                                <ComboBoxItem x:Name="LayoutDetectionVisionItem"
+                                        Content="Vision LLM"
+                                        Tag="VisionLLM"/>
+                                <ComboBoxItem x:Name="LayoutDetectionHeuristicItem"
+                                        Content="Heuristic Only"
+                                        Tag="Heuristic"/>
+                            </ComboBox>
+
+                            <!-- ONNX Model Download -->
+                            <StackPanel x:Name="OnnxModelPanel"
+                                    Spacing="8">
+                                <StackPanel Orientation="Horizontal"
+                                        Spacing="8"
+                                        VerticalAlignment="Center">
+                                    <TextBlock x:Name="OnnxModelStatusText"
+                                            Text="ONNX Model: Not Downloaded"
+                                            VerticalAlignment="Center"/>
+                                    <FontIcon x:Name="OnnxModelStatusIcon"
+                                            Glyph="&#xE946;"
+                                            FontSize="14"
+                                            Visibility="Collapsed"
+                                              Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                            VerticalAlignment="Center"/>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal"
+                                        Spacing="8">
+                                    <Button x:Name="DownloadOnnxModelButton"
+                                            Content="Download Model (~75MB)"
+                                            Click="OnDownloadOnnxModelClick"/>
+                                    <Button x:Name="DeleteOnnxModelButton"
+                                            Content="Delete"
+                                            Click="OnDeleteOnnxModelClick"
+                                            Visibility="Collapsed"/>
+                                </StackPanel>
+                                <ProgressBar x:Name="OnnxDownloadProgress"
+                                        Visibility="Collapsed"
+                                        Minimum="0"
+                                        Maximum="100"/>
+                                <TextBlock x:Name="OnnxDownloadProgressText"
+                                        Visibility="Collapsed"
+                                           FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            </StackPanel>
+
+                            <!-- Vision LLM Service Selection (visible when VisionLLM mode selected) -->
+                            <StackPanel x:Name="VisionLLMPanel"
+                                    Spacing="8"
+                                    Visibility="Collapsed">
+                                <ComboBox x:Name="VisionLayoutServiceCombo"
+                                        Header="Vision Service"
+                                        Width="300">
+                                    <ComboBoxItem Content="OpenAI (GPT-4o)"
+                                            Tag="openai"/>
+                                    <ComboBoxItem Content="Gemini"
+                                            Tag="gemini"/>
+                                    <ComboBoxItem Content="Custom OpenAI"
+                                            Tag="custom_openai"/>
+                                </ComboBox>
+                                <TextBlock Text="Requires a configured API key for the selected service."
+                                           FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- CJK Font -->
+                <StackPanel x:Name="CjkFontSection"
+                        Spacing="12">
+                    <TextBlock x:Name="CjkFontHeaderText"
+                            Text="CJK Font"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
+                    <TextBlock x:Name="CjkFontDescriptionText"
+                               Text="Download CJK fonts for proper Chinese, Japanese, and Korean text rendering in PDF output."
+                               FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            TextWrapping="Wrap"/>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="16">
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="12">
+                                <Button x:Name="CjkFontDownloadButton"
+                                        Content="Download CJK Font"
+                                        Click="OnCjkFontDownloadClick"/>
+                                <Button x:Name="CjkFontDeleteButton"
+                                        Content="Delete"
+                                        Click="OnCjkFontDeleteClick"/>
+                            </StackPanel>
+                            <ProgressBar x:Name="CjkFontProgressBar"
+                                    Visibility="Collapsed"
+                                    Minimum="0"
+                                    Maximum="100"/>
+                            <TextBlock x:Name="CjkFontStatusText"
+                                    Text=""
+                                    FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                            <TextBlock x:Name="CjkFontNoteText"
+                                       Text="Downloads Noto Sans CJK (~16MB per language). Required for CJK text in PDF overlay rendering."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Formula Detection -->
+                <StackPanel x:Name="FormulaDetectionSection"
+                        Spacing="12">
+                    <TextBlock x:Name="FormulaDetectionHeaderText"
+                            Text="Formula Detection"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
+                    <TextBlock x:Name="FormulaDetectionDescriptionText"
+                               Text="Advanced formula detection uses font names and Unicode math characters to protect formulas from translation."
+                               FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            TextWrapping="Wrap"/>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="16">
+                            <TextBox x:Name="FormulaFontPatternBox"
+                                    Header="Font Pattern (Regex)"
+                                     Width="450"
+                                    PlaceholderText="e.g. CMSY|CMMI|Symbol|Mathematica"
+                                     HorizontalAlignment="Left"
+                                    TextChanged="OnFormulaPatternChanged"/>
+                            <TextBox x:Name="FormulaCharPatternBox"
+                                    Header="Character Pattern (Regex)"
+                                     Width="450"
+                                    PlaceholderText="e.g. [\u2200-\u22FF\u0370-\u03FF]"
+                                     HorizontalAlignment="Left"
+                                    TextChanged="OnFormulaPatternChanged"/>
+                            <TextBlock x:Name="FormulaDetectionNoteText"
+                                       Text="Leave empty to use built-in patterns. Font pattern matches PDF font names (Level 2). Character pattern matches Unicode ranges (Level 3)."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Translation Cache -->
+                <StackPanel x:Name="TranslationCacheSection"
+                        Spacing="12">
+                    <TextBlock x:Name="TranslationCacheHeaderText"
+                            Text="Translation Cache"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
+                    <TextBlock x:Name="TranslationCacheDescriptionText"
+                               Text="Cache translated segments locally to speed up repeated translations and save API costs."
+                               FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            TextWrapping="Wrap"/>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="16">
+                            <ToggleSwitch x:Name="TranslationCacheToggle"
+                                    Header="Enable Translation Cache"
+                                          Toggled="OnTranslationCacheToggled"/>
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="12">
+                                <Button x:Name="ClearCacheButton"
+                                        Content="Clear Cache"
+                                        Click="OnClearCacheClick"/>
+                                <TextBlock x:Name="CacheStatusText"
+                                        Text=""
+                                        VerticalAlignment="Center"
+                                           FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            </StackPanel>
+                            <TextBlock x:Name="TranslationCacheNoteText"
+                                       Text="Cached translations are stored locally in SQLite. Clear cache if translations become stale."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Custom LLM Prompt -->
+                <StackPanel x:Name="CustomPromptSection"
+                        Spacing="12">
+                    <TextBlock x:Name="CustomPromptHeaderText"
+                            Text="Custom Translation Prompt"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
+                    <TextBlock x:Name="CustomPromptDescriptionText"
+                               Text="Add custom instructions for LLM-based translation services (OpenAI, DeepSeek, Gemini, etc.)."
+                               FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            TextWrapping="Wrap"/>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="16">
+                            <TextBox x:Name="CustomPromptBox"
+                                    Header="Additional Instructions"
+                                     Width="450"
+                                    Height="120"
+                                    AcceptsReturn="True"
+                                    TextWrapping="Wrap"
+                                     PlaceholderText="e.g. You are translating a medical research paper. Preserve all LaTeX commands and scientific terminology."
+                                     HorizontalAlignment="Left"
+                                    TextChanged="OnCustomPromptChanged"/>
+                            <TextBlock x:Name="CustomPromptNoteText"
+                                       Text="These instructions are appended to the system prompt for LLM services. Has no effect on non-LLM services (Google, DeepL, etc.)."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- HTTP Proxy -->
+                <StackPanel x:Name="HttpProxySection"
+                        Spacing="12">
+                    <TextBlock x:Name="HttpProxyHeaderText"
+                            Text="HTTP Proxy"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="16">
+                            <ToggleSwitch x:Name="ProxyEnabledToggle"
+                                    Header="Use HTTP Proxy"/>
+                            <TextBox x:Name="ProxyUriBox"
+                                    Header="Proxy URL"
+                                    Width="300"
+                                     PlaceholderText="http://127.0.0.1:7890"/>
+                            <ToggleSwitch x:Name="ProxyBypassLocalToggle"
+                                    Header="Bypass proxy for localhost"
+                                    IsOn="True"/>
+                            <TextBlock Text="Proxy changes take effect after app restart. Localhost bypass ensures Ollama works without proxy."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Behavior -->
+                <StackPanel x:Name="BehaviorSection"
+                        Spacing="12">
+                    <TextBlock x:Uid="BehaviorHeader"
+                            Text="Behavior"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="12">
+                            <!-- App Theme -->
+                            <ComboBox
+                                x:Name="AppThemeCombo"
+                                Header="App Theme"
+                                Width="250"
+                                SelectionChanged="OnAppThemeChanged"
+                                HorizontalAlignment="Left">
+                                <ComboBoxItem Content="System"
+                                        Tag="System"/>
+                                <ComboBoxItem Content="Light"
+                                        Tag="Light"/>
+                                <ComboBoxItem Content="Dark"
+                                        Tag="Dark"/>
+                            </ComboBox>
+                            <TextBlock
+                                x:Name="AppThemeDescriptionText"
+                                Text="Choose how Easydict appears. Select System to follow Windows theme."
+                                FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+
+                            <!-- UI Language -->
+                            <ComboBox
+                                x:Name="UILanguageCombo"
+                                x:Uid="UILanguageCombo"
+                                Header="UI Language"
+                                Width="250"
+                                SelectionChanged="OnUILanguageChanged"
+                                HorizontalAlignment="Left">
+                                <ComboBoxItem x:Uid="UILangEnglishItem"
+                                        Content="English"
+                                        Tag="en-US"/>
+                                <ComboBoxItem x:Uid="UILangChineseItem"
+                                        Content="简体中文"
+                                        Tag="zh-CN"/>
+                                <ComboBoxItem x:Uid="UILangTraditionalChineseItem"
+                                        Content="繁體中文"
+                                        Tag="zh-TW"/>
+                                <ComboBoxItem x:Uid="UILangJapaneseItem"
+                                        Content="日本語"
+                                        Tag="ja-JP"/>
+                                <ComboBoxItem x:Uid="UILangKoreanItem"
+                                        Content="한국어"
+                                        Tag="ko-KR"/>
+                                <ComboBoxItem x:Uid="UILangFrenchItem"
+                                        Content="Français"
+                                        Tag="fr-FR"/>
+                                <ComboBoxItem x:Uid="UILangGermanItem"
+                                        Content="Deutsch"
+                                        Tag="de-DE"/>
+                                <ComboBoxItem x:Uid="UILangVietnameseItem"
+                                        Content="Tiếng Việt"
+                                        Tag="vi-VN"/>
+                                <ComboBoxItem x:Uid="UILangThaiItem"
+                                        Content="ไทย"
+                                        Tag="th-TH"/>
+                                <ComboBoxItem x:Uid="UILangArabicItem"
+                                        Content="العربية"
+                                        Tag="ar-SA"/>
+                                <ComboBoxItem x:Uid="UILangIndonesianItem"
+                                        Content="Bahasa Indonesia"
+                                        Tag="id-ID"/>
+                                <ComboBoxItem x:Uid="UILangItalianItem"
+                                        Content="Italiano"
+                                        Tag="it-IT"/>
+                                <ComboBoxItem x:Uid="UILangMalayItem"
+                                        Content="Bahasa Melayu"
+                                        Tag="ms-MY"/>
+                                <ComboBoxItem x:Uid="UILangHindiItem"
+                                        Content="हिन्दी"
+                                        Tag="hi-IN"/>
+                                <ComboBoxItem x:Uid="UILangDanishItem"
+                                        Content="Dansk"
+                                        Tag="da-DK"/>
+                            </ComboBox>
+                            <TextBlock x:Uid="UILanguageDescription"
+                                       Text="Select the display language for the application interface. Restart required."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+
+                            <ToggleSwitch x:Name="MinimizeToTrayToggle"
+                                    x:Uid="MinimizeToTrayToggle"
+                                    Header="Minimize to system tray"/>
+                            <ToggleSwitch x:Name="MinimizeToTrayOnStartupToggle"
+                                    x:Uid="MinimizeToTrayOnStartupToggle"
+                                    Header="Start minimized to tray"/>
+                            <ToggleSwitch x:Name="ClipboardMonitorToggle"
+                                    x:Uid="ClipboardMonitorToggle"
+                                    Header="Monitor clipboard for text"/>
+                            <ToggleSwitch x:Name="MouseSelectionTranslateToggle"
+                                    x:Uid="MouseSelectionTranslateToggle"
+                                    Header="Mouse selection translate"/>
+                            <StackPanel x:Name="MouseSelectionExcludedAppsPanel"
+                                    Spacing="4"
+                                    Margin="44,0,0,0"
+                                        Visibility="Collapsed">
+                                <TextBox x:Name="MouseSelectionExcludedAppsBox"
+                                         x:Uid="MouseSelectionExcludedAppsBox"
+                                         Header="Excluded apps"
+                                         PlaceholderText="code, slack, discord"
+                                         Width="350"
+                                         HorizontalAlignment="Left"/>
+                                <TextBlock x:Uid="MouseSelectionExcludedAppsDescription"
+                                           Text="Process names to exclude, separated by commas."
+                                           FontSize="11"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           TextWrapping="Wrap"
+                                           MaxWidth="350"
+                                           HorizontalAlignment="Left"/>
+                            </StackPanel>
+                            <ToggleSwitch x:Name="AlwaysOnTopToggle"
+                                    x:Uid="AlwaysOnTopToggle"
+                                    Header="Always on top"/>
+                            <ToggleSwitch x:Name="LaunchAtStartupToggle"
+                                    x:Uid="LaunchAtStartupToggle"
+                                    Header="Launch at Windows startup"/>
+                            <ToggleSwitch x:Name="HideEmptyServiceResultsToggle"
+                                    Header="Hide dictionaries with no result"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Hotkeys -->
+                <StackPanel x:Name="HotkeysSection"
+                        Spacing="12">
+                    <StackPanel Orientation="Horizontal"
+                            Spacing="8">
+                        <TextBlock x:Name="HotkeysHeaderText"
+                                Text="Hotkeys"
+                                FontSize="18"
+                                FontWeight="SemiBold"/>
+                        <FontIcon x:Name="HotkeysHelpIcon"
+                                Glyph="&#xE897;"
+                                FontSize="14"
+                                  Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                VerticalAlignment="Center"/>
                     </StackPanel>
-                </Border>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="16">
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="12"
+                                    VerticalAlignment="Bottom">
+                                <TextBox x:Name="ShowHotkeyBox"
+                                        Header="Show Window"
+                                        Width="200"
+                                        PlaceholderText="Ctrl+Alt+T"/>
+                                <ToggleSwitch x:Name="ShowHotkeyEnabledToggle"
+                                        OnContent=""
+                                        OffContent=""
+                                        VerticalAlignment="Bottom"
+                                        Margin="0,0,0,4"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="12"
+                                    VerticalAlignment="Bottom">
+                                <TextBox x:Name="TranslateHotkeyBox"
+                                        Header="Translate Selection"
+                                        Width="200"
+                                        PlaceholderText="Ctrl+Alt+D"/>
+                                <ToggleSwitch x:Name="TranslateHotkeyEnabledToggle"
+                                        OnContent=""
+                                        OffContent=""
+                                        VerticalAlignment="Bottom"
+                                        Margin="0,0,0,4"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="12"
+                                    VerticalAlignment="Bottom">
+                                <TextBox x:Name="ShowMiniHotkeyBox"
+                                        Header="Show Mini Window"
+                                        Width="200"
+                                        PlaceholderText="Ctrl+Alt+M"/>
+                                <ToggleSwitch x:Name="ShowMiniHotkeyEnabledToggle"
+                                        OnContent=""
+                                        OffContent=""
+                                        VerticalAlignment="Bottom"
+                                        Margin="0,0,0,4"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="12"
+                                    VerticalAlignment="Bottom">
+                                <TextBox x:Name="ShowFixedHotkeyBox"
+                                        Header="Show Fixed Window"
+                                        Width="200"
+                                        PlaceholderText="Ctrl+Alt+F"/>
+                                <ToggleSwitch x:Name="ShowFixedHotkeyEnabledToggle"
+                                        OnContent=""
+                                        OffContent=""
+                                        VerticalAlignment="Bottom"
+                                        Margin="0,0,0,4"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="12"
+                                    VerticalAlignment="Bottom">
+                                <TextBox x:Name="OcrTranslateHotkeyBox"
+                                        Header="OCR Screenshot Translate"
+                                        Width="200"
+                                        PlaceholderText="Ctrl+Alt+S"/>
+                                <ToggleSwitch x:Name="OcrTranslateHotkeyEnabledToggle"
+                                        OnContent=""
+                                        OffContent=""
+                                        VerticalAlignment="Bottom"
+                                        Margin="0,0,0,4"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="12"
+                                    VerticalAlignment="Bottom">
+                                <TextBox x:Name="SilentOcrHotkeyBox"
+                                        Header="Silent OCR"
+                                        Width="200"
+                                        PlaceholderText="Ctrl+Alt+Shift+S"/>
+                                <ToggleSwitch x:Name="SilentOcrHotkeyEnabledToggle"
+                                        OnContent=""
+                                        OffContent=""
+                                        VerticalAlignment="Bottom"
+                                        Margin="0,0,0,4"/>
+                            </StackPanel>
+                            <TextBlock x:Name="HotkeysDescriptionText"
+                                    Text="Note: Restart app to apply hotkey changes. Toggle hotkeys use the same key with Shift added (e.g., Ctrl+Alt+Shift+M)."
+                                       FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- About -->
+                <StackPanel x:Name="AboutSection"
+                        Spacing="12">
+                    <TextBlock x:Name="AboutHeaderText"
+                            Text="About"
+                            FontSize="18"
+                            FontWeight="SemiBold"/>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Padding="16">
+                        <StackPanel Spacing="8">
+                            <TextBlock FontWeight="SemiBold"
+                                    Text="Easydict for Windows ᵇᵉᵗᵃ"/>
+                            <TextBlock x:Name="VersionText"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            <HyperlinkButton Content="GitHub Repository"
+                                    NavigateUri="https://github.com/xiaocang/easydict_win32"/>
+                            <HyperlinkButton x:Name="IssueFeedbackLink"
+                                    Content="Issue Feedback"
+                                    NavigateUri="https://github.com/xiaocang/easydict_win32/issues/new/choose"/>
+
+                            <StackPanel Orientation="Horizontal"
+                                    Spacing="4">
+                                <TextBlock Text="Inspired by"
+                                        FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        VerticalAlignment="Center"/>
+                                <HyperlinkButton Content="Easydict for macOS"
+                                        NavigateUri="https://github.com/tisfeng/Easydict"
+                                        FontSize="12"
+                                        Padding="0"/>
+                            </StackPanel>
+
+                            <TextBlock Text="License: GPL-3.0"
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Spacer to make room for floating save button -->
+                <Border Height="80"/>
             </StackPanel>
+        </ScrollViewer>
 
-            <!-- Spacer to make room for floating save button -->
-            <Border Height="80" />
-        </StackPanel>
-    </ScrollViewer>
+        <!-- Floating Save Button (fixed at bottom-right) -->
+        <Button x:Name="SaveButton"
+                Grid.Column="1"
+                Content="Save Settings"
+                Click="OnSaveClick"
+                Style="{StaticResource AccentButtonStyle}"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                Margin="0,0,32,32"
+                Padding="24,12"
+                Visibility="Collapsed">
+            <Button.Shadow>
+                <ThemeShadow/>
+            </Button.Shadow>
+        </Button>
 
-    <!-- Floating Save Button (fixed at bottom-right) -->
-    <Button x:Name="SaveButton"
-            Grid.Column="1"
-            Content="Save Settings"
-            Click="OnSaveClick"
-            Style="{StaticResource AccentButtonStyle}"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Bottom"
-            Margin="0,0,32,32"
-            Padding="24,12"
-            Visibility="Collapsed">
-        <Button.Shadow>
-            <ThemeShadow />
-        </Button.Shadow>
-    </Button>
+        <!-- Floating Navigation Sidebar (left side, vertically centered) -->
+        <Border x:Name="NavSidebar"
+                Grid.Column="0"
+                Width="36"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Margin="0"
+                CornerRadius="12"
+                Padding="6,10"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                Opacity="0.9"
+                Visibility="Collapsed">
+            <Border.Shadow>
+                <ThemeShadow/>
+            </Border.Shadow>
+            <StackPanel x:Name="NavIndicators"
+                    Spacing="12">
+                <!-- Nav dots created programmatically -->
+            </StackPanel>
+        </Border>
 
-    <!-- Floating Navigation Sidebar (left side, vertically centered) -->
-    <Border x:Name="NavSidebar"
-            Grid.Column="0"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            Margin="0"
-            CornerRadius="12"
-            Padding="6,10"
-            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-            Opacity="0.9"
-            Visibility="Collapsed">
-        <Border.Shadow>
-            <ThemeShadow />
-        </Border.Shadow>
-        <StackPanel x:Name="NavIndicators" Spacing="12">
-            <!-- Nav dots created programmatically -->
-        </StackPanel>
-    </Border>
+        <!-- Floating Back Button (top-left, collapsed by default) -->
+        <Button x:Name="FloatingBackButton"
+                Grid.Column="1"
+                Click="OnBackClick"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Margin="8,8,0,0"
+                Width="36"
+                Height="36"
+                Padding="0"
+                CornerRadius="18"
+                Visibility="Collapsed"
+                ToolTipService.ToolTip="Back">
+            <FontIcon Glyph="&#xE72B;"
+                    FontSize="14"/>
+            <Button.Shadow>
+                <ThemeShadow/>
+            </Button.Shadow>
+        </Button>
 
-    <!-- Floating Back Button (top-left, collapsed by default) -->
-    <Button x:Name="FloatingBackButton"
-            Grid.Column="1"
-            Click="OnBackClick"
-            HorizontalAlignment="Left"
-            VerticalAlignment="Top"
-            Margin="8,8,0,0"
-            Width="36"
-            Height="36"
-            Padding="0"
-            CornerRadius="18"
-            Visibility="Collapsed"
-            ToolTipService.ToolTip="Back">
-        <FontIcon Glyph="&#xE72B;" FontSize="14" />
-        <Button.Shadow>
-            <ThemeShadow />
-        </Button.Shadow>
-    </Button>
-
-    <!-- Back to Top Button (bottom-left, collapsed by default) -->
-    <Button x:Name="BackToTopButton"
-            Grid.Column="1"
-            Click="OnBackToTopClick"
-            HorizontalAlignment="Left"
-            VerticalAlignment="Bottom"
-            Margin="8,0,0,32"
-            Width="32"
-            Height="32"
-            Padding="0"
-            CornerRadius="16"
-            Visibility="Collapsed"
-            ToolTipService.ToolTip="Back to top">
-        <FontIcon Glyph="&#xE70E;" FontSize="14" />
-        <Button.Shadow>
-            <ThemeShadow />
-        </Button.Shadow>
-    </Button>
-</Grid>
+        <!-- Back to Top Button (bottom-left, collapsed by default) -->
+        <Button x:Name="BackToTopButton"
+                Grid.Column="1"
+                Click="OnBackToTopClick"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Bottom"
+                Margin="8,0,0,32"
+                Width="32"
+                Height="32"
+                Padding="0"
+                CornerRadius="16"
+                Visibility="Collapsed"
+                ToolTipService.ToolTip="Back to top">
+            <FontIcon Glyph="&#xE70E;"
+                    FontSize="14"/>
+            <Button.Shadow>
+                <ThemeShadow/>
+            </Button.Shadow>
+        </Button>
+    </Grid>
 </Page>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -163,6 +163,8 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <CheckBox
                                             Content="{Binding DisplayName}"
@@ -179,6 +181,24 @@
                                             IsEnabled="{Binding IsAvailable}"
                                             MinWidth="0"
                                             Margin="8,0,0,0" />
+                                        <Button
+                                            Grid.Column="2"
+                                            Click="OnMoveMainServiceUp"
+                                            Tag="{Binding ServiceId}"
+                                            ToolTipService.ToolTip="Move up"
+                                            Width="32" Height="28" Padding="0"
+                                            Margin="4,0,0,0">
+                                            <FontIcon Glyph="&#xE70E;" FontSize="12" />
+                                        </Button>
+                                        <Button
+                                            Grid.Column="3"
+                                            Click="OnMoveMainServiceDown"
+                                            Tag="{Binding ServiceId}"
+                                            ToolTipService.ToolTip="Move down"
+                                            Width="32" Height="28" Padding="0"
+                                            Margin="2,0,0,0">
+                                            <FontIcon Glyph="&#xE70D;" FontSize="12" />
+                                        </Button>
                                     </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
@@ -197,6 +217,8 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <CheckBox
                                             Content="{Binding DisplayName}"
@@ -213,6 +235,24 @@
                                             IsEnabled="{Binding IsAvailable}"
                                             MinWidth="0"
                                             Margin="8,0,0,0" />
+                                        <Button
+                                            Grid.Column="2"
+                                            Click="OnMoveMiniServiceUp"
+                                            Tag="{Binding ServiceId}"
+                                            ToolTipService.ToolTip="Move up"
+                                            Width="32" Height="28" Padding="0"
+                                            Margin="4,0,0,0">
+                                            <FontIcon Glyph="&#xE70E;" FontSize="12" />
+                                        </Button>
+                                        <Button
+                                            Grid.Column="3"
+                                            Click="OnMoveMiniServiceDown"
+                                            Tag="{Binding ServiceId}"
+                                            ToolTipService.ToolTip="Move down"
+                                            Width="32" Height="28" Padding="0"
+                                            Margin="2,0,0,0">
+                                            <FontIcon Glyph="&#xE70D;" FontSize="12" />
+                                        </Button>
                                     </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
@@ -231,6 +271,8 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <CheckBox
                                             Content="{Binding DisplayName}"
@@ -247,6 +289,24 @@
                                             IsEnabled="{Binding IsAvailable}"
                                             MinWidth="0"
                                             Margin="8,0,0,0" />
+                                        <Button
+                                            Grid.Column="2"
+                                            Click="OnMoveFixedServiceUp"
+                                            Tag="{Binding ServiceId}"
+                                            ToolTipService.ToolTip="Move up"
+                                            Width="32" Height="28" Padding="0"
+                                            Margin="4,0,0,0">
+                                            <FontIcon Glyph="&#xE70E;" FontSize="12" />
+                                        </Button>
+                                        <Button
+                                            Grid.Column="3"
+                                            Click="OnMoveFixedServiceDown"
+                                            Tag="{Binding ServiceId}"
+                                            ToolTipService.ToolTip="Move down"
+                                            Width="32" Height="28" Padding="0"
+                                            Margin="2,0,0,0">
+                                            <FontIcon Glyph="&#xE70D;" FontSize="12" />
+                                        </Button>
                                     </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
@@ -817,6 +877,7 @@
                         </StackPanel>
                         <ToggleSwitch x:Name="AlwaysOnTopToggle" x:Uid="AlwaysOnTopToggle" Header="Always on top" />
                         <ToggleSwitch x:Name="LaunchAtStartupToggle" x:Uid="LaunchAtStartupToggle" Header="Launch at Windows startup" />
+                        <ToggleSwitch x:Name="HideEmptyServiceResultsToggle" Header="Hide dictionaries with no result" />
                     </StackPanel>
                 </Border>
             </StackPanel>
@@ -831,12 +892,30 @@
 
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
                     <StackPanel Spacing="16">
-                        <TextBox x:Name="ShowHotkeyBox" Header="Show Window" Width="200" PlaceholderText="Ctrl+Alt+T" />
-                        <TextBox x:Name="TranslateHotkeyBox" Header="Translate Selection" Width="200" PlaceholderText="Ctrl+Alt+D" />
-                        <TextBox x:Name="ShowMiniHotkeyBox" Header="Show Mini Window" Width="200" PlaceholderText="Ctrl+Alt+M" />
-                        <TextBox x:Name="ShowFixedHotkeyBox" Header="Show Fixed Window" Width="200" PlaceholderText="Ctrl+Alt+F" />
-                        <TextBox x:Name="OcrTranslateHotkeyBox" Header="OCR Screenshot Translate" Width="200" PlaceholderText="Ctrl+Alt+S" />
-                        <TextBox x:Name="SilentOcrHotkeyBox" Header="Silent OCR" Width="200" PlaceholderText="Ctrl+Alt+Shift+S" />
+                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
+                            <TextBox x:Name="ShowHotkeyBox" Header="Show Window" Width="200" PlaceholderText="Ctrl+Alt+T" />
+                            <ToggleSwitch x:Name="ShowHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
+                            <TextBox x:Name="TranslateHotkeyBox" Header="Translate Selection" Width="200" PlaceholderText="Ctrl+Alt+D" />
+                            <ToggleSwitch x:Name="TranslateHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
+                            <TextBox x:Name="ShowMiniHotkeyBox" Header="Show Mini Window" Width="200" PlaceholderText="Ctrl+Alt+M" />
+                            <ToggleSwitch x:Name="ShowMiniHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
+                            <TextBox x:Name="ShowFixedHotkeyBox" Header="Show Fixed Window" Width="200" PlaceholderText="Ctrl+Alt+F" />
+                            <ToggleSwitch x:Name="ShowFixedHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
+                            <TextBox x:Name="OcrTranslateHotkeyBox" Header="OCR Screenshot Translate" Width="200" PlaceholderText="Ctrl+Alt+S" />
+                            <ToggleSwitch x:Name="OcrTranslateHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Bottom">
+                            <TextBox x:Name="SilentOcrHotkeyBox" Header="Silent OCR" Width="200" PlaceholderText="Ctrl+Alt+Shift+S" />
+                            <ToggleSwitch x:Name="SilentOcrHotkeyEnabledToggle" OnContent="" OffContent="" VerticalAlignment="Bottom" Margin="0,0,0,4" />
+                        </StackPanel>
                         <TextBlock x:Name="HotkeysDescriptionText" Text="Note: Restart app to apply hotkey changes. Toggle hotkeys use the same key with Shift added (e.g., Ctrl+Alt+Shift+M)."
                                    FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
                     </StackPanel>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -115,6 +115,12 @@
                 <TextBlock x:Name="EnabledServicesDescriptionText" Text="Select which translation services to display in each window. Multiple services will run in parallel."
                            FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
 
+                <Button x:Name="ServiceReorderModeButton"
+                        Content="Reorder"
+                        Click="OnToggleServiceReorderModeClicked"
+                        HorizontalAlignment="Left"
+                        Padding="10,4" />
+
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <Button x:Name="ImportMdxDictionaryButton"
                             Content="Import MDX Dictionary"
@@ -186,6 +192,7 @@
                                             Click="OnMoveMainServiceUp"
                                             Tag="{Binding ServiceId}"
                                             ToolTipService.ToolTip="Move up"
+                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
                                             Width="32" Height="28" Padding="0"
                                             Margin="4,0,0,0">
                                             <FontIcon Glyph="&#xE70E;" FontSize="12" />
@@ -195,6 +202,7 @@
                                             Click="OnMoveMainServiceDown"
                                             Tag="{Binding ServiceId}"
                                             ToolTipService.ToolTip="Move down"
+                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
                                             Width="32" Height="28" Padding="0"
                                             Margin="2,0,0,0">
                                             <FontIcon Glyph="&#xE70D;" FontSize="12" />
@@ -240,6 +248,7 @@
                                             Click="OnMoveMiniServiceUp"
                                             Tag="{Binding ServiceId}"
                                             ToolTipService.ToolTip="Move up"
+                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
                                             Width="32" Height="28" Padding="0"
                                             Margin="4,0,0,0">
                                             <FontIcon Glyph="&#xE70E;" FontSize="12" />
@@ -249,6 +258,7 @@
                                             Click="OnMoveMiniServiceDown"
                                             Tag="{Binding ServiceId}"
                                             ToolTipService.ToolTip="Move down"
+                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
                                             Width="32" Height="28" Padding="0"
                                             Margin="2,0,0,0">
                                             <FontIcon Glyph="&#xE70D;" FontSize="12" />
@@ -294,6 +304,7 @@
                                             Click="OnMoveFixedServiceUp"
                                             Tag="{Binding ServiceId}"
                                             ToolTipService.ToolTip="Move up"
+                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
                                             Width="32" Height="28" Padding="0"
                                             Margin="4,0,0,0">
                                             <FontIcon Glyph="&#xE70E;" FontSize="12" />
@@ -303,6 +314,7 @@
                                             Click="OnMoveFixedServiceDown"
                                             Tag="{Binding ServiceId}"
                                             ToolTipService.ToolTip="Move down"
+                                            Visibility="{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
                                             Width="32" Height="28" Padding="0"
                                             Margin="2,0,0,0">
                                             <FontIcon Glyph="&#xE70D;" FontSize="12" />

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -115,12 +115,6 @@
                 <TextBlock x:Name="EnabledServicesDescriptionText" Text="Select which translation services to display in each window. Multiple services will run in parallel."
                            FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" />
 
-                <Button x:Name="ServiceReorderModeButton"
-                        Content="Reorder"
-                        Click="OnToggleServiceReorderModeClicked"
-                        HorizontalAlignment="Left"
-                        Padding="10,4" />
-
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <Button x:Name="ImportMdxDictionaryButton"
                             Content="Import MDX Dictionary"
@@ -161,7 +155,13 @@
                 <!-- Main Window Services -->
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
                     <StackPanel Spacing="12">
-                        <TextBlock x:Name="MainWindowHeaderText" Text="Main Window" FontWeight="SemiBold" FontSize="14" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button x:Name="MainWindowReorderModeButton"
+                                    Click="OnToggleMainWindowReorderModeClicked"
+                                    Padding="8,2"
+                                    VerticalAlignment="Center" />
+                            <TextBlock x:Name="MainWindowHeaderText" Text="Main Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
+                        </StackPanel>
                         <ItemsControl x:Name="MainWindowServicesPanel">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
@@ -217,7 +217,13 @@
                 <!-- Mini Window Services -->
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
                     <StackPanel Spacing="12">
-                        <TextBlock x:Name="MiniWindowHeaderText" Text="Mini Window" FontWeight="SemiBold" FontSize="14" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button x:Name="MiniWindowReorderModeButton"
+                                    Click="OnToggleMiniWindowReorderModeClicked"
+                                    Padding="8,2"
+                                    VerticalAlignment="Center" />
+                            <TextBlock x:Name="MiniWindowHeaderText" Text="Mini Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
+                        </StackPanel>
                         <ItemsControl x:Name="MiniWindowServicesPanel">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
@@ -273,7 +279,13 @@
                 <!-- Fixed Window Services -->
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
                     <StackPanel Spacing="12">
-                        <TextBlock x:Name="FixedWindowHeaderText" Text="Fixed Window" FontWeight="SemiBold" FontSize="14" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button x:Name="FixedWindowReorderModeButton"
+                                    Click="OnToggleFixedWindowReorderModeClicked"
+                                    Padding="8,2"
+                                    VerticalAlignment="Center" />
+                            <TextBlock x:Name="FixedWindowHeaderText" Text="Fixed Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
+                        </StackPanel>
                         <ItemsControl x:Name="FixedWindowServicesPanel">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -156,11 +156,11 @@
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
                     <StackPanel Spacing="12">
                         <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock x:Name="MainWindowHeaderText" Text="Main Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
                             <Button x:Name="MainWindowReorderModeButton"
                                     Click="OnToggleMainWindowReorderModeClicked"
                                     Padding="8,2"
                                     VerticalAlignment="Center" />
-                            <TextBlock x:Name="MainWindowHeaderText" Text="Main Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
                         </StackPanel>
                         <ItemsControl x:Name="MainWindowServicesPanel">
                             <ItemsControl.ItemTemplate>
@@ -218,11 +218,11 @@
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
                     <StackPanel Spacing="12">
                         <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock x:Name="MiniWindowHeaderText" Text="Mini Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
                             <Button x:Name="MiniWindowReorderModeButton"
                                     Click="OnToggleMiniWindowReorderModeClicked"
                                     Padding="8,2"
                                     VerticalAlignment="Center" />
-                            <TextBlock x:Name="MiniWindowHeaderText" Text="Mini Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
                         </StackPanel>
                         <ItemsControl x:Name="MiniWindowServicesPanel">
                             <ItemsControl.ItemTemplate>
@@ -280,11 +280,11 @@
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="8" Padding="16">
                     <StackPanel Spacing="12">
                         <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBlock x:Name="FixedWindowHeaderText" Text="Fixed Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
                             <Button x:Name="FixedWindowReorderModeButton"
                                     Click="OnToggleFixedWindowReorderModeClicked"
                                     Padding="8,2"
                                     VerticalAlignment="Center" />
-                            <TextBlock x:Name="FixedWindowHeaderText" Text="Fixed Window" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
                         </StackPanel>
                         <ItemsControl x:Name="FixedWindowServicesPanel">
                             <ItemsControl.ItemTemplate>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -2442,8 +2442,9 @@ public sealed partial class SettingsPage : Page
             var icon = new FontIcon
             {
                 Glyph = section.IconGlyph,
-                FontSize = 14,
+                FontSize = 16,
                 Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                Opacity = 0.6,
                 Tag = i
             };
 

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -722,6 +722,7 @@ public sealed partial class SettingsPage : Page
         MouseSelectionExcludedAppsBox.TextChanged += OnSettingChanged;
         AlwaysOnTopToggle.Toggled += OnSettingChanged;
         LaunchAtStartupToggle.Toggled += OnSettingChanged;
+        HideEmptyServiceResultsToggle.Toggled += OnSettingChanged;
         ProxyEnabledToggle.Toggled += OnSettingChanged;
         ProxyBypassLocalToggle.Toggled += OnSettingChanged;
 
@@ -737,6 +738,12 @@ public sealed partial class SettingsPage : Page
         ShowFixedHotkeyBox.TextChanged += OnSettingChanged;
         OcrTranslateHotkeyBox.TextChanged += OnSettingChanged;
         SilentOcrHotkeyBox.TextChanged += OnSettingChanged;
+        ShowHotkeyEnabledToggle.Toggled += OnSettingChanged;
+        TranslateHotkeyEnabledToggle.Toggled += OnSettingChanged;
+        ShowMiniHotkeyEnabledToggle.Toggled += OnSettingChanged;
+        ShowFixedHotkeyEnabledToggle.Toggled += OnSettingChanged;
+        OcrTranslateHotkeyEnabledToggle.Toggled += OnSettingChanged;
+        SilentOcrHotkeyEnabledToggle.Toggled += OnSettingChanged;
 
         // TextBox/PasswordBox changes - new services
         DeepSeekKeyBox.PasswordChanged += OnSettingChanged;
@@ -799,6 +806,7 @@ public sealed partial class SettingsPage : Page
         MouseSelectionExcludedAppsBox.TextChanged -= OnSettingChanged;
         AlwaysOnTopToggle.Toggled -= OnSettingChanged;
         LaunchAtStartupToggle.Toggled -= OnSettingChanged;
+        HideEmptyServiceResultsToggle.Toggled -= OnSettingChanged;
         ProxyEnabledToggle.Toggled -= OnSettingChanged;
         ProxyBypassLocalToggle.Toggled -= OnSettingChanged;
 
@@ -813,6 +821,12 @@ public sealed partial class SettingsPage : Page
         ShowFixedHotkeyBox.TextChanged -= OnSettingChanged;
         OcrTranslateHotkeyBox.TextChanged -= OnSettingChanged;
         SilentOcrHotkeyBox.TextChanged -= OnSettingChanged;
+        ShowHotkeyEnabledToggle.Toggled -= OnSettingChanged;
+        TranslateHotkeyEnabledToggle.Toggled -= OnSettingChanged;
+        ShowMiniHotkeyEnabledToggle.Toggled -= OnSettingChanged;
+        ShowFixedHotkeyEnabledToggle.Toggled -= OnSettingChanged;
+        OcrTranslateHotkeyEnabledToggle.Toggled -= OnSettingChanged;
+        SilentOcrHotkeyEnabledToggle.Toggled -= OnSettingChanged;
 
         DeepSeekKeyBox.PasswordChanged -= OnSettingChanged;
         GroqKeyBox.PasswordChanged -= OnSettingChanged;
@@ -883,6 +897,74 @@ public sealed partial class SettingsPage : Page
             toggle.OnContent = loc.GetString("Auto");
             toggle.OffContent = loc.GetString("Manual");
         }
+    }
+
+    /// <summary>
+    /// Move a service one position up in the given collection.
+    /// </summary>
+    private static void MoveServiceUp(ObservableCollection<ServiceCheckItem> collection, string? serviceId)
+    {
+        if (string.IsNullOrEmpty(serviceId)) return;
+        for (int i = 1; i < collection.Count; i++)
+        {
+            if (collection[i].ServiceId == serviceId)
+            {
+                collection.Move(i, i - 1);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Move a service one position down in the given collection.
+    /// </summary>
+    private static void MoveServiceDown(ObservableCollection<ServiceCheckItem> collection, string? serviceId)
+    {
+        if (string.IsNullOrEmpty(serviceId)) return;
+        for (int i = 0; i < collection.Count - 1; i++)
+        {
+            if (collection[i].ServiceId == serviceId)
+            {
+                collection.Move(i, i + 1);
+                return;
+            }
+        }
+    }
+
+    private void OnMoveMainServiceUp(object sender, RoutedEventArgs e)
+    {
+        MoveServiceUp(_mainWindowServices, (sender as FrameworkElement)?.Tag as string);
+        OnSettingChanged(sender, e);
+    }
+
+    private void OnMoveMainServiceDown(object sender, RoutedEventArgs e)
+    {
+        MoveServiceDown(_mainWindowServices, (sender as FrameworkElement)?.Tag as string);
+        OnSettingChanged(sender, e);
+    }
+
+    private void OnMoveMiniServiceUp(object sender, RoutedEventArgs e)
+    {
+        MoveServiceUp(_miniWindowServices, (sender as FrameworkElement)?.Tag as string);
+        OnSettingChanged(sender, e);
+    }
+
+    private void OnMoveMiniServiceDown(object sender, RoutedEventArgs e)
+    {
+        MoveServiceDown(_miniWindowServices, (sender as FrameworkElement)?.Tag as string);
+        OnSettingChanged(sender, e);
+    }
+
+    private void OnMoveFixedServiceUp(object sender, RoutedEventArgs e)
+    {
+        MoveServiceUp(_fixedWindowServices, (sender as FrameworkElement)?.Tag as string);
+        OnSettingChanged(sender, e);
+    }
+
+    private void OnMoveFixedServiceDown(object sender, RoutedEventArgs e)
+    {
+        MoveServiceDown(_fixedWindowServices, (sender as FrameworkElement)?.Tag as string);
+        OnSettingChanged(sender, e);
     }
 
     /// <summary>
@@ -1000,6 +1082,7 @@ public sealed partial class SettingsPage : Page
             ? Visibility.Visible : Visibility.Collapsed;
         AlwaysOnTopToggle.IsOn = _settings.AlwaysOnTop;
         LaunchAtStartupToggle.IsOn = _settings.LaunchAtStartup;
+        HideEmptyServiceResultsToggle.IsOn = _settings.HideEmptyServiceResults;
 
         // Hotkeys
         ShowHotkeyBox.Text = _settings.ShowWindowHotkey;
@@ -1008,6 +1091,12 @@ public sealed partial class SettingsPage : Page
         ShowFixedHotkeyBox.Text = _settings.ShowFixedWindowHotkey;
         OcrTranslateHotkeyBox.Text = _settings.OcrTranslateHotkey;
         SilentOcrHotkeyBox.Text = _settings.SilentOcrHotkey;
+        ShowHotkeyEnabledToggle.IsOn = _settings.EnableShowWindowHotkey;
+        TranslateHotkeyEnabledToggle.IsOn = _settings.EnableTranslateSelectionHotkey;
+        ShowMiniHotkeyEnabledToggle.IsOn = _settings.EnableShowMiniWindowHotkey;
+        ShowFixedHotkeyEnabledToggle.IsOn = _settings.EnableShowFixedWindowHotkey;
+        OcrTranslateHotkeyEnabledToggle.IsOn = _settings.EnableOcrTranslateHotkey;
+        SilentOcrHotkeyEnabledToggle.IsOn = _settings.EnableSilentOcrHotkey;
 
         // Enabled services for each window (populate from TranslationManager.Services)
         // Acquire handle once for all three collections to avoid repeated handle acquisition
@@ -1574,8 +1663,26 @@ public sealed partial class SettingsPage : Page
 
         try
         {
-            foreach (var (serviceId, service) in manager.Services)
+            // Sort enabled services to the user's saved order; disabled services follow in
+            // manager registration order. This preserves the up/down reorder UI choice.
+            var orderIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < enabledServices.Count; i++)
             {
+                orderIndex[enabledServices[i]] = i;
+            }
+
+            var managerOrder = manager.Services.Keys.ToList();
+            var ordered = managerOrder
+                .Select((id, idx) => (id, idx))
+                .OrderBy(t => orderIndex.TryGetValue(t.id, out var sortIdx) ? sortIdx : int.MaxValue)
+                .ThenBy(t => t.idx)
+                .Select(t => t.id);
+
+            foreach (var serviceId in ordered)
+            {
+                if (!manager.Services.TryGetValue(serviceId, out var service))
+                    continue;
+
                 // Default EnabledQuery is true (auto-query); use stored setting if available
                 var enabledQuery = enabledQuerySettings.TryGetValue(serviceId, out var stored) ? stored : true;
 
@@ -2026,6 +2133,7 @@ public sealed partial class SettingsPage : Page
             .ToList();
         _settings.AlwaysOnTop = AlwaysOnTopToggle.IsOn;
         _settings.LaunchAtStartup = LaunchAtStartupToggle.IsOn;
+        _settings.HideEmptyServiceResults = HideEmptyServiceResultsToggle.IsOn;
 
         // Apply startup setting to Windows registry
         StartupService.SetEnabled(_settings.LaunchAtStartup);
@@ -2037,6 +2145,12 @@ public sealed partial class SettingsPage : Page
         _settings.ShowFixedWindowHotkey = ShowFixedHotkeyBox.Text;
         _settings.OcrTranslateHotkey = OcrTranslateHotkeyBox.Text;
         _settings.SilentOcrHotkey = SilentOcrHotkeyBox.Text;
+        _settings.EnableShowWindowHotkey = ShowHotkeyEnabledToggle.IsOn;
+        _settings.EnableTranslateSelectionHotkey = TranslateHotkeyEnabledToggle.IsOn;
+        _settings.EnableShowMiniWindowHotkey = ShowMiniHotkeyEnabledToggle.IsOn;
+        _settings.EnableShowFixedWindowHotkey = ShowFixedHotkeyEnabledToggle.IsOn;
+        _settings.EnableOcrTranslateHotkey = OcrTranslateHotkeyEnabledToggle.IsOn;
+        _settings.EnableSilentOcrHotkey = SilentOcrHotkeyEnabledToggle.IsOn;
 
         // Save enabled services for each window (from collections)
         _settings.MainWindowEnabledServices = GetEnabledServicesFromCollection(_mainWindowServices);

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -2548,14 +2548,12 @@ public sealed partial class SettingsPage : Page
             {
                 if (i == activeIndex)
                 {
-                    // Active icon: larger + accent color
-                    icon.FontSize = 16;
+                    // Keep the nav rail layout-stable during scroll sync.
                     icon.Foreground = (Brush)Application.Current.Resources["AccentFillColorDefaultBrush"];
                 }
                 else
                 {
-                    // Inactive icon: smaller + secondary color
-                    icon.FontSize = 14;
+                    // Only change non-layout-affecting state for inactive items.
                     icon.Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
                 }
             }

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -27,6 +27,7 @@ internal sealed record NavSection(string Name, string Tooltip, string IconGlyph,
 public sealed partial class SettingsPage : Page
 {
     private static readonly Regex NonServiceIdCharRegex = new("[^a-z0-9-]", RegexOptions.Compiled);
+    private const string ReorderButtonEmoji = "\u2195\uFE0F";
     private readonly SettingsService _settings = SettingsService.Instance;
     private bool _isLoading = true; // Prevent change detection during initial load
     private bool _isInitialized;
@@ -34,7 +35,9 @@ public sealed partial class SettingsPage : Page
     private bool _isTornDown;
     private bool _changeHandlersRegistered;
     private bool _hasUnsavedChanges; // Track whether any settings have been modified since last save
-    private bool _isServiceReorderModeEnabled;
+    private bool _isMainWindowReorderModeEnabled;
+    private bool _isMiniWindowReorderModeEnabled;
+    private bool _isFixedWindowReorderModeEnabled;
     private ContentDialog? _currentDialog; // Track open dialog to prevent COMException
     private readonly CancellationTokenSource _lifetimeCts = new();
 
@@ -236,7 +239,6 @@ public sealed partial class SettingsPage : Page
             EnabledServicesHeaderText.Text = loc.GetString("EnabledServices");
         if (EnabledServicesDescriptionText != null)
             EnabledServicesDescriptionText.Text = loc.GetString("EnabledServicesDescription");
-        UpdateServiceReorderModeButtonText();
 
         // International Services toggle
         EnableInternationalServicesHeaderText.Text = loc.GetString("EnableInternationalServices");
@@ -250,6 +252,7 @@ public sealed partial class SettingsPage : Page
             MiniWindowHeaderText.Text = loc.GetString("MiniWindow");
         if (FixedWindowHeaderText != null)
             FixedWindowHeaderText.Text = loc.GetString("FixedWindow");
+        UpdateAllServiceReorderModeButtonText();
 
         // Language Preferences section
         if (LanguagePreferencesHeaderText != null)
@@ -901,18 +904,47 @@ public sealed partial class SettingsPage : Page
         }
     }
 
-    private void OnToggleServiceReorderModeClicked(object sender, RoutedEventArgs e)
+    private void OnToggleMainWindowReorderModeClicked(object sender, RoutedEventArgs e)
     {
-        SetServiceReorderMode(!_isServiceReorderModeEnabled);
+        SetMainWindowReorderMode(!_isMainWindowReorderModeEnabled);
     }
 
-    private void SetServiceReorderMode(bool isEnabled)
+    private void OnToggleMiniWindowReorderModeClicked(object sender, RoutedEventArgs e)
     {
-        _isServiceReorderModeEnabled = isEnabled;
+        SetMiniWindowReorderMode(!_isMiniWindowReorderModeEnabled);
+    }
+
+    private void OnToggleFixedWindowReorderModeClicked(object sender, RoutedEventArgs e)
+    {
+        SetFixedWindowReorderMode(!_isFixedWindowReorderModeEnabled);
+    }
+
+    private void SetMainWindowReorderMode(bool isEnabled)
+    {
+        _isMainWindowReorderModeEnabled = isEnabled;
         ApplyServiceReorderMode(_mainWindowServices, isEnabled);
+        UpdateServiceReorderModeButtonText(MainWindowReorderModeButton, isEnabled);
+    }
+
+    private void SetMiniWindowReorderMode(bool isEnabled)
+    {
+        _isMiniWindowReorderModeEnabled = isEnabled;
         ApplyServiceReorderMode(_miniWindowServices, isEnabled);
+        UpdateServiceReorderModeButtonText(MiniWindowReorderModeButton, isEnabled);
+    }
+
+    private void SetFixedWindowReorderMode(bool isEnabled)
+    {
+        _isFixedWindowReorderModeEnabled = isEnabled;
         ApplyServiceReorderMode(_fixedWindowServices, isEnabled);
-        UpdateServiceReorderModeButtonText();
+        UpdateServiceReorderModeButtonText(FixedWindowReorderModeButton, isEnabled);
+    }
+
+    private void ResetServiceReorderModes()
+    {
+        SetMainWindowReorderMode(false);
+        SetMiniWindowReorderMode(false);
+        SetFixedWindowReorderMode(false);
     }
 
     private static void ApplyServiceReorderMode(ObservableCollection<ServiceCheckItem> collection, bool isEnabled)
@@ -923,18 +955,25 @@ public sealed partial class SettingsPage : Page
         }
     }
 
-    private void UpdateServiceReorderModeButtonText()
+    private void UpdateAllServiceReorderModeButtonText()
     {
-        if (ServiceReorderModeButton == null)
+        UpdateServiceReorderModeButtonText(MainWindowReorderModeButton, _isMainWindowReorderModeEnabled);
+        UpdateServiceReorderModeButtonText(MiniWindowReorderModeButton, _isMiniWindowReorderModeEnabled);
+        UpdateServiceReorderModeButtonText(FixedWindowReorderModeButton, _isFixedWindowReorderModeEnabled);
+    }
+
+    private static void UpdateServiceReorderModeButtonText(Button? button, bool isEnabled)
+    {
+        if (button == null)
         {
             return;
         }
 
         var loc = LocalizationService.Instance;
-        ServiceReorderModeButton.Content = loc.GetString(
-            _isServiceReorderModeEnabled
+        button.Content = $"{ReorderButtonEmoji} {loc.GetString(
+            isEnabled
                 ? "EnabledServicesDoneReorderingButton"
-                : "EnabledServicesReorderButton");
+                : "EnabledServicesReorderButton")}";
     }
 
     /// <summary>
@@ -1148,7 +1187,7 @@ public sealed partial class SettingsPage : Page
             PopulateServiceCollection(_miniWindowServices, _settings.MiniWindowEnabledServices, _settings.MiniWindowServiceEnabledQuery, manager);
             PopulateServiceCollection(_fixedWindowServices, _settings.FixedWindowEnabledServices, _settings.FixedWindowServiceEnabledQuery, manager);
         }
-        SetServiceReorderMode(false);
+        ResetServiceReorderModes();
         if (_changeHandlersRegistered)
         {
             RegisterServiceCollectionHandlers(_mainWindowServices);
@@ -2222,7 +2261,7 @@ public sealed partial class SettingsPage : Page
 
         // Persist to storage
         _settings.Save();
-        SetServiceReorderMode(false);
+        ResetServiceReorderModes();
 
         // Refresh window service results to pick up new EnabledQuery settings
         MiniWindowService.Instance.RefreshServiceResults();

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -34,6 +34,7 @@ public sealed partial class SettingsPage : Page
     private bool _isTornDown;
     private bool _changeHandlersRegistered;
     private bool _hasUnsavedChanges; // Track whether any settings have been modified since last save
+    private bool _isServiceReorderModeEnabled;
     private ContentDialog? _currentDialog; // Track open dialog to prevent COMException
     private readonly CancellationTokenSource _lifetimeCts = new();
 
@@ -235,6 +236,7 @@ public sealed partial class SettingsPage : Page
             EnabledServicesHeaderText.Text = loc.GetString("EnabledServices");
         if (EnabledServicesDescriptionText != null)
             EnabledServicesDescriptionText.Text = loc.GetString("EnabledServicesDescription");
+        UpdateServiceReorderModeButtonText();
 
         // International Services toggle
         EnableInternationalServicesHeaderText.Text = loc.GetString("EnableInternationalServices");
@@ -899,6 +901,42 @@ public sealed partial class SettingsPage : Page
         }
     }
 
+    private void OnToggleServiceReorderModeClicked(object sender, RoutedEventArgs e)
+    {
+        SetServiceReorderMode(!_isServiceReorderModeEnabled);
+    }
+
+    private void SetServiceReorderMode(bool isEnabled)
+    {
+        _isServiceReorderModeEnabled = isEnabled;
+        ApplyServiceReorderMode(_mainWindowServices, isEnabled);
+        ApplyServiceReorderMode(_miniWindowServices, isEnabled);
+        ApplyServiceReorderMode(_fixedWindowServices, isEnabled);
+        UpdateServiceReorderModeButtonText();
+    }
+
+    private static void ApplyServiceReorderMode(ObservableCollection<ServiceCheckItem> collection, bool isEnabled)
+    {
+        foreach (var item in collection)
+        {
+            item.IsReorderModeEnabled = isEnabled;
+        }
+    }
+
+    private void UpdateServiceReorderModeButtonText()
+    {
+        if (ServiceReorderModeButton == null)
+        {
+            return;
+        }
+
+        var loc = LocalizationService.Instance;
+        ServiceReorderModeButton.Content = loc.GetString(
+            _isServiceReorderModeEnabled
+                ? "EnabledServicesDoneReorderingButton"
+                : "EnabledServicesReorderButton");
+    }
+
     /// <summary>
     /// Move a service one position up in the given collection.
     /// </summary>
@@ -1110,6 +1148,7 @@ public sealed partial class SettingsPage : Page
             PopulateServiceCollection(_miniWindowServices, _settings.MiniWindowEnabledServices, _settings.MiniWindowServiceEnabledQuery, manager);
             PopulateServiceCollection(_fixedWindowServices, _settings.FixedWindowEnabledServices, _settings.FixedWindowServiceEnabledQuery, manager);
         }
+        SetServiceReorderMode(false);
         if (_changeHandlersRegistered)
         {
             RegisterServiceCollectionHandlers(_mainWindowServices);
@@ -2183,6 +2222,7 @@ public sealed partial class SettingsPage : Page
 
         // Persist to storage
         _settings.Save();
+        SetServiceReorderMode(false);
 
         // Refresh window service results to pick up new EnabledQuery settings
         MiniWindowService.Instance.RefreshServiceResults();

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DictionaryWebViewRenderingTests.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DictionaryWebViewRenderingTests.cs
@@ -16,7 +16,7 @@ public class DictionaryWebViewRenderingTests : IDisposable
     private readonly AppLauncher _launcher;
     private readonly ITestOutputHelper _output;
 
-    private const string DictionaryQuery = "draft";
+    private const string DictionaryQuery = "no";
     private const int TranslationWaitMs = 10000;
 
     public DictionaryWebViewRenderingTests(ITestOutputHelper output)
@@ -60,21 +60,33 @@ public class DictionaryWebViewRenderingTests : IDisposable
         _output.WriteLine($"Screenshot saved: {pathAfterTranslate}");
         File.Exists(pathAfterTranslate).Should().BeTrue("the post-query screenshot should be written for manual review");
 
-        var dictWebView = Retry.WhileNull(
-            () => window.FindFirstDescendant(cf => cf.ByAutomationId("DictWebView")),
+        var visibleDictWebView = Retry.WhileNull(
+            () =>
+            {
+                var candidate = window.FindFirstDescendant(cf => cf.ByAutomationId("DictWebView"));
+                return candidate != null && !candidate.IsOffscreen ? candidate : null;
+            },
             TimeSpan.FromSeconds(5)).Result;
 
-        if (dictWebView == null)
+        if (visibleDictWebView != null)
         {
-            _output.WriteLine("Dictionary WebView not detected in this environment. Window screenshots were still captured for manual review.");
+            var pathElement = ScreenshotHelper.CaptureElement(visibleDictWebView, "52_dictionary_webview_element");
+            _output.WriteLine($"Element screenshot saved: {pathElement}");
+            File.Exists(pathElement).Should().BeTrue("the dictionary WebView element screenshot should be written when the WebView is present");
         }
         else
         {
-            dictWebView.IsOffscreen.Should().BeFalse("the dictionary WebView should be visible once the word query completes");
+            var visibleResultText = Retry.WhileNull(
+                () =>
+                {
+                    var candidate = window.FindFirstDescendant(cf => cf.ByAutomationId("ResultText"));
+                    return candidate != null && !candidate.IsOffscreen ? candidate : null;
+                },
+                TimeSpan.FromSeconds(5)).Result;
 
-            var pathElement = ScreenshotHelper.CaptureElement(dictWebView, "52_dictionary_webview_element");
-            _output.WriteLine($"Element screenshot saved: {pathElement}");
-            File.Exists(pathElement).Should().BeTrue("the dictionary WebView element screenshot should be written when the WebView is present");
+            visibleResultText.Should().NotBeNull(
+                "when WebView2 cannot render the MDX HTML, the plain-text fallback should still be visible for dictionary entries that exist");
+            _output.WriteLine("Dictionary WebView not visible; plain-text fallback is visible instead.");
         }
 
         var comparison = VisualRegressionHelper.CompareWithBaseline(

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DictionaryWebViewRenderingTests.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DictionaryWebViewRenderingTests.cs
@@ -52,6 +52,10 @@ public class DictionaryWebViewRenderingTests : IDisposable
         _output.WriteLine($"Waiting {TranslationWaitMs}ms for dictionary results...");
         Thread.Sleep(TranslationWaitMs);
 
+        _output.WriteLine($"App has exited after dictionary query: {_launcher.Application.HasExited}");
+        _launcher.Application.HasExited.Should().BeFalse(
+            "triggering a dictionary query should not freeze the UI hard enough to terminate the app");
+
         var pathAfterTranslate = ScreenshotHelper.CaptureWindow(window, "51_dictionary_webview_after_query");
         _output.WriteLine($"Screenshot saved: {pathAfterTranslate}");
         File.Exists(pathAfterTranslate).Should().BeTrue("the post-query screenshot should be written for manual review");

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DictionaryWebViewRenderingTests.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DictionaryWebViewRenderingTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Easydict.UIAutomation.Tests.Infrastructure;
 using FluentAssertions;
 using FlaUI.Core.AutomationElements;
@@ -16,8 +17,10 @@ public class DictionaryWebViewRenderingTests : IDisposable
     private readonly AppLauncher _launcher;
     private readonly ITestOutputHelper _output;
 
-    private const string DictionaryQuery = "no";
     private const int TranslationWaitMs = 10000;
+
+    private static string DictionaryQuery =>
+        Environment.GetEnvironmentVariable("EASYDICT_UIA_DICTIONARY_QUERY") ?? "no";
 
     public DictionaryWebViewRenderingTests(ITestOutputHelper output)
     {
@@ -61,11 +64,7 @@ public class DictionaryWebViewRenderingTests : IDisposable
         File.Exists(pathAfterTranslate).Should().BeTrue("the post-query screenshot should be written for manual review");
 
         var visibleDictWebView = Retry.WhileNull(
-            () =>
-            {
-                var candidate = window.FindFirstDescendant(cf => cf.ByAutomationId("DictWebView"));
-                return candidate != null && !candidate.IsOffscreen ? candidate : null;
-            },
+            () => TryFindVisibleDescendant(window, "DictWebView"),
             TimeSpan.FromSeconds(5)).Result;
 
         if (visibleDictWebView != null)
@@ -77,11 +76,7 @@ public class DictionaryWebViewRenderingTests : IDisposable
         else
         {
             var visibleResultText = Retry.WhileNull(
-                () =>
-                {
-                    var candidate = window.FindFirstDescendant(cf => cf.ByAutomationId("ResultText"));
-                    return candidate != null && !candidate.IsOffscreen ? candidate : null;
-                },
+                () => TryFindVisibleDescendant(window, "ResultText"),
                 TimeSpan.FromSeconds(5)).Result;
 
             visibleResultText.Should().NotBeNull(
@@ -107,5 +102,22 @@ public class DictionaryWebViewRenderingTests : IDisposable
     public void Dispose()
     {
         _launcher.Dispose();
+    }
+
+    private static AutomationElement? TryFindVisibleDescendant(AutomationElement root, string automationId)
+    {
+        try
+        {
+            var candidate = root.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
+            return candidate != null && !candidate.IsOffscreen ? candidate : null;
+        }
+        catch (COMException)
+        {
+            return null;
+        }
+        catch (TimeoutException)
+        {
+            return null;
+        }
     }
 }

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DictionaryWebViewRenderingTests.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DictionaryWebViewRenderingTests.cs
@@ -1,0 +1,95 @@
+using Easydict.UIAutomation.Tests.Infrastructure;
+using FluentAssertions;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Input;
+using FlaUI.Core.Tools;
+using FlaUI.Core.WindowsAPI;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Easydict.UIAutomation.Tests.Tests;
+
+[Trait("Category", "UIAutomation")]
+[Collection("UIAutomation")]
+public class DictionaryWebViewRenderingTests : IDisposable
+{
+    private readonly AppLauncher _launcher;
+    private readonly ITestOutputHelper _output;
+
+    private const string DictionaryQuery = "draft";
+    private const int TranslationWaitMs = 10000;
+
+    public DictionaryWebViewRenderingTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _launcher = new AppLauncher();
+        _launcher.LaunchAuto(TimeSpan.FromSeconds(45));
+    }
+
+    [Fact]
+    public void MainWindow_DictionaryWebView_CapturesScreenshotForManualReview()
+    {
+        var window = _launcher.GetMainWindow();
+        Thread.Sleep(2000);
+
+        var inputBox = Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByAutomationId("InputTextBox"))?.AsTextBox(),
+            TimeSpan.FromSeconds(10)).Result;
+
+        inputBox.Should().NotBeNull("InputTextBox must exist on main window");
+
+        inputBox!.Click();
+        Thread.Sleep(300);
+        inputBox.Text = DictionaryQuery;
+        Thread.Sleep(500);
+
+        var pathBeforeTranslate = ScreenshotHelper.CaptureWindow(window, "50_dictionary_webview_before_query");
+        _output.WriteLine($"Screenshot saved: {pathBeforeTranslate}");
+        File.Exists(pathBeforeTranslate).Should().BeTrue("the pre-query screenshot should be written for manual review");
+
+        Keyboard.Type(VirtualKeyShort.ENTER);
+
+        _output.WriteLine($"Waiting {TranslationWaitMs}ms for dictionary results...");
+        Thread.Sleep(TranslationWaitMs);
+
+        var pathAfterTranslate = ScreenshotHelper.CaptureWindow(window, "51_dictionary_webview_after_query");
+        _output.WriteLine($"Screenshot saved: {pathAfterTranslate}");
+        File.Exists(pathAfterTranslate).Should().BeTrue("the post-query screenshot should be written for manual review");
+
+        var dictWebView = Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByAutomationId("DictWebView")),
+            TimeSpan.FromSeconds(5)).Result;
+
+        if (dictWebView == null)
+        {
+            _output.WriteLine("Dictionary WebView not detected in this environment. Window screenshots were still captured for manual review.");
+        }
+        else
+        {
+            dictWebView.IsOffscreen.Should().BeFalse("the dictionary WebView should be visible once the word query completes");
+
+            var pathElement = ScreenshotHelper.CaptureElement(dictWebView, "52_dictionary_webview_element");
+            _output.WriteLine($"Element screenshot saved: {pathElement}");
+            File.Exists(pathElement).Should().BeTrue("the dictionary WebView element screenshot should be written when the WebView is present");
+        }
+
+        var comparison = VisualRegressionHelper.CompareWithBaseline(
+            pathAfterTranslate,
+            "dictionary_webview_main_window",
+            VisualRegressionHelper.ThresholdText);
+
+        if (comparison == null)
+        {
+            _output.WriteLine("No baseline found - screenshot saved as baseline candidate for manual review.");
+        }
+        else
+        {
+            _output.WriteLine(comparison.ToString());
+        }
+    }
+
+    public void Dispose()
+    {
+        _launcher.Dispose();
+    }
+}

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -194,6 +194,14 @@ public class KanbanTodoUxRegressionTests
             "dictionary navigation should not walk the entire DOM on the UI thread after every query");
         code.Should().Contain("var targetHeight = height + 8;",
             "dictionary WebView sizing should still derive from measured content height");
+        code.Should().Contain("DictWebView.CoreWebView2.WebMessageReceived += OnDictWebViewWebMessageReceived;",
+            "the host should subscribe to WebView messages so wheel-boundary events can escape the dictionary surface");
+        code.Should().Contain("window.chrome?.webview?.postMessage({",
+            "dictionary HTML should signal top/bottom wheel-boundary events back to the host");
+        code.Should().Contain("type: 'dict-wheel-boundary'",
+            "the wheel relay should use a dedicated message type instead of piggybacking on unrelated messages");
+        code.Should().Contain("private void OnDictWebViewWebMessageReceived",
+            "the host control should translate WebView wheel-boundary messages into outer ScrollViewer movement");
         code.Should().NotContain("Math.Min(height + 8, 800)",
             "the WebView should no longer keep its own 800px internal scroll cap");
     }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -115,9 +115,9 @@ public class KanbanTodoUxRegressionTests
             "the reorder entry should use localized copy");
         code.Should().Contain("EnabledServicesDoneReorderingButton",
             "the active-state button label should also come from localization");
-        AssertPrecedes(xaml, "MainWindowReorderModeButton", "MainWindowHeaderText");
-        AssertPrecedes(xaml, "MiniWindowReorderModeButton", "MiniWindowHeaderText");
-        AssertPrecedes(xaml, "FixedWindowReorderModeButton", "FixedWindowHeaderText");
+        AssertPrecedes(xaml, "MainWindowHeaderText", "MainWindowReorderModeButton");
+        AssertPrecedes(xaml, "MiniWindowHeaderText", "MiniWindowReorderModeButton");
+        AssertPrecedes(xaml, "FixedWindowHeaderText", "FixedWindowReorderModeButton");
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -197,6 +197,23 @@ public class KanbanTodoUxRegressionTests
     }
 
     [Fact]
+    public void ServiceResultItem_AppliesReadableDictionaryWebViewStyles()
+    {
+        var code = File.ReadAllText(ServiceResultItemPath);
+
+        code.Should().Contain("padding: 0 8px 12px;",
+            "dictionary HTML should keep a little horizontal and bottom breathing room inside the WebView");
+        code.Should().Contain("line-height: 1.45;",
+            "dictionary body text should render with a slightly more readable line height");
+        code.Should().Contain("overflow-x: hidden;",
+            "dictionary WebView content should avoid accidental horizontal overflow");
+        code.Should().Contain("img, svg, table { max-width: 100% !important; height: auto; }",
+            "media-heavy dictionary content should stay inside the result viewport");
+        code.Should().Contain("pre { white-space: pre-wrap; overflow-wrap: anywhere; }",
+            "long preformatted fragments should wrap instead of forcing awkward horizontal overflow");
+    }
+
+    [Fact]
     public void AppAndWindowServices_ImplementForegroundToggleContract()
     {
         var appCode = File.ReadAllText(AppPath);

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -184,12 +184,12 @@ public class KanbanTodoUxRegressionTests
             "edge-wheel forwarding should locate the parent results ScrollViewer");
         code.Should().Contain("outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);",
             "the outer results ScrollViewer should continue scrolling once the inner content hits its edge");
-        code.Should().Contain("NormalizeDictionaryVerticalOverflowAsync(sender)",
-            "dictionary WebView results should normalize nested HTML overflow before sizing themselves");
-        code.Should().Contain("element.style.overflowY = 'visible';",
-            "nested vertical scrollers inside dictionary HTML should be flattened so wheel input can escape to the host");
-        code.Should().Contain("body.style.overflowY = 'hidden';",
-            "the dictionary document itself should stop owning a separate vertical scroll layer");
+        code.Should().Contain("MeasureDictionaryHeightAsync(sender)",
+            "dictionary WebView results should keep a lightweight post-navigation sizing pass");
+        code.Should().Contain("await Task.Delay(50);",
+            "dictionary WebView sizing should wait briefly for the CSS normalization/layout pass to settle");
+        code.Should().NotContain("document.querySelectorAll('*')",
+            "dictionary navigation should not walk the entire DOM on the UI thread after every query");
         code.Should().Contain("sender.Height = height + 8;",
             "dictionary WebView content should expand to its full height so the outer chained ScrollViewer owns overflow");
         code.Should().NotContain("Math.Min(height + 8, 800)",
@@ -207,10 +207,14 @@ public class KanbanTodoUxRegressionTests
             "dictionary body text should render with a slightly more readable line height");
         code.Should().Contain("overflow-x: hidden;",
             "dictionary WebView content should avoid accidental horizontal overflow");
+        code.Should().Contain("overflow-y: hidden;",
+            "the dictionary document should yield vertical scrolling to the host result container");
         code.Should().Contain("ol, ul {",
             "dictionary definition lists should get consistent spacing");
         code.Should().Contain("li {",
             "dictionary list items should keep a little vertical separation");
+        code.Should().Contain("[style*=\"overflow-y\"],",
+            "common inline-scroll dictionary containers should be flattened through CSS instead of a DOM-wide JS walk");
         code.Should().Contain("[class*=\"phon\"], [class*=\"pron\"], [class*=\"ipa\"] {",
             "common phonetic markup should get a small readability pass");
         code.Should().Contain("[class*=\"meaning\"], [class*=\"def\"], [class*=\"sense\"], [class*=\"gloss\"] {",

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -223,8 +223,14 @@ public class KanbanTodoUxRegressionTests
             "dictionary HTML should signal top/bottom wheel-boundary events back to the host");
         code.Should().Contain("type: 'dict-wheel-boundary'",
             "the wheel relay should use a dedicated message type instead of piggybacking on unrelated messages");
+        code.Should().Contain("type: 'dict-wheel-passthrough'",
+            "dictionary HTML should also proxy ordinary wheel input back to the host when there is no true internal scroll container");
         code.Should().Contain("private void OnDictWebViewWebMessageReceived",
             "the host control should translate WebView wheel-boundary messages into outer ScrollViewer movement");
+        code.Should().Contain("ResultContentScrollViewer ?? FindAncestorScrollViewer(DictWebView)",
+            "the WebView relay should target the named result-content scroller first instead of relying only on ancestor lookup");
+        code.Should().Contain("typeElement.GetString() is not \"dict-wheel-boundary\" and not \"dict-wheel-passthrough\"",
+            "the host should accept both boundary handoff and full passthrough wheel messages from the WebView surface");
         code.Should().NotContain("Math.Min(height + 8, 800)",
             "the WebView should no longer keep its own 800px internal scroll cap");
     }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -19,6 +19,7 @@ public class KanbanTodoUxRegressionTests
     private static readonly string StringsPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Strings");
     private static readonly string SettingsPageXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "SettingsPage.xaml");
     private static readonly string SettingsPageCodePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "SettingsPage.xaml.cs");
+    private static readonly string ServiceCheckItemPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Models", "ServiceCheckItem.cs");
     private static readonly string ServiceResultItemPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "ServiceResultItem.xaml.cs");
     private static readonly string AppPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "App.xaml.cs");
     private static readonly string MiniWindowServicePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Services", "MiniWindowService.cs");
@@ -72,7 +73,9 @@ public class KanbanTodoUxRegressionTests
     [Fact]
     public void SettingsPage_PreservesUserServiceOrder()
     {
+        var xaml = File.ReadAllText(SettingsPageXamlPath);
         var code = File.ReadAllText(SettingsPageCodePath);
+        var itemCode = File.ReadAllText(ServiceCheckItemPath);
 
         code.Should().Contain("private static void MoveServiceUp(",
             "the Settings page should expose explicit move-up helpers for service ordering");
@@ -86,6 +89,43 @@ public class KanbanTodoUxRegressionTests
             "service population should honor the persisted enabled-service order");
         code.Should().Contain("var ordered = managerOrder",
             "service population should rebuild the view in persisted order");
+        xaml.Should().Contain("x:Name=\"ServiceReorderModeButton\"",
+            "the Settings page should provide an explicit entry point for reordering instead of always showing move controls");
+        xaml.Should().Contain("Click=\"OnToggleServiceReorderModeClicked\"",
+            "the reorder entry should toggle an explicit reorder mode");
+        xaml.Should().Contain("Visibility=\"{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}\"",
+            "per-row move buttons should only appear while reorder mode is enabled");
+        itemCode.Should().Contain("public bool IsReorderModeEnabled",
+            "service items should expose reorder-mode visibility state for the move controls");
+        code.Should().Contain("SetServiceReorderMode(false);",
+            "the page should fall back to the clean default state after load/save");
+        code.Should().Contain("EnabledServicesReorderButton",
+            "the reorder entry should use localized copy");
+        code.Should().Contain("EnabledServicesDoneReorderingButton",
+            "the active-state button label should also come from localization");
+    }
+
+    [Fact]
+    public void AllLanguages_HaveEnabledServicesReorderResources()
+    {
+        foreach (var languageDir in Directory.GetDirectories(StringsPath))
+        {
+            var reswPath = Path.Combine(languageDir, "Resources.resw");
+            File.Exists(reswPath).Should().BeTrue($"{languageDir} should contain Resources.resw");
+
+            var doc = XDocument.Load(reswPath);
+            var reorderElement = doc.Descendants("data")
+                .FirstOrDefault(e => e.Attribute("name")?.Value == "EnabledServicesReorderButton");
+            var doneElement = doc.Descendants("data")
+                .FirstOrDefault(e => e.Attribute("name")?.Value == "EnabledServicesDoneReorderingButton");
+
+            reorderElement.Should().NotBeNull($"{languageDir} should contain EnabledServicesReorderButton");
+            doneElement.Should().NotBeNull($"{languageDir} should contain EnabledServicesDoneReorderingButton");
+            reorderElement!.Element("value")?.Value.Should().NotBeNullOrWhiteSpace(
+                $"{languageDir} should provide a non-empty EnabledServicesReorderButton translation");
+            doneElement!.Element("value")?.Value.Should().NotBeNullOrWhiteSpace(
+                $"{languageDir} should provide a non-empty EnabledServicesDoneReorderingButton translation");
+        }
     }
 
     [Fact]
@@ -96,7 +136,7 @@ public class KanbanTodoUxRegressionTests
         var start = code.IndexOf(marker, StringComparison.Ordinal);
 
         start.Should().BeGreaterOrEqualTo(0, "the hide-empty guard should still exist in ServiceResultItem");
-        var snippet = code.Substring(start, Math.Min(320, code.Length - start));
+        var snippet = code.Substring(start, Math.Min(520, code.Length - start));
 
         code.Should().Contain("SettingsService.Instance.HideEmptyServiceResults",
             "the new settings toggle should control no-result row presentation");

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -207,6 +207,14 @@ public class KanbanTodoUxRegressionTests
             "dictionary body text should render with a slightly more readable line height");
         code.Should().Contain("overflow-x: hidden;",
             "dictionary WebView content should avoid accidental horizontal overflow");
+        code.Should().Contain("ol, ul {",
+            "dictionary definition lists should get consistent spacing");
+        code.Should().Contain("li {",
+            "dictionary list items should keep a little vertical separation");
+        code.Should().Contain("[class*=\"phon\"], [class*=\"pron\"], [class*=\"ipa\"] {",
+            "common phonetic markup should get a small readability pass");
+        code.Should().Contain("[class*=\"meaning\"], [class*=\"def\"], [class*=\"sense\"], [class*=\"gloss\"] {",
+            "common meaning/definition markup should get a slightly roomier line height");
         code.Should().Contain("img, svg, table { max-width: 100% !important; height: auto; }",
             "media-heavy dictionary content should stay inside the result viewport");
         code.Should().Contain("pre { white-space: pre-wrap; overflow-wrap: anywhere; }",

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -89,18 +89,23 @@ public class KanbanTodoUxRegressionTests
     }
 
     [Fact]
-    public void ServiceResultItem_CollapsesNoResultRowsWhenHideEmptyResultsIsEnabled()
+    public void ServiceResultItem_LeavesNoResultRowsVisibleButCollapsedWhenHideEmptyResultsIsEnabled()
     {
         var code = File.ReadAllText(ServiceResultItemPath);
+        var marker = "var hideEmpty = SettingsService.Instance.HideEmptyServiceResults";
+        var start = code.IndexOf(marker, StringComparison.Ordinal);
+
+        start.Should().BeGreaterOrEqualTo(0, "the hide-empty guard should still exist in ServiceResultItem");
+        var snippet = code.Substring(start, Math.Min(320, code.Length - start));
 
         code.Should().Contain("SettingsService.Instance.HideEmptyServiceResults",
-            "the new settings toggle should control no-result row collapsing");
+            "the new settings toggle should control no-result row presentation");
         code.Should().Contain("TranslationResultKind.NoResult",
-            "only true no-result responses should be collapsed");
-        code.Should().Contain("this.Visibility = Visibility.Collapsed;",
-            "no-result rows should be removed from layout instead of merely dimmed");
-        code.Should().Contain("this.Visibility = Visibility.Visible;",
-            "rows should become visible again when they later have content or an error");
+            "only true no-result responses should be collapsed by the hide-empty rule");
+        snippet.Should().Contain("_serviceResult.IsExpanded = false;",
+            "hide-empty should force the row closed while keeping the service visible in the list");
+        snippet.Should().NotContain("this.Visibility = Visibility.Collapsed;",
+            "hide-empty should no longer remove the entire service row from the results list");
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -188,10 +188,12 @@ public class KanbanTodoUxRegressionTests
             "dictionary WebView results should keep a lightweight post-navigation sizing pass");
         code.Should().Contain("await Task.Delay(50);",
             "dictionary WebView sizing should wait briefly for the CSS normalization/layout pass to settle");
+        code.Should().Contain("sender.DispatcherQueue.TryEnqueue(() =>",
+            "dictionary WebView height changes should be deferred out of the navigation callback to avoid re-entrant XAML layout cycles");
         code.Should().NotContain("document.querySelectorAll('*')",
             "dictionary navigation should not walk the entire DOM on the UI thread after every query");
-        code.Should().Contain("sender.Height = height + 8;",
-            "dictionary WebView content should expand to its full height so the outer chained ScrollViewer owns overflow");
+        code.Should().Contain("var targetHeight = height + 8;",
+            "dictionary WebView sizing should still derive from measured content height");
         code.Should().NotContain("Math.Min(height + 8, 800)",
             "the WebView should no longer keep its own 800px internal scroll cap");
     }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -17,6 +17,9 @@ public class KanbanTodoUxRegressionTests
 {
     private static readonly string ProjectRoot = FindProjectRoot();
     private static readonly string StringsPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Strings");
+    private static readonly string MainPageXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "MainPage.xaml");
+    private static readonly string MiniWindowXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "MiniWindow.xaml");
+    private static readonly string FixedWindowXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "FixedWindow.xaml");
     private static readonly string SettingsPageXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "SettingsPage.xaml");
     private static readonly string SettingsPageCodePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "SettingsPage.xaml.cs");
     private static readonly string ServiceCheckItemPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Models", "ServiceCheckItem.cs");
@@ -192,8 +195,8 @@ public class KanbanTodoUxRegressionTests
 
         xaml.Should().Contain("x:Name=\"ResultContentScrollViewer\"",
             "service results should use an explicit inner scroll container for long content");
-        xaml.Should().Contain("VerticalScrollBarVisibility=\"Auto\"",
-            "the inner result container should expose a scrollbar when the content is long");
+        xaml.Should().Contain("VerticalScrollBarVisibility=\"Visible\"",
+            "the inner result container should reserve scrollbar width so WebView2 height measurement does not feed back into layout width");
         xaml.Should().Contain("PointerWheelChanged=\"OnResultContentScrollViewerPointerWheelChanged\"",
             "scrolling at the inner boundary should explicitly hand wheel input to the outer results list");
         xaml.Should().Contain("MaxHeight=\"800\"",
@@ -224,6 +227,28 @@ public class KanbanTodoUxRegressionTests
             "the host control should translate WebView wheel-boundary messages into outer ScrollViewer movement");
         code.Should().NotContain("Math.Min(height + 8, 800)",
             "the WebView should no longer keep its own 800px internal scroll cap");
+    }
+
+    [Fact]
+    public void ResultHosts_ReserveScrollbarWidth_ForDictionaryContent()
+    {
+        var mainXaml = File.ReadAllText(MainPageXamlPath);
+        var miniXaml = File.ReadAllText(MiniWindowXamlPath);
+        var fixedXaml = File.ReadAllText(FixedWindowXamlPath);
+        var itemXaml = File.ReadAllText(ServiceResultItemXamlPath);
+
+        mainXaml.Should().Contain("x:Name=\"QuickTranslateContent\"");
+        mainXaml.Should().Contain("VerticalScrollBarVisibility=\"Visible\"",
+            "the main results surface should reserve scrollbar width so dictionary WebView sizing does not feed back into page width");
+        miniXaml.Should().Contain("Grid.Row=\"4\"");
+        miniXaml.Should().Contain("VerticalScrollBarVisibility=\"Visible\"",
+            "the mini-window results host should reserve scrollbar width for the same reason");
+        fixedXaml.Should().Contain("Grid.Row=\"4\"");
+        fixedXaml.Should().Contain("VerticalScrollBarVisibility=\"Visible\"",
+            "the fixed-window results host should reserve scrollbar width for the same reason");
+        itemXaml.Should().Contain("x:Name=\"ResultContentScrollViewer\"");
+        itemXaml.Should().Contain("VerticalScrollBarVisibility=\"Visible\"",
+            "the inner result container should keep a stable viewport width while the dictionary WebView height is being applied");
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -203,10 +203,12 @@ public class KanbanTodoUxRegressionTests
             "the inner result container should cap its viewport height before scrolling");
         code.Should().Contain("private void OnResultContentScrollViewerPointerWheelChanged",
             "the inner scroll container should forward edge wheel gestures to the outer results list");
-        code.Should().Contain("FindAncestorScrollViewer(innerScrollViewer)",
-            "edge-wheel forwarding should locate the parent results ScrollViewer");
-        code.Should().Contain("outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);",
-            "the outer results ScrollViewer should continue scrolling once the inner content hits its edge");
+        code.Should().Contain("private static bool TryScrollViewerChain",
+            "nested wheel forwarding should flow through a shared helper instead of duplicating one-hop ChangeView logic");
+        code.Should().Contain("TryScrollViewerChain(FindAncestorScrollViewer(innerScrollViewer), offsetDelta)",
+            "edge-wheel forwarding should continue through the ancestor scroll chain after the inner result viewer hits its boundary");
+        code.Should().NotContain("outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);",
+            "the inner result viewer should not stop after a single outer-scroll hop");
         code.Should().Contain("MeasureDictionaryHeightAsync(sender)",
             "dictionary WebView results should keep a lightweight post-navigation sizing pass");
         code.Should().Contain("await Task.Delay(50);",
@@ -227,8 +229,12 @@ public class KanbanTodoUxRegressionTests
             "dictionary HTML should also proxy ordinary wheel input back to the host when there is no true internal scroll container");
         code.Should().Contain("private void OnDictWebViewWebMessageReceived",
             "the host control should translate WebView wheel-boundary messages into outer ScrollViewer movement");
-        code.Should().Contain("ResultContentScrollViewer ?? FindAncestorScrollViewer(DictWebView)",
-            "the WebView relay should target the named result-content scroller first instead of relying only on ancestor lookup");
+        code.Should().Contain("TryScrollViewerChain(hostScrollViewer, deltaY)",
+            "the WebView relay should traverse the scroll chain instead of stopping at the first host ScrollViewer");
+        code.Should().Contain("currentScrollViewer = FindAncestorScrollViewer(currentScrollViewer);",
+            "the shared helper should continue climbing through ancestor ScrollViewers when an intermediate host is already at its boundary");
+        code.Should().NotContain("hostScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);",
+            "the WebView relay should not stop after moving only the first host ScrollViewer");
         code.Should().Contain("typeElement.GetString() is not \"dict-wheel-boundary\" and not \"dict-wheel-passthrough\"",
             "the host should accept both boundary handoff and full passthrough wheel messages from the WebView surface");
         code.Should().NotContain("Math.Min(height + 8, 800)",

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -1,0 +1,151 @@
+using System.Xml.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+/// <summary>
+/// Static regression checks for the window/hotkey UX work in
+/// `claude/fix-kanban-todos-FUSvR`.
+///
+/// These tests intentionally validate stable source-level contracts instead of
+/// fragile UI automation interactions, so the new UX behavior stays covered by
+/// `Easydict.WinUI.Tests`.
+/// </summary>
+[Trait("Category", "WinUI")]
+public class KanbanTodoUxRegressionTests
+{
+    private static readonly string ProjectRoot = FindProjectRoot();
+    private static readonly string StringsPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Strings");
+    private static readonly string SettingsPageXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "SettingsPage.xaml");
+    private static readonly string SettingsPageCodePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "SettingsPage.xaml.cs");
+    private static readonly string ServiceResultItemPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "ServiceResultItem.xaml.cs");
+    private static readonly string AppPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "App.xaml.cs");
+    private static readonly string MiniWindowServicePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Services", "MiniWindowService.cs");
+    private static readonly string FixedWindowServicePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Services", "FixedWindowService.cs");
+    private static readonly string MiniWindowPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "MiniWindow.xaml.cs");
+    private static readonly string FixedWindowPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "FixedWindow.xaml.cs");
+
+    [Fact]
+    public void SettingsPage_HotkeysDescription_UsesLocalizedResource()
+    {
+        var xaml = File.ReadAllText(SettingsPageXamlPath);
+        var code = File.ReadAllText(SettingsPageCodePath);
+
+        xaml.Should().Contain("x:Name=\"HotkeysDescriptionText\"",
+            "the Settings page should keep a dedicated hotkey description text block");
+        code.Should().Contain("HotkeysDescriptionText.Text = loc.GetString(\"HotkeysDescription\")",
+            "the restart-required hotkey copy should come from localization resources, not stay hard-coded");
+    }
+
+    [Fact]
+    public void AllLanguages_HaveHotkeysDescriptionResource()
+    {
+        foreach (var languageDir in Directory.GetDirectories(StringsPath))
+        {
+            var reswPath = Path.Combine(languageDir, "Resources.resw");
+            File.Exists(reswPath).Should().BeTrue($"{languageDir} should contain Resources.resw");
+
+            var doc = XDocument.Load(reswPath);
+            var element = doc.Descendants("data")
+                .FirstOrDefault(e => e.Attribute("name")?.Value == "HotkeysDescription");
+
+            element.Should().NotBeNull($"{languageDir} should contain HotkeysDescription");
+            element!.Element("value")?.Value.Should().NotBeNullOrWhiteSpace(
+                $"{languageDir} should provide a non-empty HotkeysDescription translation");
+        }
+    }
+
+    [Fact]
+    public void SettingsPage_PersistsPerHotkeyEnableFlags()
+    {
+        var code = File.ReadAllText(SettingsPageCodePath);
+
+        code.Should().Contain("_settings.EnableShowWindowHotkey = ShowHotkeyEnabledToggle.IsOn;");
+        code.Should().Contain("_settings.EnableTranslateSelectionHotkey = TranslateHotkeyEnabledToggle.IsOn;");
+        code.Should().Contain("_settings.EnableShowMiniWindowHotkey = ShowMiniHotkeyEnabledToggle.IsOn;");
+        code.Should().Contain("_settings.EnableShowFixedWindowHotkey = ShowFixedHotkeyEnabledToggle.IsOn;");
+        code.Should().Contain("_settings.EnableOcrTranslateHotkey = OcrTranslateHotkeyEnabledToggle.IsOn;");
+        code.Should().Contain("_settings.EnableSilentOcrHotkey = SilentOcrHotkeyEnabledToggle.IsOn;");
+    }
+
+    [Fact]
+    public void SettingsPage_PreservesUserServiceOrder()
+    {
+        var code = File.ReadAllText(SettingsPageCodePath);
+
+        code.Should().Contain("private static void MoveServiceUp(",
+            "the Settings page should expose explicit move-up helpers for service ordering");
+        code.Should().Contain("private static void MoveServiceDown(",
+            "the Settings page should expose explicit move-down helpers for service ordering");
+        code.Should().Contain("collection.Move(i, i - 1);",
+            "move-up should reorder the observable collection");
+        code.Should().Contain("collection.Move(i, i + 1);",
+            "move-down should reorder the observable collection");
+        code.Should().Contain("var orderIndex = new Dictionary<string, int>",
+            "service population should honor the persisted enabled-service order");
+        code.Should().Contain("var ordered = managerOrder",
+            "service population should rebuild the view in persisted order");
+    }
+
+    [Fact]
+    public void ServiceResultItem_CollapsesNoResultRowsWhenHideEmptyResultsIsEnabled()
+    {
+        var code = File.ReadAllText(ServiceResultItemPath);
+
+        code.Should().Contain("SettingsService.Instance.HideEmptyServiceResults",
+            "the new settings toggle should control no-result row collapsing");
+        code.Should().Contain("TranslationResultKind.NoResult",
+            "only true no-result responses should be collapsed");
+        code.Should().Contain("this.Visibility = Visibility.Collapsed;",
+            "no-result rows should be removed from layout instead of merely dimmed");
+        code.Should().Contain("this.Visibility = Visibility.Visible;",
+            "rows should become visible again when they later have content or an error");
+    }
+
+    [Fact]
+    public void AppAndWindowServices_ImplementForegroundToggleContract()
+    {
+        var appCode = File.ReadAllText(AppPath);
+        var miniServiceCode = File.ReadAllText(MiniWindowServicePath);
+        var fixedServiceCode = File.ReadAllText(FixedWindowServicePath);
+        var miniWindowCode = File.ReadAllText(MiniWindowPath);
+        var fixedWindowCode = File.ReadAllText(FixedWindowPath);
+
+        appCode.Should().Contain("if (IsMainWindowVisible && IsMainWindowForeground)",
+            "the main window hotkey should hide the foreground window on repeated press");
+        appCode.Should().Contain("MiniWindowService.Instance.IsVisible");
+        appCode.Should().Contain("MiniWindowService.Instance.IsForeground");
+        appCode.Should().Contain("MiniWindowService.Instance.Hide();");
+        appCode.Should().Contain("FixedWindowService.Instance.IsVisible");
+        appCode.Should().Contain("FixedWindowService.Instance.IsForeground");
+        appCode.Should().Contain("FixedWindowService.Instance.Hide();");
+
+        miniServiceCode.Should().Contain("public bool IsForeground => _miniWindow?.IsForeground ?? false;",
+            "the service facade should expose mini-window foreground state");
+        fixedServiceCode.Should().Contain("public bool IsForeground => _fixedWindow?.IsForeground ?? false;",
+            "the service facade should expose fixed-window foreground state");
+
+        miniWindowCode.Should().Contain("public bool IsForeground",
+            "the concrete mini window should expose the foreground check");
+        fixedWindowCode.Should().Contain("public bool IsForeground",
+            "the concrete fixed window should expose the foreground check");
+    }
+
+    private static string FindProjectRoot()
+    {
+        var current = AppDomain.CurrentDomain.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            var solutionPath = Path.Combine(current, "Easydict.Win32.sln");
+            if (File.Exists(solutionPath))
+            {
+                return current;
+            }
+
+            current = Path.GetDirectoryName(current);
+        }
+
+        return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..");
+    }
+}

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -145,6 +145,26 @@ public class KanbanTodoUxRegressionTests
     }
 
     [Fact]
+    public void SettingsPage_ScrollNavSync_DoesNotMutateFontSize()
+    {
+        var code = File.ReadAllText(SettingsPageCodePath);
+        var marker = "private void UpdateActiveNavIcon(int activeIndex)";
+        var start = code.IndexOf(marker, StringComparison.Ordinal);
+
+        start.Should().BeGreaterOrEqualTo(0, "the settings nav rail should still have an active-state update helper");
+        var snippet = code.Substring(start, Math.Min(900, code.Length - start));
+
+        snippet.Should().Contain("AccentFillColorDefaultBrush",
+            "the active nav item should still stand out visually");
+        snippet.Should().Contain("TextFillColorSecondaryBrush",
+            "inactive nav items should still use the secondary styling");
+        snippet.Should().NotContain("icon.FontSize = 16",
+            "scroll-driven nav highlighting must not resize the Auto-column icon rail and trigger a layout feedback loop");
+        snippet.Should().NotContain("icon.FontSize = 14",
+            "scroll-driven nav highlighting should keep icon size stable once the rail is created");
+    }
+
+    [Fact]
     public void ServiceResultItem_LeavesNoResultRowsVisibleButCollapsedWhenHideEmptyResultsIsEnabled()
     {
         var code = File.ReadAllText(ServiceResultItemPath);

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -184,6 +184,12 @@ public class KanbanTodoUxRegressionTests
             "edge-wheel forwarding should locate the parent results ScrollViewer");
         code.Should().Contain("outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);",
             "the outer results ScrollViewer should continue scrolling once the inner content hits its edge");
+        code.Should().Contain("NormalizeDictionaryVerticalOverflowAsync(sender)",
+            "dictionary WebView results should normalize nested HTML overflow before sizing themselves");
+        code.Should().Contain("element.style.overflowY = 'visible';",
+            "nested vertical scrollers inside dictionary HTML should be flattened so wheel input can escape to the host");
+        code.Should().Contain("body.style.overflowY = 'hidden';",
+            "the dictionary document itself should stop owning a separate vertical scroll layer");
         code.Should().Contain("sender.Height = height + 8;",
             "dictionary WebView content should expand to its full height so the outer chained ScrollViewer owns overflow");
         code.Should().NotContain("Math.Min(height + 8, 800)",

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -20,6 +20,7 @@ public class KanbanTodoUxRegressionTests
     private static readonly string SettingsPageXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "SettingsPage.xaml");
     private static readonly string SettingsPageCodePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "SettingsPage.xaml.cs");
     private static readonly string ServiceCheckItemPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Models", "ServiceCheckItem.cs");
+    private static readonly string ServiceResultItemXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "ServiceResultItem.xaml");
     private static readonly string ServiceResultItemPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "ServiceResultItem.xaml.cs");
     private static readonly string AppPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "App.xaml.cs");
     private static readonly string MiniWindowServicePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Services", "MiniWindowService.cs");
@@ -161,6 +162,32 @@ public class KanbanTodoUxRegressionTests
             "hide-empty should force the row closed while keeping the service visible in the list");
         snippet.Should().NotContain("this.Visibility = Visibility.Collapsed;",
             "hide-empty should no longer remove the entire service row from the results list");
+    }
+
+    [Fact]
+    public void ServiceResultItem_UsesChainedInnerScrollForLongContent()
+    {
+        var xaml = File.ReadAllText(ServiceResultItemXamlPath);
+        var code = File.ReadAllText(ServiceResultItemPath);
+
+        xaml.Should().Contain("x:Name=\"ResultContentScrollViewer\"",
+            "service results should use an explicit inner scroll container for long content");
+        xaml.Should().Contain("VerticalScrollBarVisibility=\"Auto\"",
+            "the inner result container should expose a scrollbar when the content is long");
+        xaml.Should().Contain("PointerWheelChanged=\"OnResultContentScrollViewerPointerWheelChanged\"",
+            "scrolling at the inner boundary should explicitly hand wheel input to the outer results list");
+        xaml.Should().Contain("MaxHeight=\"800\"",
+            "the inner result container should cap its viewport height before scrolling");
+        code.Should().Contain("private void OnResultContentScrollViewerPointerWheelChanged",
+            "the inner scroll container should forward edge wheel gestures to the outer results list");
+        code.Should().Contain("FindAncestorScrollViewer(innerScrollViewer)",
+            "edge-wheel forwarding should locate the parent results ScrollViewer");
+        code.Should().Contain("outerScrollViewer.ChangeView(null, targetOffset, null, disableAnimation: true);",
+            "the outer results ScrollViewer should continue scrolling once the inner content hits its edge");
+        code.Should().Contain("sender.Height = height + 8;",
+            "dictionary WebView content should expand to its full height so the outer chained ScrollViewer owns overflow");
+        code.Should().NotContain("Math.Min(height + 8, 800)",
+            "the WebView should no longer keep its own 800px internal scroll cap");
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -89,20 +89,35 @@ public class KanbanTodoUxRegressionTests
             "service population should honor the persisted enabled-service order");
         code.Should().Contain("var ordered = managerOrder",
             "service population should rebuild the view in persisted order");
-        xaml.Should().Contain("x:Name=\"ServiceReorderModeButton\"",
-            "the Settings page should provide an explicit entry point for reordering instead of always showing move controls");
-        xaml.Should().Contain("Click=\"OnToggleServiceReorderModeClicked\"",
-            "the reorder entry should toggle an explicit reorder mode");
+        xaml.Should().NotContain("x:Name=\"ServiceReorderModeButton\"",
+            "the old single global reorder entry should be replaced by per-window entry points");
+        xaml.Should().Contain("x:Name=\"MainWindowReorderModeButton\"",
+            "main window services should have their own reorder entry point");
+        xaml.Should().Contain("x:Name=\"MiniWindowReorderModeButton\"",
+            "mini window services should have their own reorder entry point");
+        xaml.Should().Contain("x:Name=\"FixedWindowReorderModeButton\"",
+            "fixed window services should have their own reorder entry point");
+        xaml.Should().Contain("Click=\"OnToggleMainWindowReorderModeClicked\"",
+            "the main window reorder entry should toggle that section's reorder mode");
+        xaml.Should().Contain("Click=\"OnToggleMiniWindowReorderModeClicked\"",
+            "the mini window reorder entry should toggle that section's reorder mode");
+        xaml.Should().Contain("Click=\"OnToggleFixedWindowReorderModeClicked\"",
+            "the fixed window reorder entry should toggle that section's reorder mode");
         xaml.Should().Contain("Visibility=\"{Binding IsReorderModeEnabled, Converter={StaticResource BoolToVisibilityConverter}}\"",
             "per-row move buttons should only appear while reorder mode is enabled");
         itemCode.Should().Contain("public bool IsReorderModeEnabled",
             "service items should expose reorder-mode visibility state for the move controls");
-        code.Should().Contain("SetServiceReorderMode(false);",
+        code.Should().Contain("private const string ReorderButtonEmoji = \"\\u2195\\uFE0F\";",
+            "the new per-window reorder entries should include the requested emoji marker");
+        code.Should().Contain("ResetServiceReorderModes();",
             "the page should fall back to the clean default state after load/save");
         code.Should().Contain("EnabledServicesReorderButton",
             "the reorder entry should use localized copy");
         code.Should().Contain("EnabledServicesDoneReorderingButton",
             "the active-state button label should also come from localization");
+        AssertPrecedes(xaml, "MainWindowReorderModeButton", "MainWindowHeaderText");
+        AssertPrecedes(xaml, "MiniWindowReorderModeButton", "MiniWindowHeaderText");
+        AssertPrecedes(xaml, "FixedWindowReorderModeButton", "FixedWindowHeaderText");
     }
 
     [Fact]
@@ -192,5 +207,16 @@ public class KanbanTodoUxRegressionTests
         }
 
         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..");
+    }
+
+    private static void AssertPrecedes(string content, string firstName, string secondName)
+    {
+        var firstIndex = content.IndexOf($"x:Name=\"{firstName}\"", StringComparison.Ordinal);
+        var secondIndex = content.IndexOf($"x:Name=\"{secondName}\"", StringComparison.Ordinal);
+
+        firstIndex.Should().BeGreaterOrEqualTo(0, $"{firstName} should exist in SettingsPage.xaml");
+        secondIndex.Should().BeGreaterOrEqualTo(0, $"{secondName} should exist in SettingsPage.xaml");
+        firstIndex.Should().BeLessThan(secondIndex,
+            $"{firstName} should be rendered before {secondName} in the section header");
     }
 }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -256,6 +256,21 @@ public class KanbanTodoUxRegressionTests
     }
 
     [Fact]
+    public void ServiceResultItem_RawHtmlPath_FallsBackToPlainTextWhenWebViewFails()
+    {
+        var code = File.ReadAllText(ServiceResultItemPath);
+
+        code.Should().Contain("private void ShowRawHtmlPlainTextFallback",
+            "MDX dictionary rendering should keep a dedicated plain-text fallback helper");
+        code.Should().Contain("ShowRawHtmlPlainTextFallback(_serviceResult.Result, resultTextBrush);",
+            "the RawHtml branch should seed visible plain text before WebView2 finishes loading");
+        code.Should().Contain("ShowRawHtmlPlainTextFallback(_serviceResult.Result);",
+            "navigation and sizing failures should restore the plain-text fallback instead of leaving the result blank");
+        code.Should().NotContain("if (!args.IsSuccess) return;",
+            "failed WebView2 navigations must not silently exit without restoring visible content");
+    }
+
+    [Fact]
     public void AppAndWindowServices_ImplementForegroundToggleContract()
     {
         var appCode = File.ReadAllText(AppPath);


### PR DESCRIPTION
- #122: Add per-hotkey enable toggles in Settings; HotkeyService gates
  RegisterHotKey on each EnableXxxHotkey flag (default true).
- #123: Re-pressing a window's hotkey while that window is foreground
  now hides it. OnShowWindowHotkey, OnShowMiniWindowHotkey, and
  OnShowFixedWindowHotkey check IsVisible+IsForeground for toggle.
- #124: Add HideEmptyServiceResults setting (default true);
  ServiceResultItem.UpdateUI collapses the entire control when the
  service returned NoResult.
- #125: Add up/down reorder buttons to the per-window service lists in
  Settings; PopulateServiceCollection now sorts by saved enabledServices
  index so the order persists.
- #127: Fix Mini/Fixed window scrolling — change the ScrollViewer's row
  to Height="*" so the inner StackPanel actually becomes scrollable
  once contents exceed the 800 DIP cap.
- #129: Bring window to top via hotkey when already visible but in the
  background. FixedWindow.ShowAndActivate and App.ShowAndActivateWindow
  now call MoveInZOrderAtTop + SetForegroundWindow (matching MiniWindow).