### PR TITLE
fix: demote no-result rows in Mini/Fixed windows, matching Main

### DIFF
--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -75,6 +75,8 @@ public sealed partial class FixedWindow : Window
         this.Activated += OnWindowActivated;
         this.Closed += OnWindowClosed;
 
+        SettingsService.Instance.HideEmptyServiceResultsChanged += OnHideEmptyServiceResultsChanged;
+
         // Initialize service result controls
         InitializeServiceResults();
 
@@ -308,6 +310,8 @@ public sealed partial class FixedWindow : Window
             _resultControls.Add(control);
             ResultsPanel.Items.Add(control);
         }
+
+        ReorderResultsPanel();
     }
 
     /// <summary>
@@ -376,6 +380,7 @@ public sealed partial class FixedWindow : Window
                 serviceResult.IsLoading = false;
                 serviceResult.ApplyAutoCollapseLogic();
                 UpdatePhoneticDeduplication();
+                ReorderResultsPanel();
                 RequestResize();
             }
         }
@@ -444,6 +449,8 @@ public sealed partial class FixedWindow : Window
     {
         try
         {
+            SettingsService.Instance.HideEmptyServiceResultsChanged -= OnHideEmptyServiceResultsChanged;
+
             _isClosing = true;
             SaveWindowPosition();
             await CleanupResourcesAsync();
@@ -756,6 +763,7 @@ public sealed partial class FixedWindow : Window
                             serviceResult.IsLoading = false;
                             serviceResult.ApplyAutoCollapseLogic();
                             UpdatePhoneticDeduplication();
+                            ReorderResultsPanel();
                             // Coalesced resize so ServiceResultItem.UpdateUI() completes first
                             RequestResize();
                         });
@@ -954,6 +962,7 @@ public sealed partial class FixedWindow : Window
             serviceResult.Result = result;
             serviceResult.ApplyAutoCollapseLogic();
             UpdatePhoneticDeduplication();
+            ReorderResultsPanel();
             // Delay resize to next tick so ServiceResultItem.UpdateUI() completes first
             DispatcherQueue.TryEnqueue(() => RequestResize());
         });
@@ -1344,6 +1353,53 @@ public sealed partial class FixedWindow : Window
         {
             root.RequestedTheme = theme;
         }
+    }
+
+    /// <summary>
+    /// Reorder <see cref="ResultsPanel"/> so that rows demoted by
+    /// <see cref="ServiceResultDemotionHelper.IsDemoted"/> (no-result + hide-empty setting)
+    /// appear at the bottom of the list while preserving the configured order within each
+    /// bucket. Idempotent: safe to call on every result completion.
+    /// </summary>
+    private void ReorderResultsPanel()
+    {
+        if (_resultControls.Count == 0) return;
+
+        var hideEmpty = SettingsService.Instance.HideEmptyServiceResults;
+        var order = ServiceResultDemotionHelper.StablePartitionIndices(_serviceResults, hideEmpty);
+
+        // Only rebuild Items if order actually changes (avoid visual-tree churn during streaming).
+        bool orderMatches = ResultsPanel.Items.Count == _resultControls.Count;
+        for (int i = 0; orderMatches && i < order.Count; i++)
+        {
+            if (!ReferenceEquals(ResultsPanel.Items[i], _resultControls[order[i]]))
+                orderMatches = false;
+        }
+        if (orderMatches) return;
+
+        // Remove+Insert rather than Clear() to preserve WebView2 and streaming state.
+        for (int i = 0; i < order.Count; i++)
+        {
+            var target = _resultControls[order[i]];
+            var currentIndex = ResultsPanel.Items.IndexOf(target);
+            if (currentIndex == i) continue;
+            if (currentIndex >= 0) ResultsPanel.Items.RemoveAt(currentIndex);
+            ResultsPanel.Items.Insert(i, target);
+        }
+    }
+
+    private void OnHideEmptyServiceResultsChanged(object? sender, EventArgs e)
+    {
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_isClosing) return;
+            foreach (var control in _resultControls)
+            {
+                control.RefreshDemotionState();
+            }
+            ReorderResultsPanel();
+            RequestResize();
+        });
     }
 
     /// <summary>

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -96,6 +96,8 @@ public sealed partial class MiniWindow : Window
         this.Activated += OnWindowActivated;
         this.Closed += OnWindowClosed;
 
+        SettingsService.Instance.HideEmptyServiceResultsChanged += OnHideEmptyServiceResultsChanged;
+
         // Initialize service result controls
         InitializeServiceResults();
 
