### PR TITLE
fix(windows): clamp restored window positions to attached monitors

### DIFF
--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -368,6 +368,9 @@ public sealed class SettingsService
     public bool MiniWindowAutoClose { get; set; } = true;
     public double MiniWindowXDips { get; set; } = 0;
     public double MiniWindowYDips { get; set; } = 0;
+    // Distinguishes "never saved" from "saved at (0, 0)" or saved to a monitor whose
+    // virtual-screen coordinates are negative (monitor placed left/above primary).
+    public bool MiniWindowPositionSaved { get; set; } = false;
     public double MiniWindowWidthDips { get; set; } = 320;
     public double MiniWindowHeightDips { get; set; } = 200;
     public bool MiniWindowIsPinned { get; set; } = false;
@@ -393,6 +396,8 @@ public sealed class SettingsService
     public string ShowFixedWindowHotkey { get; set; } = "Ctrl+Alt+F";
     public double FixedWindowXDips { get; set; } = 0;
     public double FixedWindowYDips { get; set; } = 0;
+    // See MiniWindowPositionSaved.
+    public bool FixedWindowPositionSaved { get; set; } = false;
     public double FixedWindowWidthDips { get; set; } = 320;
     public double FixedWindowHeightDips { get; set; } = 280;
 
@@ -682,6 +687,11 @@ public sealed class SettingsService
         MiniWindowAutoClose = GetValue(nameof(MiniWindowAutoClose), true);
         MiniWindowXDips = GetValue(nameof(MiniWindowXDips), 0.0);
         MiniWindowYDips = GetValue(nameof(MiniWindowYDips), 0.0);
+        // Migration: pre-flag versions only stored coords. If either is non-zero, treat
+        // as previously saved so the user's position survives the upgrade.
+        MiniWindowPositionSaved = GetValue(
+            nameof(MiniWindowPositionSaved),
+            MiniWindowXDips != 0.0 || MiniWindowYDips != 0.0);
         MiniWindowWidthDips = GetValue(nameof(MiniWindowWidthDips), 320.0);
         MiniWindowHeightDips = GetValue(nameof(MiniWindowHeightDips), 200.0);
         MiniWindowIsPinned = GetValue(nameof(MiniWindowIsPinned), false);
@@ -693,6 +703,10 @@ public sealed class SettingsService
         ShowFixedWindowHotkey = GetValue(nameof(ShowFixedWindowHotkey), "Ctrl+Alt+F");
         FixedWindowXDips = GetValue(nameof(FixedWindowXDips), 0.0);
         FixedWindowYDips = GetValue(nameof(FixedWindowYDips), 0.0);
+        // See MiniWindowPositionSaved migration note.
+        FixedWindowPositionSaved = GetValue(
+            nameof(FixedWindowPositionSaved),
+            FixedWindowXDips != 0.0 || FixedWindowYDips != 0.0);
         FixedWindowWidthDips = GetValue(nameof(FixedWindowWidthDips), 320.0);
         FixedWindowHeightDips = GetValue(nameof(FixedWindowHeightDips), 280.0);
         FixedWindowEnabledServices = GetStringList(nameof(FixedWindowEnabledServices), ["google"]);
@@ -860,6 +874,7 @@ public sealed class SettingsService
         _settings[nameof(MiniWindowAutoClose)] = MiniWindowAutoClose;
         _settings[nameof(MiniWindowXDips)] = MiniWindowXDips;
         _settings[nameof(MiniWindowYDips)] = MiniWindowYDips;
+        _settings[nameof(MiniWindowPositionSaved)] = MiniWindowPositionSaved;
         _settings[nameof(MiniWindowWidthDips)] = MiniWindowWidthDips;
         _settings[nameof(MiniWindowHeightDips)] = MiniWindowHeightDips;
         _settings[nameof(MiniWindowIsPinned)] = MiniWindowIsPinned;
@@ -871,6 +886,7 @@ public sealed class SettingsService
         _settings[nameof(ShowFixedWindowHotkey)] = ShowFixedWindowHotkey;
         _settings[nameof(FixedWindowXDips)] = FixedWindowXDips;
         _settings[nameof(FixedWindowYDips)] = FixedWindowYDips;
+        _settings[nameof(FixedWindowPositionSaved)] = FixedWindowPositionSaved;
         _settings[nameof(FixedWindowWidthDips)] = FixedWindowWidthDips;
         _settings[nameof(FixedWindowHeightDips)] = FixedWindowHeightDips;
         _settings[nameof(FixedWindowEnabledServices)] = FixedWindowEnabledServices;

