### PR TITLE
fix: demote no-result service rows instead of leaving empty headers (…

### DIFF
--- a/dotnet/src/Easydict.WinUI/Services/ServiceResultDemotionHelper.cs
+++ b/dotnet/src/Easydict.WinUI/Services/ServiceResultDemotionHelper.cs
@@ -1,0 +1,45 @@
+using Easydict.TranslationService.Models;
+
+namespace Easydict.WinUI.Services;
+
+/// <summary>
+/// Shared predicate for deciding whether a <see cref="ServiceQueryResult"/> row should be
+/// demoted: grayed out, moved to the bottom of the results list, and not expandable.
+///
+/// A row is demoted when the user enabled <see cref="SettingsService.HideEmptyServiceResults"/>
+/// AND the query completed with <see cref="TranslationResultKind.NoResult"/> (no loading,
+/// streaming, or error in flight).
+/// </summary>
+internal static class ServiceResultDemotionHelper
+{
+    public static bool IsDemoted(ServiceQueryResult? result) =>
+        IsDemoted(result, SettingsService.Instance.HideEmptyServiceResults);
+
+    public static bool IsDemoted(ServiceQueryResult? result, bool hideEmptySetting)
+    {
+        if (result is null || !hideEmptySetting) return false;
+        return !result.IsLoading
+            && !result.IsStreaming
+            && !result.HasError
+            && result.Result?.ResultKind == TranslationResultKind.NoResult;
+    }
+
+    /// <summary>
+    /// Stable partition: returns the input indices rearranged so non-demoted rows come first
+    /// (in their original order) followed by demoted rows (in their original order).
+    /// </summary>
+    public static IReadOnlyList<int> StablePartitionIndices(
+        IReadOnlyList<ServiceQueryResult> results,
+        bool hideEmptySetting)
+    {
+        var kept = new List<int>(results.Count);
+        var demoted = new List<int>();
+        for (int i = 0; i < results.Count; i++)
+        {
+            if (IsDemoted(results[i], hideEmptySetting)) demoted.Add(i);
+            else kept.Add(i);
+        }
+        kept.AddRange(demoted);
+        return kept;
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -199,10 +199,28 @@ public sealed class SettingsService
     public bool EnableOcrTranslateHotkey { get; set; } = true;
     public bool EnableSilentOcrHotkey { get; set; } = true;
 
+    private bool _hideEmptyServiceResults = true;
+
     /// <summary>
-    /// When true, ServiceResultItem panels collapse entirely when the service returned no result.
+    /// When true, ServiceResultItem rows for services that returned no result are demoted
+    /// (grayed out, moved to the bottom of the list, and not expandable).
     /// </summary>
-    public bool HideEmptyServiceResults { get; set; } = true;
+    public bool HideEmptyServiceResults
+    {
+        get => _hideEmptyServiceResults;
+        set
+        {
+            if (_hideEmptyServiceResults == value) return;
+            _hideEmptyServiceResults = value;
+            HideEmptyServiceResultsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Raised when <see cref="HideEmptyServiceResults"/> changes. Subscribers should refresh any
+    /// UI that depends on the demotion state of no-result service rows.
+    /// </summary>
+    public event EventHandler? HideEmptyServiceResultsChanged;
 
     /// <summary>
     /// Preferred OCR recognition language. "auto" uses the system profile languages.

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
@@ -8,6 +8,7 @@
     mc:Ignorable="d">
 
     <Border
+        x:Name="RootBorder"
         Background="{ThemeResource ResultViewBackgroundBrush}"
         CornerRadius="6"
         Margin="0,0,0,4"

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -46,6 +46,12 @@ public sealed partial class ServiceResultItem : UserControl
         ToolTipService.SetToolTip(ReplaceButton, LocalizationService.Instance.GetString("InsertReplace"));
     }
 
+    /// <summary>
+    /// Re-runs <see cref="UpdateUI"/> to pick up changes in the demotion state (e.g., when
+    /// <see cref="SettingsService.HideEmptyServiceResults"/> is toggled at runtime).
+    /// </summary>
+    public void RefreshDemotionState() => UpdateUI();
+
     public void Cleanup()
     {
         Debug.WriteLine(
@@ -196,9 +202,8 @@ public sealed partial class ServiceResultItem : UserControl
             return;
         }
 
-        // Keep the service row visible for no-result dictionary queries, but force
-        // it collapsed so the header can still show the "No result" status without
-        // expanding the full empty payload.
+        // Demote no-result rows: keep them visible in the list but grayed out, force-collapsed,
+        // and not expandable. MainPage additionally reorders demoted rows to the bottom.
         var hideEmpty = SettingsService.Instance.HideEmptyServiceResults
             && !_serviceResult.IsLoading
             && !_serviceResult.IsStreaming
@@ -208,6 +213,8 @@ public sealed partial class ServiceResultItem : UserControl
         {
             _serviceResult.IsExpanded = false;
         }
+        RootBorder.Opacity = hideEmpty ? 0.5 : 1.0;
+        ArrowIcon.Visibility = hideEmpty ? Visibility.Collapsed : Visibility.Visible;
 
         // Service info
         ServiceNameText.Text = _serviceResult.ServiceDisplayName;
@@ -919,6 +926,13 @@ public sealed partial class ServiceResultItem : UserControl
     {
         if (_serviceResult == null || _serviceResult.IsLoading)
         {
+            return;
+        }
+
+        // Demoted (no-result + hide-empty) rows are not expandable.
+        if (ServiceResultDemotionHelper.IsDemoted(_serviceResult))
+        {
+            e.Handled = true;
             return;
         }
 

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -174,6 +174,8 @@ namespace Easydict.WinUI.Views
 
             // Initialize service result controls based on enabled services
             InitializeServiceResults(skipRebuildWhenDebugFlagSet: true, reason: "OnPageLoaded");
+
+            SettingsService.Instance.HideEmptyServiceResultsChanged += OnHideEmptyServiceResultsChanged;
             InitializeLongDocServices();
             InitializeLongDocOutputDefaults();
             OnLongDocInputModeChanged(LongDocInputModeCombo, null!);
@@ -191,6 +193,8 @@ namespace Easydict.WinUI.Views
             LogObjectState("OnPageUnloaded begin");
 #endif
             _isLoaded = false;
+
+            SettingsService.Instance.HideEmptyServiceResultsChanged -= OnHideEmptyServiceResultsChanged;
 
             if (_useMemoryAbVariantB)
             {
@@ -627,6 +631,8 @@ namespace Easydict.WinUI.Views
                 ResultsPanel.Items.Add(control);
             }
 
+            ReorderResultsPanel();
+
             // Hide placeholder since we have services
             PlaceholderText.Text = LocalizationService.Instance.GetString("TranslationPlaceholder");
             PlaceholderText.Visibility = Visibility.Collapsed;
@@ -668,6 +674,52 @@ namespace Easydict.WinUI.Views
         private void OnServiceCollapseToggled(object? sender, ServiceQueryResult result)
         {
             // Optional: could trigger layout update if needed
+        }
+
+        /// <summary>
+        /// Reorder <see cref="ResultsPanel"/> so that rows demoted by
+        /// <see cref="ServiceResultDemotionHelper.IsDemoted"/> (no-result + hide-empty setting)
+        /// appear at the bottom of the list while preserving the configured order within each
+        /// bucket. Idempotent: safe to call on every result completion.
+        /// </summary>
+        private void ReorderResultsPanel()
+        {
+            if (_resultControls.Count == 0) return;
+
+            var hideEmpty = SettingsService.Instance.HideEmptyServiceResults;
+            var order = ServiceResultDemotionHelper.StablePartitionIndices(_serviceResults, hideEmpty);
+
+            // Only rebuild Items if order actually changes (avoid visual-tree churn during streaming).
+            bool orderMatches = ResultsPanel.Items.Count == _resultControls.Count;
+            for (int i = 0; orderMatches && i < order.Count; i++)
+            {
+                if (!ReferenceEquals(ResultsPanel.Items[i], _resultControls[order[i]]))
+                    orderMatches = false;
+            }
+            if (orderMatches) return;
+
+            // Remove+Insert rather than Clear() to preserve WebView2 and streaming state.
+            for (int i = 0; i < order.Count; i++)
+            {
+                var target = _resultControls[order[i]];
+                var currentIndex = ResultsPanel.Items.IndexOf(target);
+                if (currentIndex == i) continue;
+                if (currentIndex >= 0) ResultsPanel.Items.RemoveAt(currentIndex);
+                ResultsPanel.Items.Insert(i, target);
+            }
+        }
+
+        private void OnHideEmptyServiceResultsChanged(object? sender, EventArgs e)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                foreach (var control in _resultControls)
+                {
+                    control.RefreshDemotionState();
+                }
+                ReorderResultsPanel();
+            });
         }
 
         /// <summary>
@@ -748,6 +800,7 @@ namespace Easydict.WinUI.Views
                     serviceResult.IsLoading = false;
                     serviceResult.ApplyAutoCollapseLogic();
                     UpdatePhoneticDeduplication();
+                    ReorderResultsPanel();
                 }
             }
             catch (OperationCanceledException)
@@ -1047,6 +1100,7 @@ namespace Easydict.WinUI.Views
                                 serviceResult.IsLoading = false;
                                 serviceResult.ApplyAutoCollapseLogic();
                                 UpdatePhoneticDeduplication();
+                                ReorderResultsPanel();
                             });
 
                             outcome = result.ResultKind == TranslationResultKind.Success