@@ -409,6 +411,8 @@ public sealed partial class MiniWindow : Window
             _resultControls.Add(control);
             ResultsPanel.Items.Add(control);
         }
+
+        ReorderResultsPanel();
     }
 
     /// <summary>
@@ -498,6 +502,7 @@ public sealed partial class MiniWindow : Window
                 serviceResult.IsLoading = false;
                 serviceResult.ApplyAutoCollapseLogic();
                 UpdatePhoneticDeduplication();
+                ReorderResultsPanel();
                 RequestResize();
             }
         }
@@ -607,11 +612,13 @@ public sealed partial class MiniWindow : Window
     {
         try
         {
+            SettingsService.Instance.HideEmptyServiceResultsChanged -= OnHideEmptyServiceResultsChanged;
+
             _isClosing = true;
-            
+
             // Stop any ongoing TTS audio immediately
             TextToSpeechService.Instance.Stop();
-            
+
             SaveWindowPosition();
             await CleanupResourcesAsync();
         }
@@ -1005,6 +1012,7 @@ public sealed partial class MiniWindow : Window
                             serviceResult.IsLoading = false;
                             serviceResult.ApplyAutoCollapseLogic();
                             UpdatePhoneticDeduplication();
+                            ReorderResultsPanel();
 
                             if (result.ResultKind == TranslationResultKind.Success &&
                                 !_hasAutoPlayedCurrentQuery && SettingsService.Instance.AutoPlayTranslation)
@@ -1379,6 +1387,7 @@ public sealed partial class MiniWindow : Window
             serviceResult.Result = result;
             serviceResult.ApplyAutoCollapseLogic();
             UpdatePhoneticDeduplication();
+            ReorderResultsPanel();
 
             if (result.ResultKind == TranslationResultKind.Success &&
                 !_hasAutoPlayedCurrentQuery && SettingsService.Instance.AutoPlayTranslation)
@@ -1892,6 +1901,53 @@ public sealed partial class MiniWindow : Window
         {
             root.RequestedTheme = theme;
         }
+    }
+
+    /// <summary>
+    /// Reorder <see cref="ResultsPanel"/> so that rows demoted by
+    /// <see cref="ServiceResultDemotionHelper.IsDemoted"/> (no-result + hide-empty setting)
+    /// appear at the bottom of the list while preserving the configured order within each
+    /// bucket. Idempotent: safe to call on every result completion.
+    /// </summary>
+    private void ReorderResultsPanel()
+    {
+        if (_resultControls.Count == 0) return;
+
+        var hideEmpty = SettingsService.Instance.HideEmptyServiceResults;
+        var order = ServiceResultDemotionHelper.StablePartitionIndices(_serviceResults, hideEmpty);
+
+        // Only rebuild Items if order actually changes (avoid visual-tree churn during streaming).
+        bool orderMatches = ResultsPanel.Items.Count == _resultControls.Count;
+        for (int i = 0; orderMatches && i < order.Count; i++)
+        {
+            if (!ReferenceEquals(ResultsPanel.Items[i], _resultControls[order[i]]))
+                orderMatches = false;
+        }
+        if (orderMatches) return;
+
+        // Remove+Insert rather than Clear() to preserve WebView2 and streaming state.
+        for (int i = 0; i < order.Count; i++)
+        {
+            var target = _resultControls[order[i]];
+            var currentIndex = ResultsPanel.Items.IndexOf(target);
+            if (currentIndex == i) continue;
+            if (currentIndex >= 0) ResultsPanel.Items.RemoveAt(currentIndex);
+            ResultsPanel.Items.Insert(i, target);
+        }
+    }
+
+    private void OnHideEmptyServiceResultsChanged(object? sender, EventArgs e)
+    {
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_isClosing) return;
+            foreach (var control in _resultControls)
+            {
+                control.RefreshDemotionState();
+            }
+            ReorderResultsPanel();
+            RequestResize();
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
Extends PR #134's demotion behavior to MiniWindow and FixedWindow so that services returning TranslationResultKind.NoResult are greyed and sent to the bottom of the list, instead of leaving empty headers among real results.

Both windows now subscribe to HideEmptyServiceResultsChanged, reuse ServiceResultDemotionHelper.StablePartitionIndices, and call ReorderResultsPanel() at the same four completion sites MainPage uses (init, manual re-query, batch non-streaming, streaming final enrichment). The handler also triggers RequestResize() since these windows are auto-sizing.