--- a/dotnet/src/Easydict.WinUI/Services/WindowPositionHelper.cs
+++ b/dotnet/src/Easydict.WinUI/Services/WindowPositionHelper.cs
@@ -140,8 +140,12 @@ public static class WindowPositionHelper
         {
             workAreas.Add(primary.WorkArea);
         }
-        foreach (var display in displays)
+        // Index-based iteration: foreach on the WinRT-projected IReadOnlyList<DisplayArea>
+        // throws InvalidCastException because the underlying WinRT object can't be QI'd
+        // for IEnumerable<DisplayArea>. Indexing goes through a different code path.
+        for (var i = 0; i < displays.Count; i++)
         {
+            var display = displays[i];
             if (primary != null && display.DisplayId.Value == primary.DisplayId.Value)
             {
                 continue;

--- a/dotnet/src/Easydict.WinUI/Services/WindowPositionHelper.cs
+++ b/dotnet/src/Easydict.WinUI/Services/WindowPositionHelper.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Windowing;
+using Windows.Graphics;
+
+namespace Easydict.WinUI.Services;
+
+/// <summary>
+/// Clamps saved window positions to the currently-attached monitors so a
+/// restored window never appears off-screen — e.g. after an external monitor
+/// is disconnected (issue #148).
+/// </summary>
+public static class WindowPositionHelper
+{
+    /// <summary>
+    /// <list type="bullet">
+    /// <item>If every corner of the desired rect is inside the union of work areas
+    /// (e.g. the user deliberately straddled two monitors), the position is
+    /// returned unchanged.</item>
+    /// <item>Otherwise the largest-overlap work area is chosen and the position is
+    /// shifted so the window fits inside it.</item>
+    /// <item>If the desired rect doesn't overlap any work area, returns false so
+    /// the caller can fall back to its own default placement.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="workAreas">First entry wins overlap ties (callers should put the primary monitor first).</param>
+    public static bool TryClampToVisibleWorkArea(
+        PointInt32 desiredTopLeft,
+        SizeInt32 windowSize,
+        IReadOnlyList<RectInt32> workAreas,
+        out PointInt32 clamped)
+    {
+        clamped = default;
+        if (workAreas == null || workAreas.Count == 0)
+        {
+            return false;
+        }
+
+        // If every corner is covered by some work area, the window is fully visible
+        // (modulo unusual gapped monitor layouts) — preserve the user's chosen position.
+        if (AllCornersCovered(desiredTopLeft, windowSize, workAreas))
+        {
+            clamped = desiredTopLeft;
+            return true;
+        }
+
+        long bestOverlap = 0;
+        var bestIndex = -1;
+
+        for (var i = 0; i < workAreas.Count; i++)
+        {
+            var overlap = IntersectionArea(desiredTopLeft, windowSize, workAreas[i]);
+            if (overlap > bestOverlap)
+            {
+                bestOverlap = overlap;
+                bestIndex = i;
+            }
+        }
+
+        if (bestIndex < 0)
+        {
+            return false;
+        }
+
+        var work = workAreas[bestIndex];
+
+        // Shift (do not resize) so the window fits inside the chosen work area.
+        // If the window is wider/taller than the work area, pin to that axis's
+        // top-left rather than producing a negative coordinate.
+        var maxX = work.X + Math.Max(0, work.Width - windowSize.Width);
+        var maxY = work.Y + Math.Max(0, work.Height - windowSize.Height);
+        var x = Math.Clamp(desiredTopLeft.X, work.X, maxX);
+        var y = Math.Clamp(desiredTopLeft.Y, work.Y, maxY);
+
+        clamped = new PointInt32(x, y);
+        return true;
+    }
+
+    private static bool AllCornersCovered(
+        PointInt32 topLeft,
+        SizeInt32 size,
+        IReadOnlyList<RectInt32> workAreas)
+    {
+        // Right/bottom edges are exclusive: the rect (x, y, x+w, y+h) covers
+        // pixels in [x, x+w) × [y, y+h), so a corner exactly at the rect's
+        // right or bottom edge belongs to the *next* monitor (if any).
+        var right = topLeft.X + size.Width;
+        var bottom = topLeft.Y + size.Height;
+        return CoveredExclusive(topLeft.X, topLeft.Y, workAreas)
+            && CoveredExclusive(right - 1, topLeft.Y, workAreas)
+            && CoveredExclusive(topLeft.X, bottom - 1, workAreas)
+            && CoveredExclusive(right - 1, bottom - 1, workAreas);
+    }
+
+    private static bool CoveredExclusive(int x, int y, IReadOnlyList<RectInt32> workAreas)
+    {
+        for (var i = 0; i < workAreas.Count; i++)
+        {
+            var w = workAreas[i];
+            if (x >= w.X && x < w.X + w.Width && y >= w.Y && y < w.Y + w.Height)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Pulls the current monitor work areas (primary first) and forwards to
+    /// <see cref="TryClampToVisibleWorkArea"/>.
+    /// </summary>
+    public static bool TryGetVisiblePosition(
+        PointInt32 desiredTopLeft,
+        SizeInt32 windowSize,
+        out PointInt32 result)
+    {
+        result = default;
+
+        IReadOnlyList<DisplayArea> displays;
+        try
+        {
+            displays = DisplayArea.FindAll();
+        }
+        catch (COMException)
+        {
+            // DisplayArea is a WinRT API; the realistic failure mode is the runtime
+            // not being initialized. Fall back to the caller's default placement.
+            return false;
+        }
+
+        if (displays.Count == 0)
+        {
+            return false;
+        }
+
+        var primary = DisplayArea.Primary;
+        var workAreas = new List<RectInt32>(displays.Count);
+        if (primary != null)
+        {
+            workAreas.Add(primary.WorkArea);
+        }
+        foreach (var display in displays)
+        {
+            if (primary != null && display.DisplayId.Value == primary.DisplayId.Value)
+            {
+                continue;
+            }
+            workAreas.Add(display.WorkArea);
+        }
+
+        return TryClampToVisibleWorkArea(desiredTopLeft, windowSize, workAreas, out result);
+    }
+
+    private static long IntersectionArea(PointInt32 topLeft, SizeInt32 size, RectInt32 work)
+    {
+        var left = Math.Max(topLeft.X, work.X);
+        var top = Math.Max(topLeft.Y, work.Y);
+        var right = Math.Min(topLeft.X + size.Width, work.X + work.Width);
+        var bottom = Math.Min(topLeft.Y + size.Height, work.Y + work.Height);
+        var w = right - left;
+        var h = bottom - top;
+        if (w <= 0 || h <= 0)
+        {
+            return 0;
+        }
+        return (long)w * h;
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -216,7 +216,9 @@ public sealed partial class FixedWindow : Window
 
         // Try saved position first; fall through to the default if it's off-screen
         // (e.g. saved on a now-disconnected external monitor — issue #148).
-        if (_settings.FixedWindowXDips > 0 || _settings.FixedWindowYDips > 0)
+        // Use the explicit "saved" flag rather than `> 0` so monitors with negative
+        // virtual-screen coordinates (placed left/above primary) still restore.
+        if (_settings.FixedWindowPositionSaved)
         {
             var savedX = (int)DpiHelper.DipsToPhysicalPixels(_settings.FixedWindowXDips, scale);
             var savedY = (int)DpiHelper.DipsToPhysicalPixels(_settings.FixedWindowYDips, scale);
@@ -253,6 +255,7 @@ public sealed partial class FixedWindow : Window
 
         _settings.FixedWindowXDips = DpiHelper.PhysicalPixelsToDips(position.X, scale);
         _settings.FixedWindowYDips = DpiHelper.PhysicalPixelsToDips(position.Y, scale);
+        _settings.FixedWindowPositionSaved = true;
         _settings.Save();
     }
 

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -214,25 +214,29 @@ public sealed partial class FixedWindow : Window
         var hWnd = WindowNative.GetWindowHandle(this);
         var scale = DpiHelper.GetScaleFactorForWindow(hWnd);
 
-        // Check if we have a saved position
+        // Try saved position first; fall through to the default if it's off-screen
+        // (e.g. saved on a now-disconnected external monitor — issue #148).
         if (_settings.FixedWindowXDips > 0 || _settings.FixedWindowYDips > 0)
         {
-            var x = DpiHelper.DipsToPhysicalPixels(_settings.FixedWindowXDips, scale);
-            var y = DpiHelper.DipsToPhysicalPixels(_settings.FixedWindowYDips, scale);
-            _appWindow.Move(new PointInt32((int)x, (int)y));
-        }
-        else
-        {
-            // Center on primary display
-            var displayArea = DisplayArea.Primary;
-            if (displayArea != null)
+            var savedX = (int)DpiHelper.DipsToPhysicalPixels(_settings.FixedWindowXDips, scale);
+            var savedY = (int)DpiHelper.DipsToPhysicalPixels(_settings.FixedWindowYDips, scale);
+            if (WindowPositionHelper.TryGetVisiblePosition(
+                    new PointInt32(savedX, savedY), _appWindow.Size, out var safe))
             {
-                var workArea = displayArea.WorkArea;
-                var windowSize = _appWindow.Size;
-                var x = (workArea.Width - windowSize.Width) / 2 + workArea.X;
-                var y = (workArea.Height - windowSize.Height) / 2 + workArea.Y;
-                _appWindow.Move(new PointInt32(x, y));
+                _appWindow.Move(safe);
+                return;
             }
+        }
+
+        // Default: center on primary display
+        var primary = DisplayArea.Primary;
+        if (primary != null)
+        {
+            var workArea = primary.WorkArea;
+            var windowSize = _appWindow.Size;
+            var x = (workArea.Width - windowSize.Width) / 2 + workArea.X;
+            var y = (workArea.Height - windowSize.Height) / 2 + workArea.Y;
+            _appWindow.Move(new PointInt32(x, y));
         }
     }
 

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -291,7 +291,9 @@ public sealed partial class MiniWindow : Window
 
         // Try saved position first; fall through to the default if it's off-screen
         // (e.g. saved on a now-disconnected external monitor — issue #148).
-        if (_settings.MiniWindowXDips > 0 || _settings.MiniWindowYDips > 0)
+        // Use the explicit "saved" flag rather than `> 0` so monitors with negative
+        // virtual-screen coordinates (placed left/above primary) still restore.
+        if (_settings.MiniWindowPositionSaved)
         {
             var savedX = (int)DpiHelper.DipsToPhysicalPixels(_settings.MiniWindowXDips, scale);
             var savedY = (int)DpiHelper.DipsToPhysicalPixels(_settings.MiniWindowYDips, scale);
@@ -346,6 +348,7 @@ public sealed partial class MiniWindow : Window
 
         _settings.MiniWindowXDips = DpiHelper.PhysicalPixelsToDips(position.X, scale);
         _settings.MiniWindowYDips = DpiHelper.PhysicalPixelsToDips(position.Y, scale);
+        _settings.MiniWindowPositionSaved = true;
         _settings.MiniWindowIsPinned = _isPinned;
         _settings.Save();
     }

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -289,43 +289,47 @@ public sealed partial class MiniWindow : Window
         var hWnd = WindowNative.GetWindowHandle(this);
         var scale = DpiHelper.GetScaleFactorForWindow(hWnd);
 
-        // Check if we have a saved position
+        // Try saved position first; fall through to the default if it's off-screen
+        // (e.g. saved on a now-disconnected external monitor — issue #148).
         if (_settings.MiniWindowXDips > 0 || _settings.MiniWindowYDips > 0)
         {
-            var x = DpiHelper.DipsToPhysicalPixels(_settings.MiniWindowXDips, scale);
-            var y = DpiHelper.DipsToPhysicalPixels(_settings.MiniWindowYDips, scale);
-            _appWindow.Move(new PointInt32((int)x, (int)y));
-        }
-        else
-        {
-            // Position at top-right corner of the screen where cursor is located
-            var gotCursorPos = GetCursorPos(out var cursorPos);
-
-            // Use cursor position when available; otherwise fall back to display containing current window
-            var displayArea = gotCursorPos
-                ? DisplayArea.GetFromPoint(
-                    new PointInt32(cursorPos.X, cursorPos.Y),
-                    DisplayAreaFallback.Primary)
-                : DisplayArea.GetFromWindowId(_appWindow.Id, DisplayAreaFallback.Primary);
-
-            if (displayArea != null)
+            var savedX = (int)DpiHelper.DipsToPhysicalPixels(_settings.MiniWindowXDips, scale);
+            var savedY = (int)DpiHelper.DipsToPhysicalPixels(_settings.MiniWindowYDips, scale);
+            if (WindowPositionHelper.TryGetVisiblePosition(
+                    new PointInt32(savedX, savedY), _appWindow.Size, out var safe))
             {
-                var workArea = displayArea.WorkArea;
-                var windowSize = _appWindow.Size;
-
-                // Use DIP-aware margin (20 DIPs) for consistent appearance across DPI settings
-                const int marginDips = 20;
-                var margin = (int)DpiHelper.DipsToPhysicalPixels(marginDips, scale);
-
-                var x = workArea.X + workArea.Width - windowSize.Width - margin;
-                var y = workArea.Y + margin;
-
-                // Clamp to keep window within display work area
-                x = Math.Max(workArea.X, Math.Min(x, workArea.X + workArea.Width - windowSize.Width));
-                y = Math.Max(workArea.Y, Math.Min(y, workArea.Y + workArea.Height - windowSize.Height));
-
-                _appWindow.Move(new PointInt32(x, y));
+                _appWindow.Move(safe);
+                return;
             }
+        }
+
+        // Default: top-right corner of the display where the cursor lives
+        var gotCursorPos = GetCursorPos(out var cursorPos);
+
+        // Use cursor position when available; otherwise fall back to display containing current window
+        var displayArea = gotCursorPos
+            ? DisplayArea.GetFromPoint(
+                new PointInt32(cursorPos.X, cursorPos.Y),
+                DisplayAreaFallback.Primary)
+            : DisplayArea.GetFromWindowId(_appWindow.Id, DisplayAreaFallback.Primary);
+
+        if (displayArea != null)
+        {
+            var workArea = displayArea.WorkArea;
+            var windowSize = _appWindow.Size;
+
+            // Use DIP-aware margin (20 DIPs) for consistent appearance across DPI settings
+            const int marginDips = 20;
+            var margin = (int)DpiHelper.DipsToPhysicalPixels(marginDips, scale);
+
+            var x = workArea.X + workArea.Width - windowSize.Width - margin;
+            var y = workArea.Y + margin;
+
+            // Clamp to keep window within display work area
+            x = Math.Max(workArea.X, Math.Min(x, workArea.X + workArea.Width - windowSize.Width));
+            y = Math.Max(workArea.Y, Math.Min(y, workArea.Y + workArea.Height - windowSize.Height));
+
+            _appWindow.Move(new PointInt32(x, y));
         }
     }
 

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/WindowPositionHelperTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/WindowPositionHelperTests.cs
@@ -1,0 +1,197 @@
+using Easydict.WinUI.Services;
+using FluentAssertions;
+using Windows.Graphics;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+/// <summary>
+/// Tests the pure clamping logic of <see cref="WindowPositionHelper"/>.
+/// Drives <see cref="WindowPositionHelper.TryClampToVisibleWorkArea"/> with synthetic
+/// work areas so the production wrapper's <c>DisplayArea.FindAll()</c> dependency stays
+/// out of the test (DisplayArea requires the Windows App SDK runtime).
+/// </summary>
+public class WindowPositionHelperTests
+{
+    private static readonly RectInt32 PrimaryWorkArea = new(0, 0, 1920, 1080);
+    private static readonly RectInt32 SecondaryRightWorkArea = new(1920, 0, 2560, 1440);
+    private static readonly SizeInt32 MiniSize = new(400, 200);
+
+    [Fact]
+    public void Clamp_PointInsideWorkArea_ReturnsUnchanged()
+    {
+        var desired = new PointInt32(500, 400);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, [PrimaryWorkArea], out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(500);
+        clamped.Y.Should().Be(400);
+    }
+
+    [Fact]
+    public void Clamp_PointPastRightEdge_ShiftsLeftToFit()
+    {
+        // Saved x = 1700; window is 400 wide; primary work area max-x = 1920. Window would extend
+        // 180px past the right edge — clamp x to 1920 - 400 = 1520.
+        var desired = new PointInt32(1700, 100);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, [PrimaryWorkArea], out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(1520);
+        clamped.Y.Should().Be(100);
+    }
+
+    [Fact]
+    public void Clamp_PointPastBottomEdge_ShiftsUpToFit()
+    {
+        // y = 1000, window is 200 tall, work area bottom = 1080 → clamp y to 1080 - 200 = 880.
+        var desired = new PointInt32(100, 1000);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, [PrimaryWorkArea], out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(100);
+        clamped.Y.Should().Be(880);
+    }
+
+    [Fact]
+    public void Clamp_PointBeforeTopLeft_ShiftsToWorkAreaOrigin()
+    {
+        // Negative top-left but window still overlaps the work area.
+        var desired = new PointInt32(-50, -30);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, [PrimaryWorkArea], out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(0);
+        clamped.Y.Should().Be(0);
+    }
+
+    [Fact]
+    public void Clamp_RectFullyOutsideAllAreas_ReturnsFalse()
+    {
+        // The disconnected-external-monitor case: saved at x=3000 but only the
+        // laptop's primary screen (0..1920) is currently attached. No overlap → false.
+        var desired = new PointInt32(3000, 200);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, [PrimaryWorkArea], out var clamped);
+
+        ok.Should().BeFalse();
+        clamped.X.Should().Be(0);
+        clamped.Y.Should().Be(0);
+    }
+
+    [Fact]
+    public void Clamp_RectStraddlesTwoAdjacentAreas_PreservesPosition()
+    {
+        // Window spans (1820..2220) — 100px in primary, 300px in secondary.
+        // All four corners are covered by the union → user's deliberate straddle is preserved.
+        var desired = new PointInt32(1820, 100);
+        var workAreas = new[] { PrimaryWorkArea, SecondaryRightWorkArea };
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, workAreas, out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(1820);
+        clamped.Y.Should().Be(100);
+    }
+
+    [Fact]
+    public void Clamp_SecondaryStillAttachedSavedRectFullyOnSecondary_PreservesPosition()
+    {
+        // Saved on the right-side secondary, both monitors still attached → no clamping.
+        var desired = new PointInt32(2400, 300);
+        var workAreas = new[] { PrimaryWorkArea, SecondaryRightWorkArea };
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, workAreas, out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(2400);
+        clamped.Y.Should().Be(300);
+    }
+
+    [Fact]
+    public void Clamp_EmptyWorkAreaList_ReturnsFalse()
+    {
+        var desired = new PointInt32(100, 100);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, [], out var clamped);
+
+        ok.Should().BeFalse();
+        clamped.X.Should().Be(0);
+        clamped.Y.Should().Be(0);
+    }
+
+    [Fact]
+    public void Clamp_WindowWiderThanWorkArea_PinsToLeftEdge()
+    {
+        // Window is wider than work area → can't fit; pin x to work.X.
+        var workArea = new RectInt32(0, 0, 300, 1080);
+        var bigWindow = new SizeInt32(500, 200);
+        var desired = new PointInt32(100, 100);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, bigWindow, [workArea], out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(0);
+        clamped.Y.Should().Be(100);
+    }
+
+    [Fact]
+    public void Clamp_TouchingEdgeOnly_NoOverlap_ReturnsFalse()
+    {
+        // Top-left exactly at right edge — zero-area intersection counts as no overlap.
+        var desired = new PointInt32(1920, 0);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, [PrimaryWorkArea], out _);
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clamp_WindowTallerThanWorkArea_PinsToTopEdge()
+    {
+        // Mirror of WindowWiderThanWorkArea: window taller than work area → pin y to work.Y.
+        var workArea = new RectInt32(0, 0, 1920, 300);
+        var bigWindow = new SizeInt32(400, 500);
+        var desired = new PointInt32(100, 100);
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, bigWindow, [workArea], out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(100);
+        clamped.Y.Should().Be(0);
+    }
+
+    [Fact]
+    public void Clamp_StraddleBreaksAtBottom_BestOverlapPicksSecondaryAndClamps()
+    {
+        // desired = (3000, 1300), size = 400×200 → window is fully in secondary's X range
+        // but extends past primary's bottom (1080) AND past secondary's bottom (1440).
+        // Bottom-right corner (3399, 1499) lies outside both work areas → AllCornersCovered
+        // is false. Loop picks secondary (only overlap), then clamps Y from 1300 to 1240
+        // (= 1440 - 200). Confirms best-overlap-on-secondary + post-clamp inside it.
+        var desired = new PointInt32(3000, 1300);
+        var workAreas = new[] { PrimaryWorkArea, SecondaryRightWorkArea };
+
+        var ok = WindowPositionHelper.TryClampToVisibleWorkArea(
+            desired, MiniSize, workAreas, out var clamped);
+
+        ok.Should().BeTrue();
+        clamped.X.Should().Be(3000);
+        clamped.Y.Should().Be(1240);
+    }
+}


### PR DESCRIPTION
Fixed #148

Saved Mini/Fixed window positions could land off-screen after a monitor was disconnected. Validate the saved point against current work areas via the new WindowPositionHelper, falling through to each window's default placement when no overlap exists.