@@ -1447,6 +1501,7 @@ namespace Easydict.WinUI.Views
                 serviceResult.Result = result;
                 serviceResult.ApplyAutoCollapseLogic();
                 UpdatePhoneticDeduplication();
+                ReorderResultsPanel();
             });
         }
 

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/ServiceResultDemotionHelperTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/ServiceResultDemotionHelperTests.cs
@@ -1,0 +1,130 @@
+using Easydict.TranslationService;
+using Easydict.TranslationService.Models;
+using Easydict.WinUI.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+public class ServiceResultDemotionHelperTests
+{
+    private static ServiceQueryResult MakeResult(
+        TranslationResultKind? kind = TranslationResultKind.NoResult,
+        bool isLoading = false,
+        bool isStreaming = false,
+        bool hasError = false)
+    {
+        var r = new ServiceQueryResult
+        {
+            ServiceId = "test",
+            IsLoading = isLoading,
+            IsStreaming = isStreaming,
+        };
+        if (hasError)
+        {
+            r.Error = new TranslationException("boom");
+        }
+        if (kind.HasValue)
+        {
+            r.Result = new TranslationResult
+            {
+                ServiceName = "test",
+                ResultKind = kind.Value,
+                TranslatedText = kind == TranslationResultKind.Success ? "hi" : "",
+                OriginalText = "q"
+            };
+        }
+        return r;
+    }
+
+    [Fact]
+    public void IsDemoted_ReturnsFalse_WhenSettingDisabled()
+    {
+        var r = MakeResult(TranslationResultKind.NoResult);
+        ServiceResultDemotionHelper.IsDemoted(r, hideEmptySetting: false).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDemoted_ReturnsTrue_ForNoResultWithSettingEnabled()
+    {
+        var r = MakeResult(TranslationResultKind.NoResult);
+        ServiceResultDemotionHelper.IsDemoted(r, hideEmptySetting: true).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDemoted_ReturnsFalse_ForSuccessResult()
+    {
+        var r = MakeResult(TranslationResultKind.Success);
+        ServiceResultDemotionHelper.IsDemoted(r, hideEmptySetting: true).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDemoted_ReturnsFalse_WhileLoading()
+    {
+        var r = MakeResult(kind: null, isLoading: true);
+        ServiceResultDemotionHelper.IsDemoted(r, hideEmptySetting: true).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDemoted_ReturnsFalse_WhileStreaming()
+    {
+        var r = MakeResult(TranslationResultKind.NoResult, isStreaming: true);
+        ServiceResultDemotionHelper.IsDemoted(r, hideEmptySetting: true).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDemoted_ReturnsFalse_WhenErrorPresent()
+    {
+        var r = MakeResult(TranslationResultKind.NoResult, hasError: true);
+        ServiceResultDemotionHelper.IsDemoted(r, hideEmptySetting: true).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDemoted_ReturnsFalse_ForNullResult()
+    {
+        ServiceResultDemotionHelper.IsDemoted(null, hideEmptySetting: true).Should().BeFalse();
+    }
+
+    [Fact]
+    public void StablePartitionIndices_PreservesOrderWithinBuckets()
+    {
+        var results = new[]
+        {
+            MakeResult(TranslationResultKind.Success),       // 0 kept
+            MakeResult(TranslationResultKind.NoResult),      // 1 demoted
+            MakeResult(TranslationResultKind.Success),       // 2 kept
+            MakeResult(TranslationResultKind.NoResult),      // 3 demoted
+            MakeResult(kind: null, isLoading: true),         // 4 kept (loading)
+        };
+
+        var order = ServiceResultDemotionHelper.StablePartitionIndices(results, hideEmptySetting: true);
+        order.Should().Equal(new[] { 0, 2, 4, 1, 3 });
+    }
+
+    [Fact]
+    public void StablePartitionIndices_IsIdentityWhenSettingDisabled()
+    {
+        var results = new[]
+        {
+            MakeResult(TranslationResultKind.NoResult),
+            MakeResult(TranslationResultKind.Success),
+        };
+        var order = ServiceResultDemotionHelper.StablePartitionIndices(results, hideEmptySetting: false);
+        order.Should().Equal(new[] { 0, 1 });
+    }
+
+    [Fact]
+    public void StablePartitionIndices_Idempotent()
+    {
+        var results = new[]
+        {
+            MakeResult(TranslationResultKind.NoResult),
+            MakeResult(TranslationResultKind.Success),
+            MakeResult(TranslationResultKind.NoResult),
+        };
+        var first = ServiceResultDemotionHelper.StablePartitionIndices(results, hideEmptySetting: true);
+        var reordered = first.Select(i => results[i]).ToArray();
+        var second = ServiceResultDemotionHelper.StablePartitionIndices(reordered, hideEmptySetting: true);
+        second.Should().Equal(new[] { 0, 1, 2 });
+    }
+}


### PR DESCRIPTION
…#133)

When HideEmptyServiceResults is enabled, rows for services that returned NoResult are now grayed out, moved to the bottom of the results list (stable partition), and no longer expandable — rather than staying in place as visible-but-collapsed empty headers.