### PR TITLE
fix(settings): refresh tab and control chrome on theme change

### DIFF
--- a/.github/workflows/ui-automation.yml
+++ b/.github/workflows/ui-automation.yml
@@ -246,7 +246,7 @@ jobs:
           path: dotnet/**/TestResults/*.trx
           retention-days: 30
 
-  # ── Job 3: UI Automation Tests (parallel, 5 shards) ──
+  # ── Job 3: UI Automation Tests (parallel shards) ──
   ui-automation:
     name: UI Automation (${{ matrix.shard.name }})
     runs-on: windows-latest
@@ -267,6 +267,9 @@ jobs:
           - name: "Core & Settings"
             filter: "Category=UIAutomation & (FullyQualifiedName~Easydict.UIAutomation.Tests.Tests.MainWindowTests. | FullyQualifiedName~Easydict.UIAutomation.Tests.Tests.TranslationTests. | FullyQualifiedName~Easydict.UIAutomation.Tests.Tests.WindowLifecycleTests. | FullyQualifiedName~Easydict.UIAutomation.Tests.Tests.SettingsPageTests. | FullyQualifiedName~Easydict.UIAutomation.Tests.Tests.SettingsPageScrollTests. | FullyQualifiedName~Easydict.UIAutomation.Tests.Tests.DarkModeTests.)"
             suffix: "shard-3"
+          - name: "Theme Contrast"
+            filter: "Category=UIAutomation & FullyQualifiedName~Easydict.UIAutomation.Tests.Tests.ThemeContrastTests."
+            suffix: "theme-contrast"
           - name: "OCR"
             filter: "Category=UIAutomation & FullyQualifiedName~Easydict.UIAutomation.Tests.Tests.OcrTests."
             suffix: "shard-4"
@@ -419,6 +422,117 @@ jobs:
             Write-Host "::error title=UI test $outcome (${{ matrix.shard.name }})::$name%0A$msg"
           }
 
+      - name: Publish theme contrast screenshot summary
+        if: always() && matrix.shard.suffix == 'theme-contrast'
+        shell: pwsh
+        run: |
+          $matrixDir = Join-Path "${{ github.workspace }}" "screenshots/theme-contrast-regression/theme-matrix"
+          $galleryDir = Join-Path "${{ github.workspace }}" "screenshots/theme-contrast-regression"
+          $summary = [System.Collections.Generic.List[string]]::new()
+          $summary.Add("## Theme contrast regression screenshots")
+          $summary.Add("")
+          $summary.Add("Artifact: ``theme-contrast-regression-screenshots-theme-contrast``")
+          $summary.Add("Path inside artifact: ``theme-matrix/``")
+
+          if (-not (Test-Path $matrixDir)) {
+            $summary.Add("")
+            $summary.Add("No theme contrast screenshots were produced.")
+            $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            exit 0
+          }
+
+          $screenshots = @(Get-ChildItem -Path $matrixDir -Filter "theme-contrast_*.png" | Sort-Object Name)
+          $summary.Add("")
+          $summary.Add("Generated **$($screenshots.Count)** screenshots.")
+
+          if ($screenshots.Count -gt 0) {
+            try {
+              Add-Type -AssemblyName System.Drawing
+
+              $columns = 4
+              $thumbWidth = 190
+              $thumbHeight = 170
+              $labelHeight = 50
+              $padding = 12
+              $rows = [int][Math]::Ceiling($screenshots.Count / [double]$columns)
+              $sheetWidth = ($columns * $thumbWidth) + (($columns + 1) * $padding)
+              $sheetHeight = ($rows * ($labelHeight + $thumbHeight + $padding)) + $padding
+
+              $sheet = [System.Drawing.Bitmap]::new($sheetWidth, $sheetHeight)
+              $graphics = [System.Drawing.Graphics]::FromImage($sheet)
+              $font = [System.Drawing.Font]::new("Segoe UI", 8)
+              $brush = [System.Drawing.SolidBrush]::new([System.Drawing.Color]::FromArgb(32, 36, 43))
+              $tileBrush = [System.Drawing.SolidBrush]::new([System.Drawing.Color]::FromArgb(245, 247, 250))
+              $borderPen = [System.Drawing.Pen]::new([System.Drawing.Color]::FromArgb(205, 213, 224))
+
+              try {
+                $graphics.Clear([System.Drawing.Color]::White)
+                $graphics.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+                $graphics.TextRenderingHint = [System.Drawing.Text.TextRenderingHint]::ClearTypeGridFit
+
+                for ($i = 0; $i -lt $screenshots.Count; $i++) {
+                  $row = [Math]::Floor($i / $columns)
+                  $column = $i % $columns
+                  $x = $padding + ($column * ($thumbWidth + $padding))
+                  $y = $padding + ($row * ($labelHeight + $thumbHeight + $padding))
+                  $tile = [System.Drawing.Rectangle]::new($x, $y, $thumbWidth, $labelHeight + $thumbHeight)
+                  $graphics.FillRectangle($tileBrush, $tile)
+                  $graphics.DrawRectangle($borderPen, $tile)
+
+                  $name = $screenshots[$i].BaseName -replace "theme-contrast_", ""
+                  $graphics.DrawString($name, $font, $brush, [System.Drawing.RectangleF]::new($x + 6, $y + 6, $thumbWidth - 12, $labelHeight - 8))
+
+                  $image = [System.Drawing.Image]::FromFile($screenshots[$i].FullName)
+                  try {
+                    $scale = [Math]::Min(($thumbWidth - 12) / [double]$image.Width, ($thumbHeight - 12) / [double]$image.Height)
+                    $drawWidth = [int]($image.Width * $scale)
+                    $drawHeight = [int]($image.Height * $scale)
+                    $drawX = $x + [int](($thumbWidth - $drawWidth) / 2)
+                    $drawY = $y + $labelHeight + [int](($thumbHeight - $drawHeight) / 2)
+                    $graphics.DrawImage($image, $drawX, $drawY, $drawWidth, $drawHeight)
+                  }
+                  finally {
+                    $image.Dispose()
+                  }
+                }
+
+                New-Item -ItemType Directory -Force -Path $galleryDir | Out-Null
+                $galleryPath = Join-Path $galleryDir "theme-contrast-regression-gallery.png"
+                $sheet.Save($galleryPath, [System.Drawing.Imaging.ImageFormat]::Png)
+              }
+              finally {
+                $borderPen.Dispose()
+                $tileBrush.Dispose()
+                $brush.Dispose()
+                $font.Dispose()
+                $graphics.Dispose()
+                $sheet.Dispose()
+              }
+
+              $galleryBytes = [System.IO.File]::ReadAllBytes($galleryPath)
+              $summary.Add("")
+              $summary.Add("### Gallery")
+              if ($galleryBytes.Length -le 600000) {
+                $galleryBase64 = [Convert]::ToBase64String($galleryBytes)
+                $summary.Add("<img alt=""Theme contrast regression screenshot gallery"" src=""data:image/png;base64,$galleryBase64"" />")
+              } else {
+                $summary.Add("Gallery image was generated at ``theme-contrast-regression-gallery.png`` in the artifact.")
+              }
+            }
+            catch {
+              $summary.Add("")
+              $summary.Add("Could not generate inline gallery: $($_.Exception.Message)")
+            }
+
+            $summary.Add("")
+            $summary.Add("### Screenshot files")
+            foreach ($screenshot in $screenshots) {
+              $summary.Add("- ``theme-matrix/$($screenshot.Name)``")
+            }
+          }
+
+          $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
         if: always()
@@ -427,6 +541,15 @@ jobs:
           path: |
             screenshots/
           retention-days: 30
+
+      - name: Upload theme contrast regression screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: theme-contrast-regression-screenshots-${{ matrix.shard.suffix }}
+          path: screenshots/theme-contrast-regression/
+          retention-days: 30
+          if-no-files-found: ignore
 
       - name: Upload baseline candidates
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ nul
 
 # Local test artifacts (screenshots, captures from local test runs)
 artifacts/
+screenshots/
 
 # Local review and package files
 packages-microsoft-prod.deb

--- a/dotnet/src/Easydict.WinUI/Services/LanguageDetectionService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/LanguageDetectionService.cs
@@ -66,6 +66,8 @@ public sealed class LanguageDetectionService : IDisposable
             return Language.Auto;
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         // Check cache (guard against disposed cache)
         var cacheKey = GetCacheKey(text);
         try
@@ -110,6 +112,11 @@ public sealed class LanguageDetectionService : IDisposable
 
             Debug.WriteLine($"[Detection] Detected language: {detected.GetDisplayName()}");
             return detected;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            Debug.WriteLine("[Detection] Canceled");
+            throw;
         }
         catch (Exception ex)
         {

--- a/dotnet/src/Easydict.WinUI/Services/LocalCredentialProtector.cs
+++ b/dotnet/src/Easydict.WinUI/Services/LocalCredentialProtector.cs
@@ -21,6 +21,7 @@ internal static class LocalCredentialProtector
     private const string LegacyMachineIdFileName = "local-machine-id";
     private const int NonceSizeBytes = 12;
     private const int TagSizeBytes = 16;
+    internal const int MaxNestedProtectedValueDepth = 4;
     private static readonly Lazy<string> MachineId = new(GetMachineId);
     private const CredentialProtectionScope DefaultProtectionScope = CredentialProtectionScope.CurrentUser;
 
@@ -102,13 +103,66 @@ internal static class LocalCredentialProtector
 
     public static bool TryUnprotect(string protectedValue, out string plaintext)
     {
+        plaintext = string.Empty;
+        return IsProtected(protectedValue) &&
+            TryUnprotectNested(protectedValue, MachineId.Value, out plaintext, out _);
+    }
+
+    private static bool TryUnprotectNested(
+        string protectedValue,
+        string machineId,
+        out string plaintext,
+        out bool needsNormalization)
+    {
+        plaintext = string.Empty;
+        needsNormalization = false;
+        var currentValue = protectedValue;
+
+        for (var depth = 0; depth < MaxNestedProtectedValueDepth; depth++)
+        {
+            if (!TryUnprotectSingle(currentValue, machineId, out var unprotectedValue, out var usedLegacyProtection))
+            {
+                return false;
+            }
+
+            if (usedLegacyProtection || depth > 0)
+            {
+                needsNormalization = true;
+            }
+
+            currentValue = unprotectedValue;
+            if (!IsProtected(currentValue))
+            {
+                plaintext = currentValue;
+                return true;
+            }
+
+            needsNormalization = true;
+        }
+
+        return false;
+    }
+
+    private static bool TryUnprotectSingle(
+        string protectedValue,
+        string machineId,
+        out string plaintext,
+        out bool usedLegacyProtection)
+    {
+        usedLegacyProtection = false;
         if (TryUnprotectDpapi(protectedValue, out plaintext))
         {
             return true;
         }
 
-        return IsLegacyProtected(protectedValue) &&
-            TryUnprotectLegacy(protectedValue, MachineId.Value, out plaintext);
+        if (IsLegacyProtected(protectedValue) &&
+            TryUnprotectLegacy(protectedValue, machineId, out plaintext))
+        {
+            usedLegacyProtection = true;
+            return true;
+        }
+
+        return false;
     }
 
     internal static string? UnprotectOrReturnPlaintext(
@@ -124,20 +178,13 @@ internal static class LocalCredentialProtector
             return null;
         }
 
-        if (TryUnprotectDpapi(storedValue, out var plaintext))
-        {
-            return string.IsNullOrEmpty(plaintext) ? null : plaintext;
-        }
-
-        if (IsLegacyProtected(storedValue) &&
-            TryUnprotectLegacy(storedValue, MachineId.Value, out plaintext))
-        {
-            needsMigration = true;
-            return string.IsNullOrEmpty(plaintext) ? null : plaintext;
-        }
-
         if (IsProtected(storedValue))
         {
+            if (TryUnprotectNested(storedValue, MachineId.Value, out var plaintext, out needsMigration))
+            {
+                return string.IsNullOrEmpty(plaintext) ? null : plaintext;
+            }
+
             decryptFailed = true;
             return null;
         }
@@ -160,20 +207,13 @@ internal static class LocalCredentialProtector
             return null;
         }
 
-        if (TryUnprotectDpapi(storedValue, out var plaintext))
-        {
-            return string.IsNullOrEmpty(plaintext) ? null : plaintext;
-        }
-
-        if (IsLegacyProtected(storedValue) &&
-            TryUnprotectLegacy(storedValue, machineId, out plaintext))
-        {
-            needsMigration = true;
-            return string.IsNullOrEmpty(plaintext) ? null : plaintext;
-        }
-
         if (IsProtected(storedValue))
         {
+            if (TryUnprotectNested(storedValue, machineId, out var plaintext, out needsMigration))
+            {
+                return string.IsNullOrEmpty(plaintext) ? null : plaintext;
+            }
+
             decryptFailed = true;
             return null;
         }

--- a/dotnet/src/Easydict.WinUI/Services/LocalCredentialProtector.cs
+++ b/dotnet/src/Easydict.WinUI/Services/LocalCredentialProtector.cs
@@ -1,0 +1,606 @@
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Easydict.WinUI.Services;
+
+/// <summary>
+/// Protects credentials stored in settings.json with Windows DPAPI.
+/// The current default is per-user protection; the payload records its scope so future
+/// shared-machine storage can coexist without changing settings call sites.
+/// </summary>
+internal static class LocalCredentialProtector
+{
+    private const string ProtectedValuePrefix = "edcred1:";
+    private const string LegacyProtectedValuePrefix = "edloc1:";
+    private const string KeyPurpose = "Easydict.WinUI.LocalSettingsCredentialKey.v1";
+    private const string DpapiPurpose = "Easydict.WinUI.LocalSettingsCredential.v2";
+    private const string UserScopeName = "user";
+    private const string MachineScopeName = "machine";
+    internal const string MachineIdFileName = "machine-id";
+    private const string LegacyMachineIdFileName = "local-machine-id";
+    private const int NonceSizeBytes = 12;
+    private const int TagSizeBytes = 16;
+    private static readonly Lazy<string> MachineId = new(GetMachineId);
+    private const CredentialProtectionScope DefaultProtectionScope = CredentialProtectionScope.CurrentUser;
+
+    internal enum CredentialProtectionScope
+    {
+        CurrentUser,
+        LocalMachine,
+    }
+
+    public static bool IsProtected(string? value)
+    {
+        return IsDpapiProtected(value) || IsLegacyProtected(value);
+    }
+
+    public static string Protect(string plaintext)
+    {
+        return Protect(plaintext, DefaultProtectionScope);
+    }
+
+    internal static string Protect(string plaintext, CredentialProtectionScope scope)
+    {
+        if (string.IsNullOrEmpty(plaintext))
+        {
+            return string.Empty;
+        }
+
+        var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+        try
+        {
+            var protectedBytes = WindowsDataProtection.Protect(
+                plaintextBytes,
+                GetDpapiOptionalEntropy(scope),
+                scope);
+
+            return $"{ProtectedValuePrefix}{GetScopeName(scope)}:{Convert.ToBase64String(protectedBytes)}";
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintextBytes);
+        }
+    }
+
+    internal static string ProtectLegacy(string plaintext, string machineId)
+    {
+        if (string.IsNullOrEmpty(plaintext))
+        {
+            return string.Empty;
+        }
+
+        var nonce = RandomNumberGenerator.GetBytes(NonceSizeBytes);
+        var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+        try
+        {
+            var ciphertext = new byte[plaintextBytes.Length];
+            var tag = new byte[TagSizeBytes];
+            var key = DeriveKey(machineId);
+            try
+            {
+                using var aes = new AesGcm(key, TagSizeBytes);
+                aes.Encrypt(nonce, plaintextBytes, ciphertext, tag, GetAssociatedData());
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(key);
+            }
+
+            var payload = new byte[NonceSizeBytes + TagSizeBytes + ciphertext.Length];
+            Buffer.BlockCopy(nonce, 0, payload, 0, NonceSizeBytes);
+            Buffer.BlockCopy(tag, 0, payload, NonceSizeBytes, TagSizeBytes);
+            Buffer.BlockCopy(ciphertext, 0, payload, NonceSizeBytes + TagSizeBytes, ciphertext.Length);
+
+            return LegacyProtectedValuePrefix + Convert.ToBase64String(payload);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(plaintextBytes);
+        }
+    }
+
+    public static bool TryUnprotect(string protectedValue, out string plaintext)
+    {
+        if (TryUnprotectDpapi(protectedValue, out plaintext))
+        {
+            return true;
+        }
+
+        return IsLegacyProtected(protectedValue) &&
+            TryUnprotectLegacy(protectedValue, MachineId.Value, out plaintext);
+    }
+
+    internal static string? UnprotectOrReturnPlaintext(
+        string? storedValue,
+        out bool needsMigration,
+        out bool decryptFailed)
+    {
+        needsMigration = false;
+        decryptFailed = false;
+
+        if (string.IsNullOrEmpty(storedValue))
+        {
+            return null;
+        }
+
+        if (TryUnprotectDpapi(storedValue, out var plaintext))
+        {
+            return string.IsNullOrEmpty(plaintext) ? null : plaintext;
+        }
+
+        if (IsLegacyProtected(storedValue) &&
+            TryUnprotectLegacy(storedValue, MachineId.Value, out plaintext))
+        {
+            needsMigration = true;
+            return string.IsNullOrEmpty(plaintext) ? null : plaintext;
+        }
+
+        if (IsProtected(storedValue))
+        {
+            decryptFailed = true;
+            return null;
+        }
+
+        needsMigration = true;
+        return storedValue;
+    }
+
+    internal static string? UnprotectOrReturnPlaintext(
+        string? storedValue,
+        string machineId,
+        out bool needsMigration,
+        out bool decryptFailed)
+    {
+        needsMigration = false;
+        decryptFailed = false;
+
+        if (string.IsNullOrEmpty(storedValue))
+        {
+            return null;
+        }
+
+        if (TryUnprotectDpapi(storedValue, out var plaintext))
+        {
+            return string.IsNullOrEmpty(plaintext) ? null : plaintext;
+        }
+
+        if (IsLegacyProtected(storedValue) &&
+            TryUnprotectLegacy(storedValue, machineId, out plaintext))
+        {
+            needsMigration = true;
+            return string.IsNullOrEmpty(plaintext) ? null : plaintext;
+        }
+
+        if (IsProtected(storedValue))
+        {
+            decryptFailed = true;
+            return null;
+        }
+
+        needsMigration = true;
+        return storedValue;
+    }
+
+    internal static bool TryUnprotectLegacy(string protectedValue, string machineId, out string plaintext)
+    {
+        plaintext = string.Empty;
+        if (!IsLegacyProtected(protectedValue))
+        {
+            return false;
+        }
+
+        try
+        {
+            var payload = Convert.FromBase64String(protectedValue[LegacyProtectedValuePrefix.Length..]);
+            if (payload.Length <= NonceSizeBytes + TagSizeBytes)
+            {
+                return false;
+            }
+
+            var nonce = payload[..NonceSizeBytes];
+            var tag = payload[NonceSizeBytes..(NonceSizeBytes + TagSizeBytes)];
+            var ciphertext = payload[(NonceSizeBytes + TagSizeBytes)..];
+            var plaintextBytes = new byte[ciphertext.Length];
+            try
+            {
+                var key = DeriveKey(machineId);
+                try
+                {
+                    using var aes = new AesGcm(key, TagSizeBytes);
+                    aes.Decrypt(nonce, ciphertext, tag, plaintextBytes, GetAssociatedData());
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(key);
+                }
+
+                plaintext = Encoding.UTF8.GetString(plaintextBytes);
+                return true;
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(plaintextBytes);
+            }
+        }
+        catch (Exception ex) when (ex is FormatException or CryptographicException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryUnprotectDpapi(string protectedValue, out string plaintext)
+    {
+        plaintext = string.Empty;
+        if (!TryParseDpapiProtectedValue(protectedValue, out var scope, out var payload))
+        {
+            return false;
+        }
+
+        try
+        {
+            var protectedBytes = Convert.FromBase64String(payload);
+            var plaintextBytes = WindowsDataProtection.Unprotect(
+                protectedBytes,
+                GetDpapiOptionalEntropy(scope),
+                scope);
+
+            try
+            {
+                plaintext = Encoding.UTF8.GetString(plaintextBytes);
+                return true;
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(plaintextBytes);
+            }
+        }
+        catch (Exception ex) when (ex is FormatException or CryptographicException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsDpapiProtected(string? value)
+    {
+        return value?.StartsWith(ProtectedValuePrefix, StringComparison.Ordinal) == true;
+    }
+
+    private static bool IsLegacyProtected(string? value)
+    {
+        return value?.StartsWith(LegacyProtectedValuePrefix, StringComparison.Ordinal) == true;
+    }
+
+    private static bool TryParseDpapiProtectedValue(
+        string protectedValue,
+        out CredentialProtectionScope scope,
+        out string payload)
+    {
+        scope = DefaultProtectionScope;
+        payload = string.Empty;
+
+        if (!IsDpapiProtected(protectedValue))
+        {
+            return false;
+        }
+
+        var rest = protectedValue[ProtectedValuePrefix.Length..];
+        var separator = rest.IndexOf(':');
+        if (separator <= 0 || separator == rest.Length - 1)
+        {
+            return false;
+        }
+
+        if (!TryParseScopeName(rest[..separator], out scope))
+        {
+            return false;
+        }
+
+        payload = rest[(separator + 1)..];
+        return true;
+    }
+
+    private static bool TryParseScopeName(string scopeName, out CredentialProtectionScope scope)
+    {
+        scope = scopeName switch
+        {
+            UserScopeName => CredentialProtectionScope.CurrentUser,
+            MachineScopeName => CredentialProtectionScope.LocalMachine,
+            _ => DefaultProtectionScope,
+        };
+
+        return scopeName is UserScopeName or MachineScopeName;
+    }
+
+    private static string GetScopeName(CredentialProtectionScope scope)
+    {
+        return scope switch
+        {
+            CredentialProtectionScope.CurrentUser => UserScopeName,
+            CredentialProtectionScope.LocalMachine => MachineScopeName,
+            _ => throw new ArgumentOutOfRangeException(nameof(scope), scope, null),
+        };
+    }
+
+    private static byte[] GetDpapiOptionalEntropy(CredentialProtectionScope scope)
+    {
+        return Encoding.UTF8.GetBytes($"{DpapiPurpose}:{GetScopeName(scope)}");
+    }
+
+    private static byte[] DeriveKey(string machineId)
+    {
+        var keyMaterial = Encoding.UTF8.GetBytes($"{KeyPurpose}:{machineId}");
+        try
+        {
+            return SHA256.HashData(keyMaterial);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(keyMaterial);
+        }
+    }
+
+    private static byte[] GetAssociatedData()
+    {
+        return Encoding.UTF8.GetBytes(KeyPurpose);
+    }
+
+    private static string GetMachineId()
+    {
+        return GetOrCreatePersistedMachineId(GetEasydictDataDirectory());
+    }
+
+    private static string? GetMachineGuidHash()
+    {
+        try
+        {
+            var machineGuid = Microsoft.Win32.Registry.GetValue(
+                @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography",
+                "MachineGuid",
+                null) as string;
+            if (!string.IsNullOrWhiteSpace(machineGuid))
+            {
+                return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(machineGuid)))
+                    .ToLowerInvariant();
+            }
+        }
+        catch
+        {
+            // Fall back to the app-local machine id below.
+        }
+
+        return null;
+    }
+
+    internal static string GetOrCreatePersistedMachineId(string directory)
+    {
+        try
+        {
+            Directory.CreateDirectory(directory);
+            var path = Path.Combine(directory, MachineIdFileName);
+            if (File.Exists(path))
+            {
+                var existing = File.ReadAllText(path).Trim();
+                if (!string.IsNullOrWhiteSpace(existing))
+                {
+                    return existing;
+                }
+            }
+
+            var legacyPath = Path.Combine(directory, LegacyMachineIdFileName);
+            if (File.Exists(legacyPath))
+            {
+                var legacy = File.ReadAllText(legacyPath).Trim();
+                if (!string.IsNullOrWhiteSpace(legacy))
+                {
+                    File.WriteAllText(path, legacy);
+                    return legacy;
+                }
+            }
+
+            // Seed with the previous derivation input so credentials encrypted before
+            // this file existed remain readable after upgrade.
+            var created = GetMachineGuidHash() ?? Guid.NewGuid().ToString("N");
+            File.WriteAllText(path, created);
+            return created;
+        }
+        catch
+        {
+            return GetMachineGuidHash() ?? Environment.MachineName;
+        }
+    }
+
+    private static string GetEasydictDataDirectory()
+    {
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(appDataPath, "Easydict");
+    }
+
+    private static class WindowsDataProtection
+    {
+        private const int CryptProtectUiForbidden = 0x1;
+        private const int CryptProtectLocalMachine = 0x4;
+
+        public static byte[] Protect(
+            byte[] plaintext,
+            byte[] optionalEntropy,
+            CredentialProtectionScope scope)
+        {
+            return Execute(
+                plaintext,
+                optionalEntropy,
+                GetFlags(scope, protect: true),
+                protect: true);
+        }
+
+        public static byte[] Unprotect(
+            byte[] protectedBytes,
+            byte[] optionalEntropy,
+            CredentialProtectionScope scope)
+        {
+            return Execute(
+                protectedBytes,
+                optionalEntropy,
+                GetFlags(scope, protect: false),
+                protect: false);
+        }
+
+        private static int GetFlags(CredentialProtectionScope scope, bool protect)
+        {
+            var flags = CryptProtectUiForbidden;
+            if (protect && scope == CredentialProtectionScope.LocalMachine)
+            {
+                flags |= CryptProtectLocalMachine;
+            }
+
+            return flags;
+        }
+
+        private static byte[] Execute(
+            byte[] input,
+            byte[] optionalEntropy,
+            int flags,
+            bool protect)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                throw new PlatformNotSupportedException("Windows DPAPI is only available on Windows.");
+            }
+
+            var inputBlob = DataBlob.FromBytes(input);
+            var entropyBlob = DataBlob.FromBytes(optionalEntropy);
+            var outputBlob = default(DataBlob);
+
+            try
+            {
+                var success = protect
+                    ? CryptProtectData(
+                        ref inputBlob,
+                        DpapiPurpose,
+                        ref entropyBlob,
+                        IntPtr.Zero,
+                        IntPtr.Zero,
+                        flags,
+                        out outputBlob)
+                    : CryptUnprotectData(
+                        ref inputBlob,
+                        IntPtr.Zero,
+                        ref entropyBlob,
+                        IntPtr.Zero,
+                        IntPtr.Zero,
+                        flags,
+                        out outputBlob);
+
+                if (!success)
+                {
+                    throw new CryptographicException(Marshal.GetHRForLastWin32Error());
+                }
+
+                return outputBlob.ToBytes();
+            }
+            finally
+            {
+                inputBlob.FreeHGlobal(clear: protect);
+                entropyBlob.FreeHGlobal(clear: true);
+                outputBlob.LocalFree(clear: !protect);
+            }
+        }
+
+        [DllImport("crypt32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptProtectData(
+            ref DataBlob dataIn,
+            string? dataDescription,
+            ref DataBlob optionalEntropy,
+            IntPtr reserved,
+            IntPtr promptStruct,
+            int flags,
+            out DataBlob dataOut);
+
+        [DllImport("crypt32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptUnprotectData(
+            ref DataBlob dataIn,
+            IntPtr dataDescription,
+            ref DataBlob optionalEntropy,
+            IntPtr reserved,
+            IntPtr promptStruct,
+            int flags,
+            out DataBlob dataOut);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr LocalFree(IntPtr handle);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DataBlob
+        {
+            public int cbData;
+            public IntPtr pbData;
+
+            public static DataBlob FromBytes(byte[] bytes)
+            {
+                if (bytes.Length == 0)
+                {
+                    return default;
+                }
+
+                var blob = new DataBlob
+                {
+                    cbData = bytes.Length,
+                    pbData = Marshal.AllocHGlobal(bytes.Length),
+                };
+
+                Marshal.Copy(bytes, 0, blob.pbData, bytes.Length);
+                return blob;
+            }
+
+            public readonly byte[] ToBytes()
+            {
+                if (cbData == 0 || pbData == IntPtr.Zero)
+                {
+                    return [];
+                }
+
+                var bytes = new byte[cbData];
+                Marshal.Copy(pbData, bytes, 0, cbData);
+                return bytes;
+            }
+
+            public readonly void FreeHGlobal(bool clear = false)
+            {
+                if (pbData != IntPtr.Zero)
+                {
+                    if (clear)
+                    {
+                        Clear();
+                    }
+
+                    Marshal.FreeHGlobal(pbData);
+                }
+            }
+
+            public readonly void LocalFree(bool clear = false)
+            {
+                if (pbData != IntPtr.Zero)
+                {
+                    if (clear)
+                    {
+                        Clear();
+                    }
+
+                    _ = WindowsDataProtection.LocalFree(pbData);
+                }
+            }
+
+            private readonly void Clear()
+            {
+                if (cbData <= 0 || pbData == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                Marshal.Copy(new byte[cbData], 0, pbData, cbData);
+            }
+        }
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -50,6 +50,7 @@ public sealed class SettingsService
     private readonly string _settingsFilePath;
     private Dictionary<string, object?> _settings = new();
     private volatile bool _needsRegionDetection;
+    private bool _needsSensitiveSettingsMigration;
 
 
     private SettingsService()
@@ -597,13 +598,13 @@ public sealed class SettingsService
             SecondLanguage = "en";
         }
 
-        DeepLApiKey = GetValue<string?>(nameof(DeepLApiKey), null);
+        DeepLApiKey = GetSensitiveSetting(nameof(DeepLApiKey));
         DeepLUseFreeApi = GetValue(nameof(DeepLUseFreeApi), true);
         DeepLUseQualityOptimized = GetValue(nameof(DeepLUseQualityOptimized), false);
         NormalizeDeepLModeSettings();
 
         // OpenAI settings
-        OpenAIApiKey = GetValue<string?>(nameof(OpenAIApiKey), null);
+        OpenAIApiKey = GetSensitiveSetting(nameof(OpenAIApiKey));
         OpenAIEndpoint = GetValue(nameof(OpenAIEndpoint), OpenAIService.DefaultEndpoint);
         OpenAIModel = GetValue(nameof(OpenAIModel), OpenAIService.DefaultModel);
         OpenAITemperature = GetValue(nameof(OpenAITemperature), 0.3);
@@ -623,7 +624,7 @@ public sealed class SettingsService
 
         // Built-in AI settings
         BuiltInAIModel = GetValue(nameof(BuiltInAIModel), "glm-4-flash-250414");
-        BuiltInAIApiKey = GetValue<string?>(nameof(BuiltInAIApiKey), null);
+        BuiltInAIApiKey = GetSensitiveSetting(nameof(BuiltInAIApiKey));
         // Try hardware-bound ID; fall back to persisted random UUID
         var hardwareId = GetHardwareDeviceId();
         if (!string.IsNullOrEmpty(hardwareId))
@@ -641,44 +642,49 @@ public sealed class SettingsService
         DeviceToken = GetValue(nameof(DeviceToken), "");
 
         // DeepSeek settings
-        DeepSeekApiKey = GetValue<string?>(nameof(DeepSeekApiKey), null);
+        DeepSeekApiKey = GetSensitiveSetting(nameof(DeepSeekApiKey));
         DeepSeekModel = GetValue(nameof(DeepSeekModel), "deepseek-chat");
 
         // Groq settings
-        GroqApiKey = GetValue<string?>(nameof(GroqApiKey), null);
+        GroqApiKey = GetSensitiveSetting(nameof(GroqApiKey));
         GroqModel = GetValue(nameof(GroqModel), "llama-3.3-70b-versatile");
 
         // Zhipu settings
-        ZhipuApiKey = GetValue<string?>(nameof(ZhipuApiKey), null);
+        ZhipuApiKey = GetSensitiveSetting(nameof(ZhipuApiKey));
         ZhipuModel = GetValue(nameof(ZhipuModel), "glm-4.5-flash");
 
         // GitHub Models settings
-        GitHubModelsToken = GetValue<string?>(nameof(GitHubModelsToken), null);
+        GitHubModelsToken = GetSensitiveSetting(nameof(GitHubModelsToken));
         GitHubModelsModel = GetValue(nameof(GitHubModelsModel), "gpt-4.1");
 
         // Custom OpenAI settings
         CustomOpenAIEndpoint = GetValue(nameof(CustomOpenAIEndpoint), "");
-        CustomOpenAIApiKey = GetValue<string?>(nameof(CustomOpenAIApiKey), null);
+        CustomOpenAIApiKey = GetSensitiveSetting(nameof(CustomOpenAIApiKey));
         CustomOpenAIModel = GetValue(nameof(CustomOpenAIModel), "gpt-3.5-turbo");
 
         // Gemini settings
-        GeminiApiKey = GetValue<string?>(nameof(GeminiApiKey), null);
+        GeminiApiKey = GetSensitiveSetting(nameof(GeminiApiKey));
         GeminiModel = GetValue(nameof(GeminiModel), "gemini-2.5-flash");
 
         // Doubao settings
-        DoubaoApiKey = GetValue<string?>(nameof(DoubaoApiKey), null);
+        DoubaoApiKey = GetSensitiveSetting(nameof(DoubaoApiKey));
         DoubaoEndpoint = GetValue(nameof(DoubaoEndpoint), "https://ark.cn-beijing.volces.com/api/v3/responses");
         DoubaoModel = GetValue(nameof(DoubaoModel), "doubao-seed-translation-250915");
 
         // Caiyun settings
-        CaiyunApiKey = GetValue<string?>(nameof(CaiyunApiKey), null);
+        CaiyunApiKey = GetSensitiveSetting(nameof(CaiyunApiKey));
 
         // NiuTrans settings
-        NiuTransApiKey = GetValue<string?>(nameof(NiuTransApiKey), null);
+        NiuTransApiKey = GetSensitiveSetting(nameof(NiuTransApiKey));
+
+        // Youdao settings
+        YoudaoAppKey = GetSensitiveSetting(nameof(YoudaoAppKey));
+        YoudaoAppSecret = GetSensitiveSetting(nameof(YoudaoAppSecret));
+        YoudaoUseOfficialApi = GetValue(nameof(YoudaoUseOfficialApi), false);
 
         // Volcano settings
-        VolcanoAccessKeyId = GetValue<string?>(nameof(VolcanoAccessKeyId), null);
-        VolcanoSecretAccessKey = GetValue<string?>(nameof(VolcanoSecretAccessKey), null);
+        VolcanoAccessKeyId = GetSensitiveSetting(nameof(VolcanoAccessKeyId));
+        VolcanoSecretAccessKey = GetSensitiveSetting(nameof(VolcanoSecretAccessKey));
 
         MinimizeToTray = GetValue(nameof(MinimizeToTray), true);
         ClipboardMonitoring = GetValue(nameof(ClipboardMonitoring), false);
@@ -701,7 +707,7 @@ public sealed class SettingsService
 
         // Load OCR Engine settings
         OcrEngine = (OcrEngineType)GetValue(nameof(OcrEngine), (int)OcrEngineType.WindowsNative);
-        OcrApiKey = GetValue<string?>(nameof(OcrApiKey), null);
+        OcrApiKey = GetSensitiveSetting(nameof(OcrApiKey));
         OcrEndpoint = GetValue(nameof(OcrEndpoint), OcrServiceOptions.DefaultEndpoint);
         OcrModel = GetValue(nameof(OcrModel), OcrServiceOptions.DefaultModel);
         OcrSystemPrompt = GetValue(nameof(OcrSystemPrompt), "Extract all the text from this image perfectly. Output ONLY the extracted text, without any conversational filler, markdown formatting, or introductory words.");
@@ -807,6 +813,8 @@ public sealed class SettingsService
         DocumentOutputMode = GetValue(nameof(DocumentOutputMode), "Monolingual");
         LongDocMaxConcurrency = GetValue(nameof(LongDocMaxConcurrency), 4);
         LongDocEnableDocumentContextPass = GetValue(nameof(LongDocEnableDocumentContextPass), true);
+
+        MigrateSensitiveSettingsIfNeeded();
     }
 
     private void NormalizeDeepLModeSettings()
@@ -829,12 +837,12 @@ public sealed class SettingsService
         _settings[nameof(AutoSelectTargetLanguage)] = AutoSelectTargetLanguage;
         _settings[nameof(SelectedLanguages)] = SelectedLanguages;
 
-        _settings[nameof(DeepLApiKey)] = DeepLApiKey ?? string.Empty;
+        _settings[nameof(DeepLApiKey)] = ProtectSensitiveSetting(DeepLApiKey);
         _settings[nameof(DeepLUseFreeApi)] = DeepLUseFreeApi;
         _settings[nameof(DeepLUseQualityOptimized)] = DeepLUseQualityOptimized;
 
         // OpenAI settings
-        _settings[nameof(OpenAIApiKey)] = OpenAIApiKey ?? string.Empty;
+        _settings[nameof(OpenAIApiKey)] = ProtectSensitiveSetting(OpenAIApiKey);
         _settings[nameof(OpenAIEndpoint)] = OpenAIEndpoint;
         _settings[nameof(OpenAIModel)] = OpenAIModel;
         _settings[nameof(OpenAIApiFormatOverride)] = OpenAIApiFormatOverride;
@@ -854,49 +862,54 @@ public sealed class SettingsService
 
         // Built-in AI settings
         _settings[nameof(BuiltInAIModel)] = BuiltInAIModel;
-        _settings[nameof(BuiltInAIApiKey)] = BuiltInAIApiKey ?? string.Empty;
+        _settings[nameof(BuiltInAIApiKey)] = ProtectSensitiveSetting(BuiltInAIApiKey);
         _settings[nameof(DeviceId)] = DeviceId;
         _settings[nameof(DeviceToken)] = DeviceToken;
 
         // DeepSeek settings
-        _settings[nameof(DeepSeekApiKey)] = DeepSeekApiKey ?? string.Empty;
+        _settings[nameof(DeepSeekApiKey)] = ProtectSensitiveSetting(DeepSeekApiKey);
         _settings[nameof(DeepSeekModel)] = DeepSeekModel;
 
         // Groq settings
-        _settings[nameof(GroqApiKey)] = GroqApiKey ?? string.Empty;
+        _settings[nameof(GroqApiKey)] = ProtectSensitiveSetting(GroqApiKey);
         _settings[nameof(GroqModel)] = GroqModel;
 
         // Zhipu settings
-        _settings[nameof(ZhipuApiKey)] = ZhipuApiKey ?? string.Empty;
+        _settings[nameof(ZhipuApiKey)] = ProtectSensitiveSetting(ZhipuApiKey);
         _settings[nameof(ZhipuModel)] = ZhipuModel;
 
         // GitHub Models settings
-        _settings[nameof(GitHubModelsToken)] = GitHubModelsToken ?? string.Empty;
+        _settings[nameof(GitHubModelsToken)] = ProtectSensitiveSetting(GitHubModelsToken);
         _settings[nameof(GitHubModelsModel)] = GitHubModelsModel;
 
         // Custom OpenAI settings
         _settings[nameof(CustomOpenAIEndpoint)] = CustomOpenAIEndpoint;
-        _settings[nameof(CustomOpenAIApiKey)] = CustomOpenAIApiKey ?? string.Empty;
+        _settings[nameof(CustomOpenAIApiKey)] = ProtectSensitiveSetting(CustomOpenAIApiKey);
         _settings[nameof(CustomOpenAIModel)] = CustomOpenAIModel;
 
         // Gemini settings
-        _settings[nameof(GeminiApiKey)] = GeminiApiKey ?? string.Empty;
+        _settings[nameof(GeminiApiKey)] = ProtectSensitiveSetting(GeminiApiKey);
         _settings[nameof(GeminiModel)] = GeminiModel;
 
         // Doubao settings
-        _settings[nameof(DoubaoApiKey)] = DoubaoApiKey ?? string.Empty;
+        _settings[nameof(DoubaoApiKey)] = ProtectSensitiveSetting(DoubaoApiKey);
         _settings[nameof(DoubaoEndpoint)] = DoubaoEndpoint;
         _settings[nameof(DoubaoModel)] = DoubaoModel;
 
         // Caiyun settings
-        _settings[nameof(CaiyunApiKey)] = CaiyunApiKey ?? string.Empty;
+        _settings[nameof(CaiyunApiKey)] = ProtectSensitiveSetting(CaiyunApiKey);
 
         // NiuTrans settings
-        _settings[nameof(NiuTransApiKey)] = NiuTransApiKey ?? string.Empty;
+        _settings[nameof(NiuTransApiKey)] = ProtectSensitiveSetting(NiuTransApiKey);
+
+        // Youdao settings
+        _settings[nameof(YoudaoAppKey)] = ProtectSensitiveSetting(YoudaoAppKey);
+        _settings[nameof(YoudaoAppSecret)] = ProtectSensitiveSetting(YoudaoAppSecret);
+        _settings[nameof(YoudaoUseOfficialApi)] = YoudaoUseOfficialApi;
 
         // Volcano settings
-        _settings[nameof(VolcanoAccessKeyId)] = VolcanoAccessKeyId ?? string.Empty;
-        _settings[nameof(VolcanoSecretAccessKey)] = VolcanoSecretAccessKey ?? string.Empty;
+        _settings[nameof(VolcanoAccessKeyId)] = ProtectSensitiveSetting(VolcanoAccessKeyId);
+        _settings[nameof(VolcanoSecretAccessKey)] = ProtectSensitiveSetting(VolcanoSecretAccessKey);
 
         _settings[nameof(MinimizeToTray)] = MinimizeToTray;
         _settings[nameof(ClipboardMonitoring)] = ClipboardMonitoring;
@@ -919,7 +932,7 @@ public sealed class SettingsService
 
         // Save OCR Engine settings
         _settings[nameof(OcrEngine)] = (int)OcrEngine;
-        _settings[nameof(OcrApiKey)] = OcrApiKey ?? string.Empty;
+        _settings[nameof(OcrApiKey)] = ProtectSensitiveSetting(OcrApiKey);
         _settings[nameof(OcrEndpoint)] = OcrEndpoint;
         _settings[nameof(OcrModel)] = OcrModel;
         _settings[nameof(OcrSystemPrompt)] = OcrSystemPrompt;
@@ -1000,6 +1013,7 @@ public sealed class SettingsService
         {
             var json = JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(_settingsFilePath, json);
+            _needsSensitiveSettingsMigration = false;
 
             // Verify the file was written successfully
             System.Diagnostics.Debug.WriteLine($"[SettingsService] Settings saved successfully to: {_settingsFilePath}");
@@ -1441,6 +1455,51 @@ public sealed class SettingsService
             catch { }
         }
         return defaultValue;
+    }
+
+    private string? GetSensitiveSetting(string key)
+    {
+        var storedValue = GetValue<string?>(key, null);
+        var plaintext = LocalCredentialProtector.UnprotectOrReturnPlaintext(
+            storedValue,
+            out var needsMigration,
+            out var decryptFailed);
+        if (needsMigration)
+        {
+            _needsSensitiveSettingsMigration = true;
+        }
+
+        if (decryptFailed)
+        {
+            Debug.WriteLine($"[SettingsService] Failed to decrypt protected setting: {key}");
+        }
+
+        return plaintext;
+    }
+
+    private static string ProtectSensitiveSetting(string? plaintext)
+    {
+        return string.IsNullOrEmpty(plaintext)
+            ? string.Empty
+            : LocalCredentialProtector.Protect(plaintext);
+    }
+
+    private void MigrateSensitiveSettingsIfNeeded()
+    {
+        if (!_needsSensitiveSettingsMigration)
+        {
+            return;
+        }
+
+        try
+        {
+            Save();
+            Debug.WriteLine("[SettingsService] Migrated plaintext sensitive settings to protected storage.");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[SettingsService] Failed to migrate sensitive settings: {ex.Message}");
+        }
     }
 
     private List<string> GetStringList(string key, List<string> defaultValue)

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -16,6 +16,8 @@ namespace Easydict.WinUI.Services;
 public sealed class SettingsService
 {
     private const string GoogleServiceId = "google";
+    private const string SettingsDirectoryEnvironmentVariable = "EASYDICT_SETTINGS_DIR";
+    private static readonly JsonSerializerOptions SettingsJsonOptions = new() { WriteIndented = true };
 
     public sealed class ImportedMdxDictionary
     {
@@ -50,18 +52,28 @@ public sealed class SettingsService
     private readonly string _settingsFilePath;
     private Dictionary<string, object?> _settings = new();
     private volatile bool _needsRegionDetection;
-    private bool _needsSensitiveSettingsMigration;
+    private readonly HashSet<string> _sensitiveSettingsPendingMigration = new(StringComparer.Ordinal);
 
 
     private SettingsService()
     {
-        // Use AppData\Local\Easydict for settings
-        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var easydictPath = Path.Combine(appDataPath, "Easydict");
+        var easydictPath = ResolveSettingsDirectory();
         Directory.CreateDirectory(easydictPath);
         _settingsFilePath = Path.Combine(easydictPath, "settings.json");
 
         LoadSettings();
+    }
+
+    private static string ResolveSettingsDirectory()
+    {
+        var settingsDirectory = Environment.GetEnvironmentVariable(SettingsDirectoryEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(settingsDirectory))
+        {
+            return Path.GetFullPath(Environment.ExpandEnvironmentVariables(settingsDirectory));
+        }
+
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(appDataPath, "Easydict");
     }
 
     // Translation settings
@@ -826,8 +838,12 @@ public sealed class SettingsService
     }
 
     public void Save()
+        => SaveCore(preserveUnmigratedSensitiveSettings: false);
+
+    private void SaveCore(bool preserveUnmigratedSensitiveSettings)
     {
         NormalizeDeepLModeSettings();
+        var previousJson = JsonSerializer.Serialize(_settings, SettingsJsonOptions);
 
         _settings[nameof(SourceLanguage)] = SourceLanguage;
 
@@ -837,12 +853,12 @@ public sealed class SettingsService
         _settings[nameof(AutoSelectTargetLanguage)] = AutoSelectTargetLanguage;
         _settings[nameof(SelectedLanguages)] = SelectedLanguages;
 
-        _settings[nameof(DeepLApiKey)] = ProtectSensitiveSetting(DeepLApiKey);
+        SaveSensitiveSetting(nameof(DeepLApiKey), DeepLApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(DeepLUseFreeApi)] = DeepLUseFreeApi;
         _settings[nameof(DeepLUseQualityOptimized)] = DeepLUseQualityOptimized;
 
         // OpenAI settings
-        _settings[nameof(OpenAIApiKey)] = ProtectSensitiveSetting(OpenAIApiKey);
+        SaveSensitiveSetting(nameof(OpenAIApiKey), OpenAIApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(OpenAIEndpoint)] = OpenAIEndpoint;
         _settings[nameof(OpenAIModel)] = OpenAIModel;
         _settings[nameof(OpenAIApiFormatOverride)] = OpenAIApiFormatOverride;
@@ -862,54 +878,54 @@ public sealed class SettingsService
 
         // Built-in AI settings
         _settings[nameof(BuiltInAIModel)] = BuiltInAIModel;
-        _settings[nameof(BuiltInAIApiKey)] = ProtectSensitiveSetting(BuiltInAIApiKey);
+        SaveSensitiveSetting(nameof(BuiltInAIApiKey), BuiltInAIApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(DeviceId)] = DeviceId;
         _settings[nameof(DeviceToken)] = DeviceToken;
 
         // DeepSeek settings
-        _settings[nameof(DeepSeekApiKey)] = ProtectSensitiveSetting(DeepSeekApiKey);
+        SaveSensitiveSetting(nameof(DeepSeekApiKey), DeepSeekApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(DeepSeekModel)] = DeepSeekModel;
 
         // Groq settings
-        _settings[nameof(GroqApiKey)] = ProtectSensitiveSetting(GroqApiKey);
+        SaveSensitiveSetting(nameof(GroqApiKey), GroqApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(GroqModel)] = GroqModel;
 
         // Zhipu settings
-        _settings[nameof(ZhipuApiKey)] = ProtectSensitiveSetting(ZhipuApiKey);
+        SaveSensitiveSetting(nameof(ZhipuApiKey), ZhipuApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(ZhipuModel)] = ZhipuModel;
 
         // GitHub Models settings
-        _settings[nameof(GitHubModelsToken)] = ProtectSensitiveSetting(GitHubModelsToken);
+        SaveSensitiveSetting(nameof(GitHubModelsToken), GitHubModelsToken, preserveUnmigratedSensitiveSettings);
         _settings[nameof(GitHubModelsModel)] = GitHubModelsModel;
 
         // Custom OpenAI settings
         _settings[nameof(CustomOpenAIEndpoint)] = CustomOpenAIEndpoint;
-        _settings[nameof(CustomOpenAIApiKey)] = ProtectSensitiveSetting(CustomOpenAIApiKey);
+        SaveSensitiveSetting(nameof(CustomOpenAIApiKey), CustomOpenAIApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(CustomOpenAIModel)] = CustomOpenAIModel;
 
         // Gemini settings
-        _settings[nameof(GeminiApiKey)] = ProtectSensitiveSetting(GeminiApiKey);
+        SaveSensitiveSetting(nameof(GeminiApiKey), GeminiApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(GeminiModel)] = GeminiModel;
 
         // Doubao settings
-        _settings[nameof(DoubaoApiKey)] = ProtectSensitiveSetting(DoubaoApiKey);
+        SaveSensitiveSetting(nameof(DoubaoApiKey), DoubaoApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(DoubaoEndpoint)] = DoubaoEndpoint;
         _settings[nameof(DoubaoModel)] = DoubaoModel;
 
         // Caiyun settings
-        _settings[nameof(CaiyunApiKey)] = ProtectSensitiveSetting(CaiyunApiKey);
+        SaveSensitiveSetting(nameof(CaiyunApiKey), CaiyunApiKey, preserveUnmigratedSensitiveSettings);
 
         // NiuTrans settings
-        _settings[nameof(NiuTransApiKey)] = ProtectSensitiveSetting(NiuTransApiKey);
+        SaveSensitiveSetting(nameof(NiuTransApiKey), NiuTransApiKey, preserveUnmigratedSensitiveSettings);
 
         // Youdao settings
-        _settings[nameof(YoudaoAppKey)] = ProtectSensitiveSetting(YoudaoAppKey);
-        _settings[nameof(YoudaoAppSecret)] = ProtectSensitiveSetting(YoudaoAppSecret);
+        SaveSensitiveSetting(nameof(YoudaoAppKey), YoudaoAppKey, preserveUnmigratedSensitiveSettings);
+        SaveSensitiveSetting(nameof(YoudaoAppSecret), YoudaoAppSecret, preserveUnmigratedSensitiveSettings);
         _settings[nameof(YoudaoUseOfficialApi)] = YoudaoUseOfficialApi;
 
         // Volcano settings
-        _settings[nameof(VolcanoAccessKeyId)] = ProtectSensitiveSetting(VolcanoAccessKeyId);
-        _settings[nameof(VolcanoSecretAccessKey)] = ProtectSensitiveSetting(VolcanoSecretAccessKey);
+        SaveSensitiveSetting(nameof(VolcanoAccessKeyId), VolcanoAccessKeyId, preserveUnmigratedSensitiveSettings);
+        SaveSensitiveSetting(nameof(VolcanoSecretAccessKey), VolcanoSecretAccessKey, preserveUnmigratedSensitiveSettings);
 
         _settings[nameof(MinimizeToTray)] = MinimizeToTray;
         _settings[nameof(ClipboardMonitoring)] = ClipboardMonitoring;
@@ -932,7 +948,7 @@ public sealed class SettingsService
 
         // Save OCR Engine settings
         _settings[nameof(OcrEngine)] = (int)OcrEngine;
-        _settings[nameof(OcrApiKey)] = ProtectSensitiveSetting(OcrApiKey);
+        SaveSensitiveSetting(nameof(OcrApiKey), OcrApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(OcrEndpoint)] = OcrEndpoint;
         _settings[nameof(OcrModel)] = OcrModel;
         _settings[nameof(OcrSystemPrompt)] = OcrSystemPrompt;
@@ -1011,9 +1027,17 @@ public sealed class SettingsService
 
         try
         {
-            var json = JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(_settings, SettingsJsonOptions);
+            if (File.Exists(_settingsFilePath)
+                && string.Equals(json, previousJson, StringComparison.Ordinal))
+            {
+                _sensitiveSettingsPendingMigration.Clear();
+                System.Diagnostics.Debug.WriteLine($"[SettingsService] Settings unchanged; save skipped for: {_settingsFilePath}");
+                return;
+            }
+
             File.WriteAllText(_settingsFilePath, json);
-            _needsSensitiveSettingsMigration = false;
+            _sensitiveSettingsPendingMigration.Clear();
 
             // Verify the file was written successfully
             System.Diagnostics.Debug.WriteLine($"[SettingsService] Settings saved successfully to: {_settingsFilePath}");
@@ -1466,7 +1490,7 @@ public sealed class SettingsService
             out var decryptFailed);
         if (needsMigration)
         {
-            _needsSensitiveSettingsMigration = true;
+            _sensitiveSettingsPendingMigration.Add(key);
         }
 
         if (decryptFailed)
@@ -1484,17 +1508,69 @@ public sealed class SettingsService
             : LocalCredentialProtector.Protect(plaintext);
     }
 
+    private void SaveSensitiveSetting(
+        string key,
+        string? plaintext,
+        bool preserveUnmigratedSensitiveSettings)
+    {
+        if (preserveUnmigratedSensitiveSettings
+            && !_sensitiveSettingsPendingMigration.Contains(key)
+            && TryGetStoredSensitiveSetting(key, out var storedValue)
+            && LocalCredentialProtector.IsProtected(storedValue))
+        {
+            _settings[key] = storedValue;
+            return;
+        }
+
+        if (!_sensitiveSettingsPendingMigration.Contains(key)
+            && TryGetStoredSensitiveSetting(key, out storedValue)
+            && LocalCredentialProtector.IsProtected(storedValue)
+            && LocalCredentialProtector.TryUnprotect(storedValue, out var storedPlaintext)
+            && string.Equals(storedPlaintext, plaintext ?? string.Empty, StringComparison.Ordinal))
+        {
+            _settings[key] = storedValue;
+            return;
+        }
+
+        _settings[key] = ProtectSensitiveSetting(plaintext);
+    }
+
+    private bool TryGetStoredSensitiveSetting(string key, out string storedValue)
+    {
+        storedValue = string.Empty;
+        if (!_settings.TryGetValue(key, out var value) || value is null)
+        {
+            return false;
+        }
+
+        if (value is string stringValue)
+        {
+            storedValue = stringValue;
+            return true;
+        }
+
+        if (value is JsonElement { ValueKind: JsonValueKind.String } jsonElement)
+        {
+            storedValue = jsonElement.GetString() ?? string.Empty;
+            return true;
+        }
+
+        return false;
+    }
+
     private void MigrateSensitiveSettingsIfNeeded()
     {
-        if (!_needsSensitiveSettingsMigration)
+        if (_sensitiveSettingsPendingMigration.Count == 0)
         {
             return;
         }
 
         try
         {
-            Save();
-            Debug.WriteLine("[SettingsService] Migrated plaintext sensitive settings to protected storage.");
+            var migratedCount = _sensitiveSettingsPendingMigration.Count;
+            SaveCore(preserveUnmigratedSensitiveSettings: true);
+            Debug.WriteLine(
+                $"[SettingsService] Migrated {migratedCount} plaintext or legacy sensitive settings to protected storage.");
         }
         catch (Exception ex)
         {

--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -214,6 +214,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>مفتاح API (اختياري)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>رمز GitHub المميز</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>إظهار {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>إخفاء {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>نقطة الاتصال</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -94,6 +94,35 @@
     <value>خطأ</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>انقر للاستعلام</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>انقر على الرأس للاستعلام</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>جارٍ التحقق...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>جارٍ البث...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>لا توجد نتيجة</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>مخزّن مؤقتًا</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>في انتظار الاستجابة...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>خطأ في الترجمة</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>إعادة المحاولة</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>اكتشاف تلقائي</value>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -47,6 +47,35 @@
   <data name="StatusReady" xml:space="preserve"><value>Klar</value></data>
   <data name="StatusTranslating" xml:space="preserve"><value>Oversætter...</value></data>
   <data name="StatusError" xml:space="preserve"><value>Fejl</value></data>
+
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>Klik for at forespørge</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>Klik på overskriften for at forespørge</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>Kontrollerer...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>Streamer...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>Intet resultat</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>cachelagret</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>Venter på svar...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>Oversættelsesfejl</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>Prøv igen</value>
+  </data>
   <data name="LangAutoDetect" xml:space="preserve"><value>Automatisk registrering</value></data>
   <data name="LangEnglish" xml:space="preserve"><value>Engelsk</value></data>
   <data name="LangChinese" xml:space="preserve"><value>Kinesisk</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -104,6 +104,15 @@
   <data name="ServiceConfigurationDescription" xml:space="preserve"><value>Konfigurer API-nøgler, endpoints og modeller for hver oversættelsestjeneste.</value></data>
   <data name="ApiKey" xml:space="preserve"><value>API-nøgle</value></data>
   <data name="ApiKeyOptional" xml:space="preserve"><value>API-nøgle (valgfri)</value></data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>GitHub-token</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>Vis {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>Skjul {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve"><value>Endpoint</value></data>
   <data name="EndpointOptional" xml:space="preserve"><value>Endpoint (valgfri)</value></data>
   <data name="EndpointRequired" xml:space="preserve"><value>Endpoint (påkrævet)</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -91,6 +91,35 @@
     <value>Fehler</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>Zum Abfragen klicken</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>Kopfzeile zum Abfragen klicken</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>Prüfen...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>Streaming...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>Kein Ergebnis</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>zwischengespeichert</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>Warte auf Antwort...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>Übersetzungsfehler</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>Erneut versuchen</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>Automatisch erkennen</value>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -322,6 +322,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>API-Schlüssel (Optional)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>GitHub-Token</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>{0} anzeigen</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>{0} ausblenden</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>Endpunkt</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -94,6 +94,35 @@
     <value>Error</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>Click to query</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>Click header to query</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>Checking...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>Streaming...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>No result</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>cached</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>Waiting for response...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>Translation error</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>Auto Detect</value>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -325,6 +325,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>API Key (Optional)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>GitHub Token</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>Show {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>Hide {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>Endpoint</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -322,6 +322,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>Clé API (optionnel)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>Jeton GitHub</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>Afficher {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>Masquer {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>Point de terminaison</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -91,6 +91,35 @@
     <value>Erreur</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>Cliquer pour interroger</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>Cliquer sur l&apos;en-tête pour interroger</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>Vérification...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>Diffusion...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>Aucun résultat</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>en cache</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>En attente de réponse...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>Erreur de traduction</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>Réessayer</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>Détection automatique</value>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -47,6 +47,35 @@
   <data name="StatusReady" xml:space="preserve"><value>तैयार</value></data>
   <data name="StatusTranslating" xml:space="preserve"><value>अनुवाद हो रहा है...</value></data>
   <data name="StatusError" xml:space="preserve"><value>त्रुटि</value></data>
+
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>क्वेरी करने के लिए क्लिक करें</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>क्वेरी करने के लिए शीर्षक पर क्लिक करें</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>जाँच हो रही है...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>स्ट्रीम हो रहा है...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>कोई परिणाम नहीं</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>कैश किया गया</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>जवाब की प्रतीक्षा...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>अनुवाद त्रुटि</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>पुनः प्रयास करें</value>
+  </data>
   <data name="LangAutoDetect" xml:space="preserve"><value>स्वतः पहचान</value></data>
   <data name="LangEnglish" xml:space="preserve"><value>अंग्रेज़ी</value></data>
   <data name="LangChinese" xml:space="preserve"><value>चीनी</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -104,6 +104,15 @@
   <data name="ServiceConfigurationDescription" xml:space="preserve"><value>प्रत्येक अनुवाद सेवा के लिए API key, endpoint और model कॉन्फ़िगर करें।</value></data>
   <data name="ApiKey" xml:space="preserve"><value>API Key</value></data>
   <data name="ApiKeyOptional" xml:space="preserve"><value>API Key (वैकल्पिक)</value></data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>GitHub टोकन</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>{0} दिखाएं</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>{0} छिपाएं</value>
+  </data>
   <data name="Endpoint" xml:space="preserve"><value>Endpoint</value></data>
   <data name="EndpointOptional" xml:space="preserve"><value>Endpoint (वैकल्पिक)</value></data>
   <data name="EndpointRequired" xml:space="preserve"><value>Endpoint (आवश्यक)</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -79,6 +79,35 @@
   <data name="StatusError" xml:space="preserve">
     <value>Kesalahan</value>
   </data>
+
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>Klik untuk kueri</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>Klik header untuk kueri</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>Memeriksa...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>Streaming...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>Tidak ada hasil</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>cache</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>Menunggu respons...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>Kesalahan terjemahan</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>Coba lagi</value>
+  </data>
   <data name="LangAutoDetect" xml:space="preserve">
     <value>Deteksi Otomatis</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -192,6 +192,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>API Key (Opsional)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>Token GitHub</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>Tampilkan {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>Sembunyikan {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>Endpoint</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -86,6 +86,35 @@
     <value>Errore</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>Fai clic per interrogare</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>Fai clic sull&apos;intestazione per interrogare</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>Controllo...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>Streaming...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>Nessun risultato</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>in cache</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>In attesa della risposta...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>Errore di traduzione</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>Riprova</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>Rilevamento automatico</value>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -206,6 +206,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>Chiave API (Opzionale)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>Token GitHub</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>Mostra {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>Nascondi {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>Endpoint</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -322,6 +322,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>APIキー（オプション）</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>GitHub トークン</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>{0}を表示</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>{0}を非表示</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>エンドポイント</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -91,6 +91,35 @@
     <value>エラー</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>クリックして照会</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>ヘッダーをクリックして照会</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>チェック中...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>ストリーミング中...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>結果なし</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>キャッシュ済み</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>応答待ち...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>翻訳エラー</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>再試行</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>自動検出</value>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -91,6 +91,35 @@
     <value>오류</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>클릭하여 조회</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>헤더를 클릭하여 조회</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>검사 중...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>스트리밍 중...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>결과 없음</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>캐시됨</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>응답 대기 중...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>번역 오류</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>다시 시도</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>자동 감지</value>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -322,6 +322,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>API 키 (선택사항)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>GitHub 토큰</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>{0} 표시</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>{0} 숨기기</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>엔드포인트</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -104,6 +104,15 @@
   <data name="ServiceConfigurationDescription" xml:space="preserve"><value>Konfigurasikan kunci API, endpoint dan model untuk setiap perkhidmatan terjemahan.</value></data>
   <data name="ApiKey" xml:space="preserve"><value>Kunci API</value></data>
   <data name="ApiKeyOptional" xml:space="preserve"><value>Kunci API (Pilihan)</value></data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>Token GitHub</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>Tunjukkan {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>Sembunyikan {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve"><value>Endpoint</value></data>
   <data name="EndpointOptional" xml:space="preserve"><value>Endpoint (Pilihan)</value></data>
   <data name="EndpointRequired" xml:space="preserve"><value>Endpoint (Wajib)</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -47,6 +47,35 @@
   <data name="StatusReady" xml:space="preserve"><value>Sedia</value></data>
   <data name="StatusTranslating" xml:space="preserve"><value>Menterjemah...</value></data>
   <data name="StatusError" xml:space="preserve"><value>Ralat</value></data>
+
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>Klik untuk tanya</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>Klik pengepala untuk tanya</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>Menyemak...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>Menstrim...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>Tiada hasil</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>cache</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>Menunggu respons...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>Ralat terjemahan</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>Cuba lagi</value>
+  </data>
   <data name="LangAutoDetect" xml:space="preserve"><value>Kesan Automatik</value></data>
   <data name="LangEnglish" xml:space="preserve"><value>Inggeris</value></data>
   <data name="LangChinese" xml:space="preserve"><value>Cina</value></data>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -87,6 +87,35 @@
   <data name="StatusError" xml:space="preserve">
     <value>&#xE02;&#xE49;&#xE2D;&#xE1C;&#xE34;&#xE14;&#xE1E;&#xE25;&#xE32;&#xE14;</value>
   </data>
+
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>คลิกเพื่อค้นหา</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>คลิกส่วนหัวเพื่อค้นหา</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>กำลังตรวจสอบ...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>กำลังสตรีม...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>ไม่มีผลลัพธ์</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>จากแคช</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>กำลังรอการตอบกลับ...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>ข้อผิดพลาดการแปล</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>ลองอีกครั้ง</value>
+  </data>
   <data name="LangAutoDetect" xml:space="preserve">
     <value>&#xE15;&#xE23;&#xE27;&#xE08;&#xE08;&#xE31;&#xE1A;&#xE2D;&#xE31;&#xE15;&#xE42;&#xE19;&#xE21;&#xE31;&#xE15;&#xE34;</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -200,6 +200,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>API Key (&#xE44;&#xE21;&#xE48;&#xE1A;&#xE31;&#xE07;&#xE04;&#xE31;&#xE1A;)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>โทเค็น GitHub</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>แสดง {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>ซ่อน {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>Endpoint</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -94,6 +94,35 @@
     <value>L&#x1ED7;i</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>Nhấp để truy vấn</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>Nhấp vào tiêu đề để truy vấn</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>Đang kiểm tra...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>Đang truyền...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>Không có kết quả</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>đã lưu cache</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>Đang chờ phản hồi...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>Lỗi dịch</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>Thử lại</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>T&#x1EF1; &#x111;&#x1ED9;ng ph&#xE1;t hi&#x1EC7;n</value>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -214,6 +214,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>API Key (T&#xF9;y ch&#x1ECD;n)</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>Mã thông báo GitHub</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>Hiển thị {0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>Ẩn {0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>Endpoint</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -94,6 +94,35 @@
     <value>错误</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>点击查询</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>点击服务标题查询</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>检查中...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>流式输出中...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>无结果</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>已缓存</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>等待响应...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>翻译错误</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>重试</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>自动检测</value>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -325,6 +325,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>API 密钥（可选）</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>GitHub 令牌</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>显示{0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>隐藏{0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>端点</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -322,6 +322,15 @@
   <data name="ApiKeyOptional" xml:space="preserve">
     <value>API 金鑰（選填）</value>
   </data>
+  <data name="GitHubToken" xml:space="preserve">
+    <value>GitHub 權杖</value>
+  </data>
+  <data name="ShowSecretFormat" xml:space="preserve">
+    <value>顯示{0}</value>
+  </data>
+  <data name="HideSecretFormat" xml:space="preserve">
+    <value>隱藏{0}</value>
+  </data>
   <data name="Endpoint" xml:space="preserve">
     <value>端點</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -91,6 +91,35 @@
     <value>錯誤</value>
   </data>
 
+  <!-- Service Result Status -->
+  <data name="ServiceResult_PendingQueryStatus" xml:space="preserve">
+    <value>點擊查詢</value>
+  </data>
+  <data name="ServiceResult_PendingQueryHint" xml:space="preserve">
+    <value>點擊服務標題查詢</value>
+  </data>
+  <data name="ServiceResult_Checking" xml:space="preserve">
+    <value>檢查中...</value>
+  </data>
+  <data name="ServiceResult_Streaming" xml:space="preserve">
+    <value>串流輸出中...</value>
+  </data>
+  <data name="ServiceResult_NoResult" xml:space="preserve">
+    <value>無結果</value>
+  </data>
+  <data name="ServiceResult_Cached" xml:space="preserve">
+    <value>已快取</value>
+  </data>
+  <data name="ServiceResult_WaitingForResponse" xml:space="preserve">
+    <value>等待回應...</value>
+  </data>
+  <data name="ServiceResult_TranslationErrorTooltip" xml:space="preserve">
+    <value>翻譯錯誤</value>
+  </data>
+  <data name="ServiceResult_Retry" xml:space="preserve">
+    <value>重試</value>
+  </data>
+
   <!-- Languages -->
   <data name="LangAutoDetect" xml:space="preserve">
     <value>自動偵測</value>

--- a/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml
@@ -62,7 +62,6 @@
                 <StackPanel Spacing="4">
                     <TextBlock
                         x:Name="PendingQueryText"
-                        Text="Click header to query"
                         FontSize="12"
                         Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                         Visibility="Collapsed"/>

--- a/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml.cs
@@ -14,6 +14,7 @@ public sealed partial class MinimalServiceResultItem : UserControl, IServiceResu
     public MinimalServiceResultItem()
     {
         InitializeComponent();
+        PendingQueryText.Text = ServiceResultStatusTextProvider.GetPendingQueryHintText();
     }
 
     public FrameworkElement Element => this;
@@ -129,14 +130,15 @@ public sealed partial class MinimalServiceResultItem : UserControl, IServiceResu
         {
             if (_serviceResult.HasError && !_serviceResult.IsLoading)
             {
-                ErrorText.Text = _serviceResult.Error?.Message ?? "Error";
+                ErrorText.Text = _serviceResult.Error?.Message
+                    ?? ServiceResultStatusTextProvider.GetErrorFallbackText();
                 ErrorText.Visibility = Visibility.Visible;
             }
             else if (_serviceResult.IsStreaming)
             {
                 var displayText = _serviceResult.DisplayText;
                 ResultText.Text = string.IsNullOrWhiteSpace(displayText)
-                    ? "Waiting for response..."
+                    ? ServiceResultStatusTextProvider.GetWaitingForResponseText()
                     : displayText;
                 ResultText.Foreground = ResolveTextBrush(isInfoResult: false)
                     ?? ResultText.Foreground;
@@ -163,12 +165,8 @@ public sealed partial class MinimalServiceResultItem : UserControl, IServiceResu
         ContentArea.Visibility = hasVisibleContent ? Visibility.Visible : Visibility.Collapsed;
     }
 
-    private static string GetStatusText(ServiceQueryResult serviceResult)
-    {
-        if (serviceResult.ShowPendingQueryHint) return "Click to query";
-        if (serviceResult.IsLoading) return "Loading";
-        return serviceResult.StatusText;
-    }
+    private static string GetStatusText(ServiceQueryResult serviceResult) =>
+        ServiceResultStatusTextProvider.GetStatusText(serviceResult);
 
     private static string GetMinimalDisplayText(ServiceQueryResult serviceResult)
     {

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
@@ -92,15 +92,13 @@
                         FontSize="12"
                         Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                         Visibility="Collapsed"
-                        Margin="0,0,4,0"
-                        ToolTipService.ToolTip="Translation error"/>
+                        Margin="0,0,4,0"/>
 
                     <!-- Retry Button (visible on error) -->
                     <Button
                         x:Name="RetryButton"
                         Grid.Column="4"
                         Click="OnRetryClicked"
-                        ToolTipService.ToolTip="Retry"
                         Background="Transparent"
                         BorderThickness="0"
                         Width="24"
@@ -151,7 +149,6 @@
                             <TextBlock
                                 x:Name="PendingQueryText"
                                 Grid.Row="0"
-                                Text="Click header to query"
                                 FontStyle="Italic"
                                 FontSize="12"
                                 Foreground="{ThemeResource TextFillColorTertiaryBrush}"

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -88,6 +88,9 @@ public sealed partial class ServiceResultItem : UserControl, IServiceResultView
         ActualThemeChanged += OnActualThemeChanged;
         var loc = LocalizationService.Instance;
         ToolTipService.SetToolTip(ReplaceButton, loc.GetString("InsertReplace"));
+        ToolTipService.SetToolTip(ErrorIcon, ServiceResultStatusTextProvider.GetTranslationErrorTooltipText());
+        ToolTipService.SetToolTip(RetryButton, ServiceResultStatusTextProvider.GetRetryText());
+        PendingQueryText.Text = ServiceResultStatusTextProvider.GetPendingQueryHintText();
         FoundryLocalStartButton.Content = loc.GetString(FoundryLocalResources.UiKeys.StartButton);
         FoundryLocalDocsLink.Content = loc.GetString(FoundryLocalResources.UiKeys.DocsLinkText);
         FoundryLocalDocsLink.NavigateUri = new Uri(FoundryLocalResources.InstallDocumentationUrl);
@@ -288,7 +291,7 @@ public sealed partial class ServiceResultItem : UserControl, IServiceResultView
         }
 
         var text = string.IsNullOrEmpty(_serviceResult.StreamingText)
-            ? "Waiting for response..."
+            ? ServiceResultStatusTextProvider.GetWaitingForResponseText()
             : _serviceResult.StreamingText;
 
         if (_serviceResult.IsGrammarMode)
@@ -367,19 +370,7 @@ public sealed partial class ServiceResultItem : UserControl, IServiceResultView
         RetryButton.Visibility = hasError && !_serviceResult.IsStreaming
             ? Visibility.Visible : Visibility.Collapsed;
 
-        // Status text - show "Click to query" hint for pending manual-query services
-        if (_serviceResult.ShowPendingQueryHint)
-        {
-            StatusText.Text = "Click to query";
-        }
-        else if (minimal && _serviceResult.IsLoading)
-        {
-            StatusText.Text = "Loading";
-        }
-        else
-        {
-            StatusText.Text = _serviceResult.StatusText;
-        }
+        StatusText.Text = ServiceResultStatusTextProvider.GetStatusText(_serviceResult);
 
         // Arrow direction
         ArrowIcon.Glyph = _serviceResult.ArrowGlyph;
@@ -471,7 +462,7 @@ public sealed partial class ServiceResultItem : UserControl, IServiceResultView
         {
             // Show streaming text or placeholder while waiting for first chunk
             ResultText.Text = string.IsNullOrEmpty(_serviceResult.StreamingText)
-                ? "Waiting for response..."
+                ? ServiceResultStatusTextProvider.GetWaitingForResponseText()
                 : _serviceResult.StreamingText;
             ResultText.Foreground = resultTextBrush;
             ResultText.Visibility = Visibility.Visible;
@@ -631,7 +622,7 @@ public sealed partial class ServiceResultItem : UserControl, IServiceResultView
             GrammarResultPanel.Visibility = Visibility.Visible;
             HideErrorPanel();
             CorrectedText.Text = string.IsNullOrEmpty(_serviceResult.StreamingText)
-                ? "Waiting for response..." : _serviceResult.StreamingText;
+                ? ServiceResultStatusTextProvider.GetWaitingForResponseText() : _serviceResult.StreamingText;
             OriginalText.Text = "";
             ExplanationPanel.Visibility = Visibility.Collapsed;
             NoCorrectionsText.Visibility = Visibility.Collapsed;

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultStatusTextProvider.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultStatusTextProvider.cs
@@ -1,0 +1,78 @@
+using Easydict.TranslationService.Models;
+using Easydict.WinUI.Services;
+
+namespace Easydict.WinUI.Views.Controls;
+
+internal static class ServiceResultStatusTextProvider
+{
+    public const string PendingQueryStatusKey = "ServiceResult_PendingQueryStatus";
+    public const string PendingQueryHintKey = "ServiceResult_PendingQueryHint";
+    public const string CheckingKey = "ServiceResult_Checking";
+    public const string StreamingKey = "ServiceResult_Streaming";
+    public const string NoResultKey = "ServiceResult_NoResult";
+    public const string CachedKey = "ServiceResult_Cached";
+    public const string WaitingForResponseKey = "ServiceResult_WaitingForResponse";
+    public const string TranslationErrorTooltipKey = "ServiceResult_TranslationErrorTooltip";
+    public const string RetryKey = "ServiceResult_Retry";
+
+    public static string GetStatusText(ServiceQueryResult serviceResult)
+    {
+        var loc = LocalizationService.Instance;
+
+        if (serviceResult.ShowPendingQueryHint)
+        {
+            return loc.GetString(PendingQueryStatusKey);
+        }
+
+        if (serviceResult.IsStreaming)
+        {
+            return loc.GetString(StreamingKey);
+        }
+
+        if (serviceResult.IsLoading)
+        {
+            return loc.GetString(serviceResult.IsGrammarMode ? CheckingKey : "StatusTranslating");
+        }
+
+        if (serviceResult.Error != null)
+        {
+            return loc.GetString("StatusError");
+        }
+
+        if (serviceResult.Result?.ResultKind == TranslationResultKind.NoResult)
+        {
+            return loc.GetString(NoResultKey);
+        }
+
+        if (serviceResult.IsGrammarMode && serviceResult.GrammarResult != null)
+        {
+            return FormatTiming(serviceResult.GrammarResult.TimingMs);
+        }
+
+        if (serviceResult.Result != null)
+        {
+            return serviceResult.Result.FromCache
+                ? loc.GetString(CachedKey)
+                : FormatTiming(serviceResult.Result.TimingMs);
+        }
+
+        return string.Empty;
+    }
+
+    public static string GetPendingQueryHintText() =>
+        LocalizationService.Instance.GetString(PendingQueryHintKey);
+
+    public static string GetWaitingForResponseText() =>
+        LocalizationService.Instance.GetString(WaitingForResponseKey);
+
+    public static string GetErrorFallbackText() =>
+        LocalizationService.Instance.GetString("StatusError");
+
+    public static string GetTranslationErrorTooltipText() =>
+        LocalizationService.Instance.GetString(TranslationErrorTooltipKey);
+
+    public static string GetRetryText() =>
+        LocalizationService.Instance.GetString(RetryKey);
+
+    private static string FormatTiming(long timingMs) => $"{timingMs}ms";
+}

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
@@ -48,7 +48,8 @@
                            FontSize="26"
                            VerticalAlignment="Center"/>
                 <StackPanel VerticalAlignment="Center">
-                    <Button Background="Transparent"
+                    <Button x:Name="ModeSelectorButton"
+                            Background="Transparent"
                             BorderThickness="0"
                             CornerRadius="{ThemeResource EasydictControlCornerRadius}"
                             Padding="4,2"
@@ -70,11 +71,14 @@
                         </Button.Flyout>
                         <StackPanel Orientation="Horizontal"
                                     Spacing="4">
-                            <TextBlock Text="Easydict"
+                            <TextBlock x:Name="ModeTitleText"
+                                       AutomationProperties.AutomationId="ModeTitleText"
+                                       Text="Easydict"
                                        FontSize="22"
                                        FontWeight="SemiBold"
                                        VerticalAlignment="Center"/>
-                            <FontIcon Glyph="&#xE70D;"
+                            <FontIcon x:Name="ModeChevronIcon"
+                                      Glyph="&#xE70D;"
                                       FontSize="10"
                                       VerticalAlignment="Center"
                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
@@ -194,6 +198,7 @@
                     <!-- Source Language -->
                     <ComboBox
                         x:Name="SourceLangCombo"
+                        AutomationProperties.AutomationId="SourceLangCombo"
                         Grid.Column="0"
                         MinWidth="130"
                         MaxWidth="200"
@@ -218,6 +223,7 @@
                     <!-- Target Language -->
                     <ComboBox
                         x:Name="TargetLangCombo"
+                        AutomationProperties.AutomationId="TargetLangCombo"
                         Grid.Column="2"
                         MinWidth="130"
                         MaxWidth="200"
@@ -277,6 +283,7 @@
 
                         <ComboBox
                             x:Name="SourceLangComboNarrow"
+                            AutomationProperties.AutomationId="SourceLangComboNarrow"
                             Grid.Column="0"
                             HorizontalAlignment="Stretch"
                             SelectionChanged="OnSourceLanguageChanged"
@@ -297,6 +304,7 @@
 
                         <ComboBox
                             x:Name="TargetLangComboNarrow"
+                            AutomationProperties.AutomationId="TargetLangComboNarrow"
                             Grid.Column="2"
                             HorizontalAlignment="Stretch"
                             SelectionChanged="OnTargetLanguageChanged"
@@ -337,6 +345,8 @@
 
                 <!-- Input Card -->
                 <Border x:Name="QuickInputCard"
+                        AutomationProperties.AutomationId="QuickInputCard"
+                        AutomationProperties.AccessibilityView="Control"
                         Grid.Row="0"
                         MaxHeight="480"
                         Style="{StaticResource CardStyle}"

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -1314,10 +1314,10 @@ namespace Easydict.WinUI.Views
 
             ReleaseServiceResultControls();
 
-            // If no services are enabled, show placeholder with guidance
+            // If no result descriptors are available, show mode-specific guidance.
             if (descriptors.Count == 0)
             {
-                PlaceholderText.Text = LocalizationService.Instance.GetString("NoServicesEnabled");
+                PlaceholderText.Text = GetEmptyServiceResultsMessage();
                 PlaceholderText.Visibility = Visibility.Visible;
 #if DEBUG
                 MemoryDiagnostics.LogDelta("MainPage.InitializeServiceResults retained after empty rebuild", initializeResultsBaseline);
@@ -1366,6 +1366,13 @@ namespace Easydict.WinUI.Views
             MemoryDiagnostics.LogSnapshot("MainPage.InitializeServiceResults complete");
             LogObjectState($"InitializeServiceResults complete (reason={reason})");
 #endif
+        }
+
+        private string GetEmptyServiceResultsMessage()
+        {
+            return _currentQuickQueryMode == QueryMode.GrammarCorrection
+                ? LocalizationService.Instance.GetString("GrammarPlaceholder")
+                : LocalizationService.Instance.GetString("NoServicesEnabled");
         }
 
         private List<ServiceResultDescriptor> GetMainWindowServiceResultDescriptors(
@@ -2134,7 +2141,7 @@ namespace Easydict.WinUI.Views
 
                 if (_serviceResults.Count == 0)
                 {
-                    SetStatusSummary(LocalizationService.Instance.GetString("NoServicesEnabled"), important: true);
+                    SetStatusSummary(GetEmptyServiceResultsMessage(), important: true);
                     return;
                 }
 

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -100,6 +100,11 @@ namespace Easydict.WinUI.Views
 
         internal readonly record struct SuggestionTokenContext(string QueryText, int StartIndex, int Length);
 
+        private readonly record struct ServiceResultDescriptor(
+            string ServiceId,
+            string DisplayName,
+            bool EnabledQuery);
+
         internal enum SuggestionNavigationCommand
         {
             None,
@@ -327,6 +332,7 @@ namespace Easydict.WinUI.Views
             ApplyStatusChrome();
             ApplyStatusSummaryChrome();
             ApplyTranslateButtonsChrome();
+            RefreshMainControlChrome();
 
             foreach (var control in _resultControls)
             {
@@ -424,10 +430,10 @@ namespace Easydict.WinUI.Views
                 return;
             }
 
-            Background = ThemeResourceService.GetBrush("ApplicationPageBackgroundThemeBrush", this)
+            Background = CreateThemeBrush("FloatingWindowBackgroundColor")
                 ?? new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-            MainWindowBorder.Background = ThemeResourceService.GetBrush("ApplicationPageBackgroundThemeBrush", this);
-            MainWindowBorder.BorderBrush = ThemeResourceService.GetBrush("MainBorderBrush", this);
+            MainWindowBorder.Background = CreateThemeBrush("FloatingWindowBackgroundColor");
+            MainWindowBorder.BorderBrush = CreateThemeBrush("MainBorderColor");
             MainWindowBorder.BorderThickness = new Thickness(0);
             MainWindowBorder.CornerRadius = new CornerRadius(0);
             MainWindowBorder.Padding = new Thickness(16);
@@ -454,12 +460,11 @@ namespace Easydict.WinUI.Views
                 return;
             }
 
-            var textBackground = ThemeResourceService.GetBrush("TextControlBackground", this)
+            var textBackground = CreateThemeBrush("FloatingInputBackgroundColor")
                 ?? new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-            var textBorder = ThemeResourceService.GetBrush("TextControlBorderBrush", this)
+            var textBorder = CreateThemeBrush("FloatingInputBorderColor")
                 ?? new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-            var textForeground = ThemeResourceService.GetBrush("TextControlForeground", this)
-                ?? ThemeResourceService.GetBrush("QueryTextBrush", this);
+            var textForeground = CreateThemeBrush("QueryTextColor");
             var placeholderForeground = ThemeResourceService.GetBrush("TextControlPlaceholderForeground", this)
                 ?? ThemeResourceService.GetBrush("TextFillColorTertiaryBrush", this);
             var transparentBrush = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
@@ -493,6 +498,184 @@ namespace Easydict.WinUI.Views
             }
 
             SetTextBoxChromeResources(InputTextBox, textBackground, transparentBrush);
+        }
+
+        private void RefreshMainControlChrome()
+        {
+            if (MinimalThemeService.IsActive)
+            {
+                ClearMainControlChromeOverrides();
+                return;
+            }
+
+            var pageBackground = CreateThemeBrush("FloatingWindowBackgroundColor")
+                ?? new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            var pageBorder = CreateThemeBrush("MainBorderColor");
+            var cardBackground = CreateThemeBrush("EasydictCardBackgroundColor");
+            var cardBorder = CreateThemeBrush("EasydictCardBorderColor");
+            var comboBackground = CreateThemeBrush("EasydictCardBackgroundColor");
+            var comboHoverBackground = CreateThemeBrush("FloatingInputBackgroundColor");
+            var comboForeground = CreateThemeBrush("QueryTextColor");
+            var comboBorder = CreateThemeBrush("FloatingInputBorderColor");
+            var foreground = CreateThemeBrush("QueryTextColor");
+            var secondaryForeground = CreateThemeBrush("ServiceResultHeaderSecondaryForegroundColor");
+            var iconForeground = CreateThemeBrush("FloatingIconForegroundColor");
+
+            Background = pageBackground;
+            MainWindowBorder.Background = pageBackground;
+            MainWindowBorder.BorderBrush = pageBorder;
+
+            ApplyHeaderChrome(foreground, secondaryForeground ?? iconForeground);
+            ApplyCardChrome(QuickInputCard, cardBackground, cardBorder);
+            ApplyCardChrome(QuickOutputCard, cardBackground, cardBorder);
+            ApplyCardChrome(LongDocInputCard, cardBackground, cardBorder);
+            ApplyCardChrome(LongDocOutputCard, cardBackground, cardBorder);
+
+            ApplyComboBoxChrome(SourceLangCombo, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+            ApplyComboBoxChrome(TargetLangCombo, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+            ApplyComboBoxChrome(SourceLangComboNarrow, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+            ApplyComboBoxChrome(TargetLangComboNarrow, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+            ApplyComboBoxChrome(LongDocSourceLangCombo, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+            ApplyComboBoxChrome(LongDocTargetLangCombo, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+            ApplyComboBoxChrome(LongDocServiceCombo, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+            ApplyComboBoxChrome(LongDocInputModeCombo, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+            ApplyComboBoxChrome(LongDocOutputModeCombo, comboBackground, comboHoverBackground, comboForeground, comboBorder);
+        }
+
+        private void ClearMainControlChromeOverrides()
+        {
+            ClearCardChrome(QuickInputCard);
+            ClearCardChrome(QuickOutputCard);
+            ClearCardChrome(LongDocInputCard);
+            ClearCardChrome(LongDocOutputCard);
+
+            ClearComboBoxChrome(SourceLangCombo);
+            ClearComboBoxChrome(TargetLangCombo);
+            ClearComboBoxChrome(SourceLangComboNarrow);
+            ClearComboBoxChrome(TargetLangComboNarrow);
+            ClearComboBoxChrome(LongDocSourceLangCombo);
+            ClearComboBoxChrome(LongDocTargetLangCombo);
+            ClearComboBoxChrome(LongDocServiceCombo);
+            ClearComboBoxChrome(LongDocInputModeCombo);
+            ClearComboBoxChrome(LongDocOutputModeCombo);
+
+            ModeSelectorButton.ClearValue(Control.ForegroundProperty);
+            ModeTitleText.ClearValue(TextBlock.ForegroundProperty);
+            ModeChevronIcon.ClearValue(FontIcon.ForegroundProperty);
+            ModeSubtitle.ClearValue(TextBlock.ForegroundProperty);
+            LangHelpIcon.ClearValue(FontIcon.ForegroundProperty);
+            LangHelpIconNarrow.ClearValue(FontIcon.ForegroundProperty);
+            InputHelpIcon.ClearValue(FontIcon.ForegroundProperty);
+        }
+
+        private void ApplyHeaderChrome(Brush? foreground, Brush? secondaryForeground)
+        {
+            if (foreground is not null)
+            {
+                ModeSelectorButton.Foreground = foreground;
+                ModeTitleText.Foreground = foreground;
+            }
+
+            if (secondaryForeground is not null)
+            {
+                ModeChevronIcon.Foreground = secondaryForeground;
+                ModeSubtitle.Foreground = secondaryForeground;
+                LangHelpIcon.Foreground = secondaryForeground;
+                LangHelpIconNarrow.Foreground = secondaryForeground;
+                InputHelpIcon.Foreground = secondaryForeground;
+            }
+        }
+
+        private Brush? CreateThemeBrush(string colorKey)
+        {
+            return ThemeResourceService.GetColor(colorKey, this) is { } color
+                ? new SolidColorBrush(color)
+                : null;
+        }
+
+        private static void ApplyCardChrome(Border card, Brush? background, Brush? border)
+        {
+            if (background is not null)
+            {
+                card.Background = background;
+            }
+
+            if (border is not null)
+            {
+                card.BorderBrush = border;
+            }
+        }
+
+        private static void ClearCardChrome(Border card)
+        {
+            card.ClearValue(Border.BackgroundProperty);
+            card.ClearValue(Border.BorderBrushProperty);
+        }
+
+        private static void ApplyComboBoxChrome(
+            ComboBox comboBox,
+            Brush? background,
+            Brush? hoverBackground,
+            Brush? foreground,
+            Brush? border)
+        {
+            if (background is not null)
+            {
+                comboBox.Background = background;
+            }
+
+            if (foreground is not null)
+            {
+                comboBox.Foreground = foreground;
+            }
+
+            if (border is not null)
+            {
+                comboBox.BorderBrush = border;
+            }
+
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxBackground", background);
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxBackgroundPointerOver", hoverBackground ?? background);
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxBackgroundFocused", background);
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxForeground", foreground);
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxForegroundPointerOver", foreground);
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxForegroundFocused", foreground);
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxBorderBrush", border);
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxBorderBrushPointerOver", border);
+            SetResourceIfNotNull(comboBox.Resources, "ComboBoxBorderBrushFocused", border);
+        }
+
+        private static void SetResourceIfNotNull(ResourceDictionary resources, string key, object? value)
+        {
+            if (value is not null)
+            {
+                resources[key] = value;
+            }
+        }
+
+        private static void ClearComboBoxChrome(ComboBox comboBox)
+        {
+            comboBox.ClearValue(Control.BackgroundProperty);
+            comboBox.ClearValue(Control.ForegroundProperty);
+            comboBox.ClearValue(Control.BorderBrushProperty);
+
+            RemoveResource(comboBox.Resources, "ComboBoxBackground");
+            RemoveResource(comboBox.Resources, "ComboBoxBackgroundPointerOver");
+            RemoveResource(comboBox.Resources, "ComboBoxBackgroundFocused");
+            RemoveResource(comboBox.Resources, "ComboBoxForeground");
+            RemoveResource(comboBox.Resources, "ComboBoxForegroundPointerOver");
+            RemoveResource(comboBox.Resources, "ComboBoxForegroundFocused");
+            RemoveResource(comboBox.Resources, "ComboBoxBorderBrush");
+            RemoveResource(comboBox.Resources, "ComboBoxBorderBrushPointerOver");
+            RemoveResource(comboBox.Resources, "ComboBoxBorderBrushFocused");
+        }
+
+        private static void RemoveResource(ResourceDictionary resources, string key)
+        {
+            if (resources.ContainsKey(key))
+            {
+                resources.Remove(key);
+            }
         }
 
         private static void SetTextBoxChromeResources(TextBox textBox, Brush background, Brush border)
@@ -1107,14 +1290,32 @@ namespace Easydict.WinUI.Views
                 return;
             }
 
-            ReleaseServiceResultControls();
-
             // Get enabled services and EnabledQuery settings from settings
             var enabledServices = _settings.MainWindowEnabledServices;
             var enabledQuerySettings = _settings.MainWindowServiceEnabledQuery;
+            var manager = TranslationManagerService.Instance.Manager;
+            var grammarSourceLanguage = _lastQuickQueryResolution?.EffectiveSourceLanguage
+                ?? TranslationLanguage.Auto;
+            var descriptors = GetMainWindowServiceResultDescriptors(
+                enabledServices,
+                enabledQuerySettings,
+                manager,
+                grammarSourceLanguage);
+
+            if (skipRebuildWhenDebugFlagSet && TryReuseServiceResultControls(descriptors, reason))
+            {
+#if DEBUG
+                MemoryDiagnostics.LogDelta("MainPage.InitializeServiceResults retained after reuse", initializeResultsBaseline);
+                MemoryDiagnostics.LogSnapshot("MainPage.InitializeServiceResults reused");
+                LogObjectState($"InitializeServiceResults reused (reason={reason})");
+#endif
+                return;
+            }
+
+            ReleaseServiceResultControls();
 
             // If no services are enabled, show placeholder with guidance
-            if (enabledServices.Count == 0)
+            if (descriptors.Count == 0)
             {
                 PlaceholderText.Text = LocalizationService.Instance.GetString("NoServicesEnabled");
                 PlaceholderText.Visibility = Visibility.Visible;
@@ -1126,33 +1327,17 @@ namespace Easydict.WinUI.Views
                 return;
             }
 
-            // Get display names from TranslationManager (single source of truth)
-            var manager = TranslationManagerService.Instance.Manager;
-            var grammarSourceLanguage = _lastQuickQueryResolution?.EffectiveSourceLanguage
-                ?? TranslationLanguage.Auto;
-
-            foreach (var serviceId in enabledServices)
+            foreach (var descriptor in descriptors)
             {
-                // Use service-provided DisplayName, fallback to serviceId if not found
-                var displayName = serviceId;
-                ITranslationService? service = null;
-                if (manager.Services.TryGetValue(serviceId, out service))
-                {
-                    displayName = service.DisplayName;
-                }
-
-                var isGrammarCapable = service is not null
+                var isGrammarCapable = manager.Services.TryGetValue(descriptor.ServiceId, out var service)
                     && GrammarCorrectionServiceAvailability.IsAvailable(service, grammarSourceLanguage);
-
-                // Get EnabledQuery setting (default true if not found)
-                var enabledQuery = enabledQuerySettings.TryGetValue(serviceId, out var eq) ? eq : true;
 
                 var result = new ServiceQueryResult
                 {
-                    ServiceId = serviceId,
-                    ServiceDisplayName = displayName,
-                    EnabledQuery = enabledQuery,
-                    IsExpanded = enabledQuery, // Manual-query services start collapsed
+                    ServiceId = descriptor.ServiceId,
+                    ServiceDisplayName = descriptor.DisplayName,
+                    EnabledQuery = descriptor.EnabledQuery,
+                    IsExpanded = descriptor.EnabledQuery, // Manual-query services start collapsed
                     CurrentMode = _currentQuickQueryMode,
                     IsGrammarCapable = isGrammarCapable,
                 };
@@ -1181,6 +1366,85 @@ namespace Easydict.WinUI.Views
             MemoryDiagnostics.LogSnapshot("MainPage.InitializeServiceResults complete");
             LogObjectState($"InitializeServiceResults complete (reason={reason})");
 #endif
+        }
+
+        private List<ServiceResultDescriptor> GetMainWindowServiceResultDescriptors(
+            IEnumerable<string> enabledServices,
+            IReadOnlyDictionary<string, bool> enabledQuerySettings,
+            TranslationManager manager,
+            TranslationLanguage grammarSourceLanguage)
+        {
+            var descriptors = new List<ServiceResultDescriptor>();
+
+            foreach (var serviceId in enabledServices)
+            {
+                var displayName = serviceId;
+                if (manager.Services.TryGetValue(serviceId, out var service))
+                {
+                    displayName = service.DisplayName;
+
+                    // In grammar correction, only show services that can correct grammar.
+                    if (_currentQuickQueryMode == QueryMode.GrammarCorrection &&
+                        !GrammarCorrectionServiceAvailability.IsAvailable(service, grammarSourceLanguage))
+                    {
+                        continue;
+                    }
+                }
+                else if (_currentQuickQueryMode == QueryMode.GrammarCorrection)
+                {
+                    continue;
+                }
+
+                // Get EnabledQuery setting (default true if not found)
+                var enabledQuery = enabledQuerySettings.TryGetValue(serviceId, out var eq) ? eq : true;
+                descriptors.Add(new ServiceResultDescriptor(serviceId, displayName, enabledQuery));
+            }
+
+            return descriptors;
+        }
+
+        private bool TryReuseServiceResultControls(
+            IReadOnlyList<ServiceResultDescriptor> descriptors,
+            string reason)
+        {
+            if (_useMemoryAbVariantB ||
+                descriptors.Count == 0 ||
+                _serviceResults.Count != descriptors.Count ||
+                _resultControls.Count != descriptors.Count ||
+                ResultsPanel.Items.Count != descriptors.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < descriptors.Count; i++)
+            {
+                var descriptor = descriptors[i];
+                var current = _serviceResults[i];
+                if (!string.Equals(current.ServiceId, descriptor.ServiceId, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(current.ServiceDisplayName, descriptor.DisplayName, StringComparison.Ordinal) ||
+                    current.EnabledQuery != descriptor.EnabledQuery)
+                {
+                    return false;
+                }
+            }
+
+            foreach (var serviceResult in _serviceResults)
+            {
+                serviceResult.CurrentMode = _currentQuickQueryMode;
+                RefreshServiceResultView(serviceResult);
+            }
+
+            ReorderResultsPanel();
+
+            PlaceholderText.Text = _currentQuickQueryMode == QueryMode.GrammarCorrection
+                ? LocalizationService.Instance.GetString("GrammarPlaceholder")
+                : LocalizationService.Instance.GetString("TranslationPlaceholder");
+            PlaceholderText.Visibility = Visibility.Collapsed;
+
+#if DEBUG
+            Debug.WriteLine($"[MainPage] InitializeServiceResults reused cached controls (reason={reason})");
+#endif
+            return true;
         }
 
         private void RebuildServiceResultControlsForCurrentTheme()
@@ -1637,6 +1901,16 @@ namespace Easydict.WinUI.Views
             _isQuerying = loading;
 
             var loc = LocalizationService.Instance;
+            var translatingStatus = loc.GetString("StatusTranslating");
+            if (loading)
+            {
+                UpdateStatus(null, translatingStatus);
+            }
+            else if (string.Equals(_lastStatusText, translatingStatus, StringComparison.Ordinal))
+            {
+                UpdateStatus(true, loc.GetString("StatusReady"));
+            }
+
             var tooltip = loading ? loc.GetString("Cancel") : loc.GetString("TranslateTooltip");
             ToolTipService.SetToolTip(TranslateButton, tooltip);
             ToolTipService.SetToolTip(TranslateButtonNarrow, tooltip);
@@ -1833,6 +2107,9 @@ namespace Easydict.WinUI.Views
             {
                 if (_isClosing) return;
 
+                SetLoading(true);
+                PrepareServiceResultsForQueryStart();
+
                 // Resolve the effective quick-query mode before prompting services so
                 // grammar mode only prepares/runs grammar-capable services.
                 var detectedLanguage = await DetectSourceLanguageForQueryAsync(inputText, detectionService, ct);
@@ -1867,6 +2144,7 @@ namespace Easydict.WinUI.Views
                     SetStatusSummary(
                         LocalizationService.Instance.GetString("NoAvailableTargetLanguage"),
                         important: true);
+                    ResetAllServiceResultsLoadingState();
                     return;
                 }
 
@@ -1914,16 +2192,17 @@ namespace Easydict.WinUI.Views
                         SetStatusSummary(
                             LocalizationService.Instance.GetString("NoAvailableTargetLanguage"),
                             important: true);
+                        ResetAllServiceResultsLoadingState();
                         return;
                     }
 
                     if (!_serviceResults.Any(result => result.EnabledQuery))
                     {
+                        ResetAllServiceResultsLoadingState();
                         return;
                     }
                 }
 
-                SetLoading(true);
                 _hasAutoPlayedCurrentQuery = false;
 
                 // Reset all service results
@@ -2143,6 +2422,28 @@ namespace Easydict.WinUI.Views
             }
 
             return trackedTask;
+        }
+
+        private void PrepareServiceResultsForQueryStart()
+        {
+            if (_serviceResults.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var serviceResult in _serviceResults)
+            {
+                serviceResult.Reset();
+                if (serviceResult.EnabledQuery)
+                {
+                    serviceResult.IsLoading = true;
+                }
+
+                RefreshServiceResultView(serviceResult);
+            }
+
+            PlaceholderText.Visibility = Visibility.Collapsed;
+            ReorderResultsPanel();
         }
 
         /// <summary>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -19,6 +19,16 @@
         <Style x:Key="SettingsSectionStyle" TargetType="Border" BasedOn="{StaticResource EasydictSurfaceStyle}">
             <Setter Property="Padding" Value="16"/>
         </Style>
+        <Style x:Key="SettingsInlineIconButtonStyle" TargetType="Button" BasedOn="{StaticResource EasydictIconButtonStyle}">
+            <Setter Property="Width" Value="28"/>
+            <Setter Property="Height" Value="28"/>
+            <Setter Property="MinWidth" Value="0"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+        </Style>
         <Style x:Key="SettingsTabButtonStyle" TargetType="Button">
             <Setter Property="MinWidth" Value="0"/>
             <Setter Property="MinHeight" Value="0"/>
@@ -100,16 +110,17 @@
                         <DataTemplate>
                             <Button Click="OnSettingsTabClick"
                                     Tag="{Binding Id}"
+                                    AutomationProperties.AutomationId="{Binding AutomationId}"
                                     Style="{StaticResource SettingsTabButtonStyle}"
                                     Width="86"
                                     Height="76"
                                     Margin="0,0,10,10"
                                     Padding="0"
-                                    Background="{ThemeResource SettingsTabBackgroundBrush}"
-                                    BorderBrush="{ThemeResource SettingsTabBorderBrush}"
+                                    Background="{Binding Background}"
+                                    BorderBrush="{Binding BorderBrush}"
                                     BorderThickness="1"
                                     CornerRadius="{ThemeResource EasydictControlCornerRadius}"
-                                    Foreground="{ThemeResource SettingsTabForegroundBrush}"
+                                    Foreground="{Binding Foreground}"
                                     HorizontalAlignment="Left"
                                     ToolTipService.ToolTip="{Binding Tooltip}">
                                 <Grid>
@@ -118,18 +129,18 @@
                                                 VerticalAlignment="Center">
                                         <FontIcon Glyph="{Binding IconGlyph}"
                                                   FontSize="22"
-                                                  Foreground="{ThemeResource SettingsTabForegroundBrush}"
+                                                  Foreground="{Binding Foreground}"
                                                   HorizontalAlignment="Center"/>
                                         <TextBlock Text="{Binding Label}"
                                                    FontSize="12"
-                                                   Foreground="{ThemeResource SettingsTabForegroundBrush}"
+                                                   Foreground="{Binding Foreground}"
                                                    TextAlignment="Center"
                                                    HorizontalAlignment="Center"/>
                                     </StackPanel>
 
                                     <Border
-                                        Background="{ThemeResource SettingsTabSelectedBackgroundBrush}"
-                                        BorderBrush="{ThemeResource SettingsTabSelectedBorderBrush}"
+                                        Background="{Binding SelectedBackground}"
+                                        BorderBrush="{Binding SelectedBorderBrush}"
                                         BorderThickness="1"
                                         CornerRadius="{ThemeResource EasydictControlCornerRadius}"
                                         Visibility="{Binding IsSelected, Converter={StaticResource BoolToVisibilityConverter}}"/>
@@ -140,11 +151,11 @@
                                                 Visibility="{Binding IsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
                                         <FontIcon Glyph="{Binding IconGlyph}"
                                                   FontSize="22"
-                                                  Foreground="{ThemeResource SettingsTabSelectedForegroundBrush}"
+                                                  Foreground="{Binding SelectedForeground}"
                                                   HorizontalAlignment="Center"/>
                                         <TextBlock Text="{Binding Label}"
                                                    FontSize="12"
-                                                   Foreground="{ThemeResource SettingsTabSelectedForegroundBrush}"
+                                                   Foreground="{Binding SelectedForeground}"
                                                    TextAlignment="Center"
                                                    HorizontalAlignment="Center"/>
                                     </StackPanel>
@@ -239,7 +250,8 @@
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
 
                         <!-- DeepL -->
-                        <Expander HorizontalAlignment="Stretch"
+                        <Expander AutomationProperties.AutomationId="DeepLServiceExpander"
+                                HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
                                 Tag="DeepL">
                             <Expander.Header>
@@ -258,11 +270,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="DeepLKeyBox"
-                                        Header="API Key (Optional)"
-                                        Width="350"
-                                        PlaceholderText="Enter your DeepL API key"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="DeepLKeyHeaderText"
+                                               Text="API Key (Optional)"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="DeepLKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter your DeepL API key"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="DeepLKeyRevealButton"
+                                                AutomationProperties.AutomationId="DeepLKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=DeepLKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <CheckBox x:Name="DeepLFreeCheck"/>
                                 <CheckBox x:Name="DeepLQualityCheck"/>
                                 <TextBlock x:Name="DeepLDescriptionText"
@@ -547,11 +579,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="OpenAIKeyBox"
-                                        Header="API Key"
-                                        Width="350"
-                                        PlaceholderText="sk-..."
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="OpenAIKeyHeaderText"
+                                               Text="API Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="OpenAIKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="sk-..."
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="OpenAIKeyRevealButton"
+                                                AutomationProperties.AutomationId="OpenAIKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=OpenAIKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <TextBox x:Name="OpenAIEndpointBox"
                                         Header="Endpoint (Optional)"
                                         Width="450"
@@ -620,11 +672,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="DeepSeekKeyBox"
-                                        Header="API Key"
-                                        Width="350"
-                                        PlaceholderText="sk-..."
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="DeepSeekKeyHeaderText"
+                                               Text="API Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="DeepSeekKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="sk-..."
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="DeepSeekKeyRevealButton"
+                                                AutomationProperties.AutomationId="DeepSeekKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=DeepSeekKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <ComboBox x:Name="DeepSeekModelCombo"
                                         Header="Model"
                                         Width="280"
@@ -665,11 +737,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="GroqKeyBox"
-                                        Header="API Key"
-                                        Width="350"
-                                        PlaceholderText="gsk_..."
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="GroqKeyHeaderText"
+                                               Text="API Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="GroqKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="gsk_..."
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="GroqKeyRevealButton"
+                                                AutomationProperties.AutomationId="GroqKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=GroqKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <ComboBox x:Name="GroqModelCombo"
                                         Header="Model"
                                         Width="280"
@@ -712,11 +804,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="ZhipuKeyBox"
-                                        Header="API Key"
-                                        Width="350"
-                                        PlaceholderText="Enter your Zhipu API key"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="ZhipuKeyHeaderText"
+                                               Text="API Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="ZhipuKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter your Zhipu API key"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="ZhipuKeyRevealButton"
+                                                AutomationProperties.AutomationId="ZhipuKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=ZhipuKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <ComboBox x:Name="ZhipuModelCombo"
                                         Header="Model"
                                         Width="280"
@@ -761,11 +873,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="GitHubModelsTokenBox"
-                                        Header="GitHub Token"
-                                        Width="350"
-                                        PlaceholderText="ghp_..."
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="GitHubModelsTokenHeaderText"
+                                               Text="GitHub Token"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="GitHubModelsTokenBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="ghp_..."
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="GitHubModelsTokenRevealButton"
+                                                AutomationProperties.AutomationId="GitHubModelsTokenRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=GitHubModelsTokenBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <ComboBox x:Name="GitHubModelsModelCombo"
                                         Header="Model"
                                         Width="280"
@@ -814,11 +946,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="GeminiKeyBox"
-                                        Header="API Key"
-                                        Width="350"
-                                        PlaceholderText="Enter your Gemini API key"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="GeminiKeyHeaderText"
+                                               Text="API Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="GeminiKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter your Gemini API key"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="GeminiKeyRevealButton"
+                                                AutomationProperties.AutomationId="GeminiKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=GeminiKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <ComboBox x:Name="GeminiModelCombo"
                                         Header="Model"
                                         Width="280"
@@ -876,11 +1028,31 @@
                                         Width="450"
                                          PlaceholderText="https://your-api.example.com/v1/chat/completions"
                                         HorizontalAlignment="Left"/>
-                                <PasswordBox x:Name="CustomOpenAIKeyBox"
-                                        Header="API Key (Optional)"
-                                        Width="350"
-                                        PlaceholderText="Enter API key if required"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="CustomOpenAIKeyHeaderText"
+                                               Text="API Key (Optional)"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="CustomOpenAIKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter API key if required"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="CustomOpenAIKeyRevealButton"
+                                                AutomationProperties.AutomationId="CustomOpenAIKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=CustomOpenAIKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <TextBox x:Name="CustomOpenAIModelBox"
                                         Header="Model"
                                         Width="200"
@@ -936,11 +1108,31 @@
                                     <ComboBoxItem Content="llama-3.1-8b-instant (Groq)"
                                             Tag="llama-3.1-8b-instant"/>
                                 </ComboBox>
-                                <PasswordBox x:Name="BuiltInApiKeyBox"
-                                        Header="API Key (Optional)"
-                                        Width="350"
-                                             PlaceholderText="Leave empty to use built-in key"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="BuiltInApiKeyHeaderText"
+                                               Text="API Key (Optional)"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="BuiltInApiKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Leave empty to use built-in key"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="BuiltInApiKeyRevealButton"
+                                                AutomationProperties.AutomationId="BuiltInApiKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=BuiltInApiKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <TextBlock x:Name="BuiltInDescriptionText"
                                            Text="Uses GLM (Zhipu AI) or Groq free models. You can provide your own API key from open.bigmodel.cn (GLM) or console.groq.com (Groq)."
                                            FontSize="12"
@@ -973,11 +1165,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="DoubaoKeyBox"
-                                        Header="API Key"
-                                        Width="350"
-                                        PlaceholderText="Enter your Doubao API key"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="DoubaoKeyHeaderText"
+                                               Text="API Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="DoubaoKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter your Doubao API key"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="DoubaoKeyRevealButton"
+                                                AutomationProperties.AutomationId="DoubaoKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=DoubaoKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <TextBox x:Name="DoubaoEndpointBox"
                                         Header="Endpoint"
                                         Width="450"
@@ -1019,11 +1231,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="CaiyunKeyBox"
-                                        Header="API Key"
-                                        Width="350"
-                                        PlaceholderText="Enter your Caiyun API key"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="CaiyunKeyHeaderText"
+                                               Text="API Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="CaiyunKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter your Caiyun API key"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="CaiyunKeyRevealButton"
+                                                AutomationProperties.AutomationId="CaiyunKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=CaiyunKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <TextBlock Text="Get your API key from fanyi.caiyunapp.com"
                                            FontSize="12"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
@@ -1054,11 +1286,31 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="NiuTransKeyBox"
-                                        Header="API Key"
-                                        Width="350"
-                                        PlaceholderText="Enter your NiuTrans API key"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="NiuTransKeyHeaderText"
+                                               Text="API Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="NiuTransKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter your NiuTrans API key"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="NiuTransKeyRevealButton"
+                                                AutomationProperties.AutomationId="NiuTransKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=NiuTransKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <TextBlock Text="NiuTrans supports 450+ language pairs. Get your API key from niutrans.com"
                                            FontSize="12"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -1080,16 +1332,56 @@
                             </Expander.Header>
                             <StackPanel Spacing="12"
                                     Padding="0,8">
-                                <PasswordBox x:Name="YoudaoAppKeyBox"
-                                        Header="App Key"
-                                        Width="350"
-                                        PlaceholderText="Enter your Youdao App Key"
-                                        HorizontalAlignment="Left"/>
-                                <PasswordBox x:Name="YoudaoAppSecretBox"
-                                        Header="App Secret"
-                                        Width="350"
-                                        PlaceholderText="Enter your Youdao App Secret"
-                                        HorizontalAlignment="Left"/>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="YoudaoAppKeyHeaderText"
+                                               Text="App Key"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="YoudaoAppKeyBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter your Youdao App Key"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="YoudaoAppKeyRevealButton"
+                                                AutomationProperties.AutomationId="YoudaoAppKeyRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=YoudaoAppKeyBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
+                                <StackPanel Width="350"
+                                            HorizontalAlignment="Left"
+                                            Spacing="4">
+                                    <TextBlock x:Name="YoudaoAppSecretHeaderText"
+                                               Text="App Secret"
+                                               FontSize="14"/>
+                                    <Grid>
+                                        <PasswordBox x:Name="YoudaoAppSecretBox"
+                                                     HorizontalAlignment="Stretch"
+                                                     Padding="12,5,40,5"
+                                                     PlaceholderText="Enter your Youdao App Secret"
+                                                     PasswordRevealMode="Hidden"/>
+                                        <Button x:Name="YoudaoAppSecretRevealButton"
+                                                AutomationProperties.AutomationId="YoudaoAppSecretRevealButton"
+                                                Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Margin="0,0,6,0"
+                                                Tag="{Binding ElementName=YoudaoAppSecretBox}"
+                                                Click="OnPasswordRevealButtonClick">
+                                            <FontIcon Glyph="&#xE890;"
+                                                      FontSize="14"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
                                 <ToggleSwitch x:Name="YoudaoUseOfficialApiToggle"
                                         Header="Use Official API"/>
                                 <TextBlock Text="Youdao provides phonetic transcriptions for English words. Without API keys, uses free web dictionary. With API keys, enables official API for higher limits. Get API keys from ai.youdao.com"
@@ -1849,27 +2141,47 @@
                                 <StackPanel x:Name="AdvancedOcrPanel"
                                         Spacing="12"
                                         Visibility="Collapsed">
-                                    <TextBox x:Name="OcrApiKeyBox"
-                                            Header="API Key (Optional)"
-                                            Width="450"
-                                            HorizontalAlignment="Left"
-                                            PlaceholderText="Enter API key if required"/>
+                                    <StackPanel Width="350"
+                                                HorizontalAlignment="Left"
+                                                Spacing="4">
+                                        <TextBlock x:Name="OcrApiKeyHeaderText"
+                                                   Text="API Key (Optional)"
+                                                   FontSize="14"/>
+                                        <Grid>
+                                            <PasswordBox x:Name="OcrApiKeyBox"
+                                                         HorizontalAlignment="Stretch"
+                                                         Padding="12,5,40,5"
+                                                         PlaceholderText="Enter API key if required"
+                                                         PasswordRevealMode="Hidden"/>
+                                            <Button x:Name="OcrApiKeyRevealButton"
+                                                    AutomationProperties.AutomationId="OcrApiKeyRevealButton"
+                                                    Style="{StaticResource SettingsInlineIconButtonStyle}"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Center"
+                                                    Margin="0,0,6,0"
+                                                    Tag="{Binding ElementName=OcrApiKeyBox}"
+                                                    Click="OnPasswordRevealButtonClick">
+                                                <FontIcon Glyph="&#xE890;"
+                                                          FontSize="14"/>
+                                            </Button>
+                                        </Grid>
+                                    </StackPanel>
 
                                     <TextBox x:Name="OcrEndpointBox"
                                             Header="Endpoint"
-                                            Width="450"
+                                            Width="350"
                                             HorizontalAlignment="Left"
                                             PlaceholderText="http://localhost:11434/api/generate"/>
 
                                     <TextBox x:Name="OcrModelBox"
                                             Header="Model"
-                                            Width="450"
+                                            Width="350"
                                             HorizontalAlignment="Left"
                                             PlaceholderText="glm-ocr"/>
 
                                     <TextBox x:Name="OcrSystemPromptBox"
                                             Header="System Prompt"
-                                            Width="450"
+                                            Width="350"
                                             Height="100"
                                             AcceptsReturn="True"
                                             TextWrapping="Wrap"
@@ -1883,7 +2195,7 @@
                                     <TextBox x:Name="OcrTestStatusBox"
                                             Header="Test Result"
                                             IsReadOnly="True"
-                                            Width="450"
+                                            Width="350"
                                             MinHeight="32"
                                             AcceptsReturn="True"
                                             TextWrapping="Wrap"

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -32,65 +32,106 @@ internal enum SettingsTabId
     About
 }
 
+internal sealed record SettingsTabBrushes(
+    Brush? Background,
+    Brush? BorderBrush,
+    Brush? Foreground,
+    Brush? SelectedBackground,
+    Brush? SelectedBorderBrush,
+    Brush? SelectedForeground);
+
 internal sealed class SettingsTabItem : INotifyPropertyChanged
 {
     private bool _isSelected;
     private string _label = string.Empty;
     private string _tooltip = string.Empty;
+    private Brush? _background;
+    private Brush? _borderBrush;
+    private Brush? _foreground;
+    private Brush? _selectedBackground;
+    private Brush? _selectedBorderBrush;
+    private Brush? _selectedForeground;
 
     public required SettingsTabId Id { get; init; }
     public required string IconGlyph { get; init; }
+    public string AutomationId => $"SettingsTab_{Id}";
 
     public string Label
     {
         get => _label;
-        set
-        {
-            if (_label == value)
-            {
-                return;
-            }
-
-            _label = value;
-            OnPropertyChanged();
-        }
+        set => SetField(ref _label, value);
     }
 
     public string Tooltip
     {
         get => _tooltip;
-        set
-        {
-            if (_tooltip == value)
-            {
-                return;
-            }
+        set => SetField(ref _tooltip, value);
+    }
 
-            _tooltip = value;
-            OnPropertyChanged();
-        }
+    public Brush? Background
+    {
+        get => _background;
+        private set => SetField(ref _background, value);
+    }
+
+    public Brush? BorderBrush
+    {
+        get => _borderBrush;
+        private set => SetField(ref _borderBrush, value);
+    }
+
+    public Brush? Foreground
+    {
+        get => _foreground;
+        private set => SetField(ref _foreground, value);
+    }
+
+    public Brush? SelectedBackground
+    {
+        get => _selectedBackground;
+        private set => SetField(ref _selectedBackground, value);
+    }
+
+    public Brush? SelectedBorderBrush
+    {
+        get => _selectedBorderBrush;
+        private set => SetField(ref _selectedBorderBrush, value);
+    }
+
+    public Brush? SelectedForeground
+    {
+        get => _selectedForeground;
+        private set => SetField(ref _selectedForeground, value);
     }
 
     public bool IsSelected
     {
         get => _isSelected;
-        set
-        {
-            if (_isSelected == value)
-            {
-                return;
-            }
-
-            _isSelected = value;
-            OnPropertyChanged();
-        }
+        set => SetField(ref _isSelected, value);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public void RefreshThemeBindings()
+    public void RefreshThemeBindings(SettingsTabBrushes brushes)
     {
+        Background = brushes.Background;
+        BorderBrush = brushes.BorderBrush;
+        Foreground = brushes.Foreground;
+        SelectedBackground = brushes.SelectedBackground;
+        SelectedBorderBrush = brushes.SelectedBorderBrush;
+        SelectedForeground = brushes.SelectedForeground;
         OnPropertyChanged(nameof(IsSelected));
+    }
+
+    private void SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
@@ -105,6 +146,48 @@ public sealed partial class SettingsPage : Page
     private static readonly Regex NonServiceIdCharRegex = new("[^a-z0-9-]", RegexOptions.Compiled);
     private const string ServiceConfigurationIconTag = "ServiceConfigurationIcon";
     private const string ReorderButtonEmoji = "\u2195\uFE0F";
+    private static readonly (string BrushKey, string ColorKey)[] ScopedThemeResourceBrushes =
+    [
+        ("ApplicationPageBackgroundThemeBrush", "FloatingWindowBackgroundColor"),
+        ("CardBackgroundFillColorDefaultBrush", "EasydictCardBackgroundColor"),
+        ("CardStrokeColorDefaultBrush", "EasydictCardBorderColor"),
+        ("ControlFillColorDefaultBrush", "EasydictCardBackgroundColor"),
+        ("ControlFillColorSecondaryBrush", "FloatingInputBackgroundColor"),
+        ("ControlFillColorTertiaryBrush", "EasydictCardBackgroundColor"),
+        ("ControlStrokeColorDefaultBrush", "FloatingInputBorderColor"),
+        ("ControlStrokeColorSecondaryBrush", "MainBorderColor"),
+        ("TextFillColorPrimaryBrush", "QueryTextColor"),
+        ("TextFillColorSecondaryBrush", "ServiceResultHeaderSecondaryForegroundColor"),
+        ("TextFillColorTertiaryBrush", "ServiceResultHeaderSecondaryForegroundColor"),
+        ("ButtonBackground", "EasydictCardBackgroundColor"),
+        ("ButtonBackgroundPointerOver", "FloatingInputBackgroundColor"),
+        ("ButtonBackgroundPressed", "FloatingInputBackgroundColor"),
+        ("ButtonForeground", "FloatingIconForegroundColor"),
+        ("ButtonBorderBrush", "FloatingInputBorderColor"),
+        ("ButtonBorderBrushPointerOver", "MainBorderColor"),
+        ("ButtonBorderBrushPressed", "MainBorderColor"),
+        ("ComboBoxBackground", "EasydictCardBackgroundColor"),
+        ("ComboBoxBackgroundPointerOver", "FloatingInputBackgroundColor"),
+        ("ComboBoxBorderBrush", "FloatingInputBorderColor"),
+        ("ComboBoxForeground", "QueryTextColor"),
+        ("TextControlBackground", "FloatingInputBackgroundColor"),
+        ("TextControlBorderBrush", "FloatingInputBorderColor"),
+        ("TextControlForeground", "QueryTextColor"),
+        ("AccentBrush", "AccentColor"),
+        ("AccentTextFillColorPrimaryBrush", "AccentForegroundColor"),
+        ("AccentForegroundBrush", "AccentForegroundColor"),
+        ("AccentPointerOverBrush", "AccentPointerOverColor"),
+        ("AccentPressedBrush", "AccentPressedColor"),
+        ("BlueAccentBrush", "BlueAccentColor"),
+        ("FloatingWindowBackgroundBrush", "FloatingWindowBackgroundColor"),
+        ("FloatingWindowBorderBrush", "FloatingWindowBorderColor"),
+        ("FloatingInputBackgroundBrush", "FloatingInputBackgroundColor"),
+        ("FloatingInputBorderBrush", "FloatingInputBorderColor"),
+        ("FloatingIconForegroundBrush", "FloatingIconForegroundColor"),
+        ("EasydictCardBackgroundBrush", "EasydictCardBackgroundColor"),
+        ("EasydictCardBorderBrush", "EasydictCardBorderColor")
+    ];
+
     private static readonly Dictionary<string, int> PreferredServiceDisplayOrder = new(StringComparer.OrdinalIgnoreCase)
     {
         ["bing"] = 0,
@@ -138,6 +221,8 @@ public sealed partial class SettingsPage : Page
     private bool _isMainWindowReorderModeEnabled;
     private bool _isMiniWindowReorderModeEnabled;
     private bool _isFixedWindowReorderModeEnabled;
+    private bool _themeChromeRefreshQueued;
+    private readonly Dictionary<PasswordBox, bool> _visiblePasswordBoxes = new();
     private ContentDialog? _currentDialog; // Track open dialog to prevent COMException
     private readonly CancellationTokenSource _lifetimeCts = new();
 
@@ -418,6 +503,9 @@ public sealed partial class SettingsPage : Page
     public void ApplyThemeChrome()
     {
         var minimal = MinimalThemeService.IsActive;
+        RefreshScopedThemeResources();
+        var chrome = CreateSettingsThemeChrome();
+        Background = chrome.PageBackground;
         SaveButton.Shadow = minimal ? null : new ThemeShadow();
         if (LoadingOverlayRing is not null)
         {
@@ -431,16 +519,345 @@ public sealed partial class SettingsPage : Page
             NavigationLoadingRing.Visibility = Visibility.Visible;
         }
 
+        var tabBrushes = CreateSettingsTabBrushes();
         foreach (var tab in _settingsTabs)
         {
-            tab.RefreshThemeBindings();
+            tab.RefreshThemeBindings(tabBrushes);
+        }
+
+        RefreshSettingsControlChrome(chrome);
+    }
+
+    private void RefreshSettingsControlChrome(SettingsThemeChrome chrome)
+    {
+        var tabStyle = Resources["SettingsTabButtonStyle"] as Style;
+        var accentButtonStyle = Resources["SettingsAccentButtonStyle"] as Style;
+        var inlineIconButtonStyle = Resources["SettingsInlineIconButtonStyle"] as Style;
+        var sectionStyle = Resources["SettingsSectionStyle"] as Style;
+        var placeholderForeground = ThemeResourceService.GetBrush("TextControlPlaceholderForeground", this);
+
+        var pending = new Queue<DependencyObject>();
+        pending.Enqueue(this);
+        while (pending.Count > 0)
+        {
+            var current = pending.Dequeue();
+
+            if (current is Button { Style: { } buttonStyle } && ReferenceEquals(buttonStyle, tabStyle))
+            {
+                continue;
+            }
+
+            if (current is Border border && ReferenceEquals(border.Style, sectionStyle))
+            {
+                border.Background = chrome.CardBackground;
+                border.BorderBrush = chrome.CardBorder;
+            }
+            else if (current is ComboBox comboBox)
+            {
+                comboBox.Background = chrome.CardBackground;
+                comboBox.Foreground = chrome.PrimaryForeground;
+                comboBox.BorderBrush = chrome.InputBorder;
+            }
+            else if (current is TextBox textBox)
+            {
+                textBox.Background = chrome.InputBackground;
+                textBox.Foreground = chrome.PrimaryForeground;
+                textBox.BorderBrush = chrome.InputBorder;
+                textBox.PlaceholderForeground = placeholderForeground;
+            }
+            else if (current is PasswordBox passwordBox)
+            {
+                passwordBox.Background = chrome.InputBackground;
+                passwordBox.Foreground = chrome.PrimaryForeground;
+                passwordBox.BorderBrush = chrome.InputBorder;
+            }
+            else if (current is TextBlock textBlock)
+            {
+                textBlock.Foreground = GetSettingsTextForeground(
+                    textBlock,
+                    chrome.PrimaryForeground,
+                    chrome.SecondaryForeground);
+            }
+            else if (current is FontIcon fontIcon)
+            {
+                fontIcon.Foreground = chrome.SecondaryForeground;
+            }
+            else if (current is HyperlinkButton hyperlinkButton)
+            {
+                hyperlinkButton.Foreground = chrome.HyperlinkForeground;
+                SetResourceIfNotNull(hyperlinkButton.Resources, "TextFillColorPrimaryBrush", chrome.HyperlinkForeground);
+                SetResourceIfNotNull(hyperlinkButton.Resources, "TextFillColorSecondaryBrush", chrome.HyperlinkForeground);
+                continue;
+            }
+            else if (current is Button button && !ReferenceEquals(button.Style, tabStyle))
+            {
+                if (ReferenceEquals(button.Style, accentButtonStyle) ||
+                    ReferenceEquals(button, BackButton) ||
+                    ReferenceEquals(button, SaveButton))
+                {
+                    ApplyButtonChrome(
+                        button,
+                        chrome.AccentBackground,
+                        chrome.AccentHoverBackground,
+                        chrome.AccentPressedBackground,
+                        chrome.AccentForeground,
+                        chrome.InputBorder);
+                }
+                else if (ReferenceEquals(button.Style, inlineIconButtonStyle))
+                {
+                    if (chrome.ButtonForeground is not null)
+                    {
+                        button.Foreground = chrome.ButtonForeground;
+                    }
+
+                    SetResourceIfNotNull(button.Resources, "ButtonForeground", chrome.ButtonForeground);
+                    SetResourceIfNotNull(button.Resources, "ButtonForegroundPointerOver", chrome.ButtonForeground);
+                    SetResourceIfNotNull(button.Resources, "ButtonForegroundPressed", chrome.ButtonForeground);
+                }
+                else
+                {
+                    ApplyButtonChrome(
+                        button,
+                        chrome.CardBackground,
+                        chrome.InputBackground,
+                        chrome.InputBackground,
+                        chrome.ButtonForeground,
+                        chrome.InputBorder);
+                }
+
+                continue;
+            }
+            else if (current is ToggleSwitch toggleSwitch)
+            {
+                toggleSwitch.Foreground = chrome.PrimaryForeground;
+                SetResourceIfNotNull(toggleSwitch.Resources, "ToggleSwitchContentForeground", chrome.PrimaryForeground);
+                SetResourceIfNotNull(toggleSwitch.Resources, "ToggleSwitchContentForegroundPointerOver", chrome.PrimaryForeground);
+                SetResourceIfNotNull(toggleSwitch.Resources, "ToggleSwitchContentForegroundPressed", chrome.PrimaryForeground);
+            }
+            else if (current is CheckBox checkBox)
+            {
+                checkBox.Foreground = chrome.PrimaryForeground;
+            }
+            else if (current is RadioButton radioButton)
+            {
+                radioButton.Foreground = chrome.PrimaryForeground;
+            }
+            else if (current is ComboBoxItem comboBoxItem)
+            {
+                comboBoxItem.Background = chrome.CardBackground;
+                comboBoxItem.Foreground = chrome.PrimaryForeground;
+            }
+
+            EnqueueVisualChildren(current, pending);
+        }
+    }
+
+    private void RefreshScopedThemeResources()
+    {
+        var brushCache = new Dictionary<string, Brush?>(StringComparer.Ordinal);
+        foreach (var (brushKey, colorKey) in ScopedThemeResourceBrushes)
+        {
+            SetResourceBrush(brushCache, brushKey, colorKey);
+        }
+    }
+
+    private SettingsTabBrushes CreateSettingsTabBrushes()
+    {
+        return new SettingsTabBrushes(
+            Background: CreateThemeBrush("SettingsTabBackgroundColor"),
+            BorderBrush: CreateThemeBrush("SettingsTabBorderColor"),
+            Foreground: CreateThemeBrush("SettingsTabForegroundColor"),
+            SelectedBackground: CreateThemeBrush("SettingsTabSelectedBackgroundColor"),
+            SelectedBorderBrush: CreateThemeBrush("SettingsTabSelectedBorderColor"),
+            SelectedForeground: CreateThemeBrush("SettingsTabSelectedForegroundColor"));
+    }
+
+    private SettingsThemeChrome CreateSettingsThemeChrome()
+    {
+        var primaryForeground = CreateThemeBrush("QueryTextColor");
+        var inputBackground = CreateThemeBrush("FloatingInputBackgroundColor");
+        var inputBorder = CreateThemeBrush("FloatingInputBorderColor");
+        var accentBackground = CreateThemeBrush("AccentColor");
+
+        return new SettingsThemeChrome(
+            PageBackground: CreateThemeBrush("FloatingWindowBackgroundColor"),
+            CardBackground: CreateThemeBrush("EasydictCardBackgroundColor"),
+            CardBorder: CreateThemeBrush("EasydictCardBorderColor"),
+            InputBackground: inputBackground,
+            InputBorder: inputBorder,
+            PrimaryForeground: primaryForeground,
+            SecondaryForeground: CreateThemeBrush("ServiceResultHeaderSecondaryForegroundColor")
+                ?? primaryForeground,
+            ButtonForeground: CreateThemeBrush("FloatingIconForegroundColor")
+                ?? primaryForeground,
+            AccentBackground: accentBackground,
+            AccentForeground: CreateThemeBrush("AccentForegroundColor"),
+            AccentHoverBackground: CreateThemeBrush("AccentPointerOverColor") ?? accentBackground,
+            AccentPressedBackground: CreateThemeBrush("AccentPressedColor") ?? accentBackground,
+            HyperlinkForeground: CreateThemeBrush("BlueAccentColor"));
+    }
+
+    private static Brush? GetSettingsTextForeground(
+        TextBlock textBlock,
+        Brush? primaryForeground,
+        Brush? secondaryForeground)
+    {
+        if (IsStatusOrSuccessText(textBlock))
+        {
+            return textBlock.Foreground;
+        }
+
+        if (!HasLocalValue(textBlock, TextBlock.ForegroundProperty) || IsPrimarySettingsText(textBlock))
+        {
+            return primaryForeground;
+        }
+
+        return secondaryForeground ?? primaryForeground;
+    }
+
+    private static bool IsPrimarySettingsText(TextBlock textBlock)
+    {
+        return textBlock.FontWeight.Weight >= 600 || textBlock.FontSize >= 18;
+    }
+
+    private static bool IsStatusOrSuccessText(TextBlock textBlock)
+    {
+        return string.Equals(textBlock.Text, "✓", StringComparison.Ordinal);
+    }
+
+    private sealed record SettingsThemeChrome(
+        Brush? PageBackground,
+        Brush? CardBackground,
+        Brush? CardBorder,
+        Brush? InputBackground,
+        Brush? InputBorder,
+        Brush? PrimaryForeground,
+        Brush? SecondaryForeground,
+        Brush? ButtonForeground,
+        Brush? AccentBackground,
+        Brush? AccentForeground,
+        Brush? AccentHoverBackground,
+        Brush? AccentPressedBackground,
+        Brush? HyperlinkForeground);
+
+    private void SetResourceBrush(
+        Dictionary<string, Brush?> brushCache,
+        string brushKey,
+        string colorKey)
+    {
+        if (!brushCache.TryGetValue(colorKey, out var brush))
+        {
+            brush = CreateThemeBrush(colorKey);
+            brushCache[colorKey] = brush;
+        }
+
+        SetResourceIfNotNull(Resources, brushKey, brush);
+    }
+
+    private Brush? CreateThemeBrush(string colorKey)
+    {
+        return ThemeResourceService.GetColor(colorKey, this) is { } color
+            ? new SolidColorBrush(color)
+            : null;
+    }
+
+    private static void ApplyButtonChrome(
+        Button button,
+        Brush? background,
+        Brush? hoverBackground,
+        Brush? pressedBackground,
+        Brush? foreground,
+        Brush? border)
+    {
+        if (background is not null)
+        {
+            button.Background = background;
+        }
+
+        if (foreground is not null)
+        {
+            button.Foreground = foreground;
+        }
+
+        if (border is not null)
+        {
+            button.BorderBrush = border;
+        }
+
+        SetResourceIfNotNull(button.Resources, "ButtonBackground", background);
+        SetResourceIfNotNull(button.Resources, "ButtonBackgroundPointerOver", hoverBackground ?? background);
+        SetResourceIfNotNull(button.Resources, "ButtonBackgroundPressed", pressedBackground ?? hoverBackground ?? background);
+        SetResourceIfNotNull(button.Resources, "ButtonForeground", foreground);
+        SetResourceIfNotNull(button.Resources, "ButtonForegroundPointerOver", foreground);
+        SetResourceIfNotNull(button.Resources, "ButtonForegroundPressed", foreground);
+        SetResourceIfNotNull(button.Resources, "ButtonBorderBrush", border);
+        SetResourceIfNotNull(button.Resources, "ButtonBorderBrushPointerOver", border);
+        SetResourceIfNotNull(button.Resources, "ButtonBorderBrushPressed", border);
+        SetResourceIfNotNull(button.Resources, "AccentTextFillColorPrimaryBrush", foreground);
+    }
+
+    private static void SetResourceIfNotNull(ResourceDictionary resources, string key, object? value)
+    {
+        if (value is not null)
+        {
+            resources[key] = value;
+        }
+    }
+
+    private static bool HasLocalValue(DependencyObject obj, DependencyProperty property)
+    {
+        return !ReferenceEquals(obj.ReadLocalValue(property), DependencyProperty.UnsetValue);
+    }
+
+    private static void EnqueueVisualChildren(
+        DependencyObject parent,
+        Queue<DependencyObject> pending)
+    {
+        int count;
+        try
+        {
+            count = VisualTreeHelper.GetChildrenCount(parent);
+        }
+        catch (COMException)
+        {
+            return;
+        }
+        catch (ArgumentException)
+        {
+            return;
+        }
+
+        for (var i = 0; i < count; i++)
+        {
+            pending.Enqueue(VisualTreeHelper.GetChild(parent, i));
         }
     }
 
     private void OnActualThemeChanged(FrameworkElement sender, object args)
     {
         UpdateServiceConfigurationHeaderIconSources();
-        DispatcherQueue.TryEnqueue(ApplyThemeChrome);
+        QueueApplyThemeChrome();
+    }
+
+    private void QueueApplyThemeChrome()
+    {
+        if (_themeChromeRefreshQueued || _isUnloaded || _isTornDown)
+        {
+            return;
+        }
+
+        _themeChromeRefreshQueued = true;
+        if (!DispatcherQueue.TryEnqueue(() =>
+        {
+            _themeChromeRefreshQueued = false;
+            if (!_isUnloaded && !_isTornDown)
+            {
+                ApplyThemeChrome();
+            }
+        }))
+        {
+            _themeChromeRefreshQueued = false;
+        }
     }
 
     private static bool IsDeferredIoDisabledForDebug()
@@ -515,6 +932,8 @@ public sealed partial class SettingsPage : Page
         {
             MainScrollViewer.ChangeView(null, 0, null, disableAnimation: true);
         }
+
+        ApplyThemeChrome();
     }
 
     private void EnsureTabContentLoaded(SettingsTabId tabId)
@@ -733,41 +1152,40 @@ public sealed partial class SettingsPage : Page
             OpenVinoDescriptionText.Text = loc.GetString(OpenVinoResources.UiKeys.ConfigDescription);
 
         // Service configuration controls (API Keys, Endpoints, Models, etc.)
-        // TextBox/PasswordBox headers for each service
         DeepLFreeCheck.Content = loc.GetString("DeepLFreeOption");
         DeepLQualityCheck.Content = loc.GetString("DeepLQualityOption");
         DeepLDescriptionText.Text = loc.GetString("DeepLDescription");
         UpdateDeepLApiKeyRequirementUi();
-        OpenAIKeyBox.Header = loc.GetString("ApiKey");
+        OpenAIKeyHeaderText.Text = loc.GetString("ApiKey");
         OpenAIEndpointBox.Header = loc.GetString("EndpointOptional");
         OpenAIModelCombo.Header = loc.GetString("Model");
-        DeepSeekKeyBox.Header = loc.GetString("ApiKey");
+        DeepSeekKeyHeaderText.Text = loc.GetString("ApiKey");
         DeepSeekModelCombo.Header = loc.GetString("Model");
-        GroqKeyBox.Header = loc.GetString("ApiKey");
+        GroqKeyHeaderText.Text = loc.GetString("ApiKey");
         GroqModelCombo.Header = loc.GetString("Model");
-        ZhipuKeyBox.Header = loc.GetString("ApiKey");
+        ZhipuKeyHeaderText.Text = loc.GetString("ApiKey");
         ZhipuModelCombo.Header = loc.GetString("Model");
-        GitHubModelsTokenBox.Header = loc.GetString("ApiKey");
+        GitHubModelsTokenHeaderText.Text = loc.GetString("GitHubToken");
         GitHubModelsModelCombo.Header = loc.GetString("Model");
-        GeminiKeyBox.Header = loc.GetString("ApiKey");
+        GeminiKeyHeaderText.Text = loc.GetString("ApiKey");
         GeminiModelCombo.Header = loc.GetString("Model");
-        CustomOpenAIKeyBox.Header = loc.GetString("ApiKeyOptional");
+        CustomOpenAIKeyHeaderText.Text = loc.GetString("ApiKeyOptional");
         CustomOpenAIEndpointBox.Header = loc.GetString("EndpointRequired");
         CustomOpenAIModelBox.Header = loc.GetString("Model");
         OllamaEndpointBox.Header = loc.GetString("EndpointOptional");
         OllamaModelCombo.Header = loc.GetString("Model");
         BuiltInModelCombo.Header = loc.GetString("Model");
-        BuiltInApiKeyBox.Header = loc.GetString("ApiKeyOptional");
+        BuiltInApiKeyHeaderText.Text = loc.GetString("ApiKeyOptional");
         BuiltInAIHintBar.Title = loc.GetString("Hint");
         BuiltInAIHintBar.Message = loc.GetString("BuiltInAIHint");
         BuiltInDescriptionText.Text = loc.GetString("BuiltInAIDescription");
-        DoubaoKeyBox.Header = loc.GetString("ApiKey");
+        DoubaoKeyHeaderText.Text = loc.GetString("ApiKey");
         DoubaoEndpointBox.Header = loc.GetString("EndpointOptional");
         DoubaoModelBox.Header = loc.GetString("Model");
-        CaiyunKeyBox.Header = loc.GetString("ApiKey");
-        NiuTransKeyBox.Header = loc.GetString("ApiKey");
-        YoudaoAppKeyBox.Header = loc.GetString("AppKey");
-        YoudaoAppSecretBox.Header = loc.GetString("AppSecret");
+        CaiyunKeyHeaderText.Text = loc.GetString("ApiKey");
+        NiuTransKeyHeaderText.Text = loc.GetString("ApiKey");
+        YoudaoAppKeyHeaderText.Text = loc.GetString("AppKey");
+        YoudaoAppSecretHeaderText.Text = loc.GetString("AppSecret");
         YoudaoUseOfficialApiToggle.Header = loc.GetString("UseOfficialApi");
         YoudaoUseOfficialApiToggle.OnContent = loc.GetString("OfficialApi");
         YoudaoUseOfficialApiToggle.OffContent = loc.GetString("WebFree");
@@ -926,6 +1344,7 @@ public sealed partial class SettingsPage : Page
         ApplyUILanguageLocalization(loc);
         ApplyOcrLocalization(loc);
         ApplyLayoutDetectionLocalization(loc);
+        ApplyPasswordRevealLocalization(loc);
     }
 
     private static void SetLocalAiRating(TextBlock? ratingText, string rating, string tooltip)
@@ -975,12 +1394,83 @@ public sealed partial class SettingsPage : Page
         OcrEngineCombo.Header = loc.GetString("OcrEngine");
         OcrEngineNativeItem.Content = loc.GetString("OcrEngineNative");
         OcrEngineCustomApiItem.Content = loc.GetString("OcrEngineCustomApi");
-        OcrApiKeyBox.Header = loc.GetString("OcrApiKey");
+        OcrApiKeyHeaderText.Text = loc.GetString("OcrApiKey");
         OcrEndpointBox.Header = loc.GetString("OcrEndpoint");
         OcrModelBox.Header = loc.GetString("OcrModel");
         OcrSystemPromptBox.Header = loc.GetString("OcrSystemPrompt");
         TestOcrConnectionButton.Content = loc.GetString("TestOcrConnection");
         OcrTestStatusBox.Header = loc.GetString("OcrTestResult");
+    }
+
+    private void ApplyPasswordRevealLocalization(LocalizationService loc)
+    {
+        foreach (var button in GetPasswordRevealButtons())
+        {
+            UpdatePasswordRevealButtonState(button, loc);
+        }
+    }
+
+    private IEnumerable<Button> GetPasswordRevealButtons()
+    {
+        yield return DeepLKeyRevealButton;
+        yield return OpenAIKeyRevealButton;
+        yield return DeepSeekKeyRevealButton;
+        yield return GroqKeyRevealButton;
+        yield return ZhipuKeyRevealButton;
+        yield return GitHubModelsTokenRevealButton;
+        yield return GeminiKeyRevealButton;
+        yield return CustomOpenAIKeyRevealButton;
+        yield return BuiltInApiKeyRevealButton;
+        yield return DoubaoKeyRevealButton;
+        yield return CaiyunKeyRevealButton;
+        yield return NiuTransKeyRevealButton;
+        yield return YoudaoAppKeyRevealButton;
+        yield return YoudaoAppSecretRevealButton;
+        yield return OcrApiKeyRevealButton;
+    }
+
+    private void UpdatePasswordRevealButtonState(Button button, LocalizationService loc)
+    {
+        if (button.Tag is not PasswordBox passwordBox)
+        {
+            return;
+        }
+
+        var isVisible = _visiblePasswordBoxes.TryGetValue(passwordBox, out var visible) && visible;
+        if (button.Content is FontIcon icon)
+        {
+            icon.Glyph = isVisible ? "\uE8F5" : "\uE890";
+        }
+
+        var secretName = loc.GetString(GetPasswordRevealSecretResourceKey(passwordBox));
+        var label = loc.GetString(isVisible ? "HideSecretFormat" : "ShowSecretFormat", secretName);
+        AutomationProperties.SetName(button, label);
+        ToolTipService.SetToolTip(button, label);
+    }
+
+    private string GetPasswordRevealSecretResourceKey(PasswordBox passwordBox)
+    {
+        if (ReferenceEquals(passwordBox, GitHubModelsTokenBox))
+        {
+            return "GitHubToken";
+        }
+
+        if (ReferenceEquals(passwordBox, YoudaoAppKeyBox))
+        {
+            return "AppKey";
+        }
+
+        if (ReferenceEquals(passwordBox, YoudaoAppSecretBox))
+        {
+            return "AppSecret";
+        }
+
+        if (ReferenceEquals(passwordBox, OcrApiKeyBox))
+        {
+            return "OcrApiKey";
+        }
+
+        return "ApiKey";
     }
 
     private void ApplyLayoutDetectionLocalization(LocalizationService loc)
@@ -1177,8 +1667,8 @@ public sealed partial class SettingsPage : Page
                 }
 
 #if DEBUG
-                UpdateDeferredIoState("onnx-running");
-                PerfLog("Deferred I/O: begin UpdateOnnxModelStatus");
+                UpdateDeferredIoState("io-dispatched");
+                PerfLog("Deferred I/O: dispatching queued work");
 #endif
                 RunDeferredSettingsIo(cancellationToken);
             });
@@ -1367,7 +1857,7 @@ public sealed partial class SettingsPage : Page
         OcrTranslateHotkeyEnabledToggle.Toggled += OnSettingChanged;
         SilentOcrHotkeyEnabledToggle.Toggled += OnSettingChanged;
         OcrEngineCombo.SelectionChanged += OnOcrEngineChanged;
-        OcrApiKeyBox.TextChanged += OnSettingChanged;
+        OcrApiKeyBox.PasswordChanged += OnSettingChanged;
         OcrEndpointBox.TextChanged += OnSettingChanged;
         OcrModelBox.TextChanged += OnSettingChanged;
         OcrSystemPromptBox.TextChanged += OnSettingChanged;
@@ -1463,7 +1953,7 @@ public sealed partial class SettingsPage : Page
         OcrTranslateHotkeyEnabledToggle.Toggled -= OnSettingChanged;
         SilentOcrHotkeyEnabledToggle.Toggled -= OnSettingChanged;
         OcrEngineCombo.SelectionChanged -= OnOcrEngineChanged;
-        OcrApiKeyBox.TextChanged -= OnSettingChanged;
+        OcrApiKeyBox.PasswordChanged -= OnSettingChanged;
         OcrEndpointBox.TextChanged -= OnSettingChanged;
         OcrModelBox.TextChanged -= OnSettingChanged;
         OcrSystemPromptBox.TextChanged -= OnSettingChanged;
@@ -1718,7 +2208,7 @@ public sealed partial class SettingsPage : Page
 
     private void UpdateDeepLApiKeyRequirementUi()
     {
-        DeepLKeyBox.Header = LocalizationService.Instance.GetString(
+        DeepLKeyHeaderText.Text = LocalizationService.Instance.GetString(
             DeepLQualityCheck.IsChecked == true ? "ApiKey" : "ApiKeyOptional");
     }
 
@@ -1883,7 +2373,7 @@ public sealed partial class SettingsPage : Page
         {
             // OCR Engine settings
             SelectComboByTag(OcrEngineCombo, _settings.OcrEngine.ToString());
-            OcrApiKeyBox.Text = _settings.OcrApiKey ?? string.Empty;
+            OcrApiKeyBox.Password = _settings.OcrApiKey ?? string.Empty;
             OcrEndpointBox.Text = _settings.OcrEndpoint;
             OcrModelBox.Text = _settings.OcrModel;
             OcrSystemPromptBox.Text = _settings.OcrSystemPrompt;
@@ -2685,7 +3175,7 @@ public sealed partial class SettingsPage : Page
 
         return new OcrServiceOptions(
             engine,
-            OcrApiKeyBox.Text,
+            OcrApiKeyBox.Password,
             OcrEndpointBox.Text,
             OcrModelBox.Text,
             OcrSystemPromptBox.Text);
@@ -3209,6 +3699,20 @@ public sealed partial class SettingsPage : Page
         AdvancedOcrPanel.Visibility = isAdvanced ? Visibility.Visible : Visibility.Collapsed;
         OcrEndpointBox.PlaceholderText = OcrServiceOptions.GetDefaultEndpoint(engine);
         OcrModelBox.PlaceholderText = OcrServiceOptions.GetDefaultModel(engine);
+    }
+
+    private void OnPasswordRevealButtonClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not PasswordBox passwordBox)
+        {
+            return;
+        }
+
+        var isVisible = !_visiblePasswordBoxes.TryGetValue(passwordBox, out var wasVisible) || !wasVisible;
+        _visiblePasswordBoxes[passwordBox] = isVisible;
+        passwordBox.PasswordRevealMode = isVisible ? PasswordRevealMode.Visible : PasswordRevealMode.Hidden;
+
+        UpdatePasswordRevealButtonState(button, LocalizationService.Instance);
     }
 
     private OcrEngineType GetSelectedOcrEngine()

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -146,6 +146,10 @@ public sealed partial class SettingsPage : Page
     private static readonly Regex NonServiceIdCharRegex = new("[^a-z0-9-]", RegexOptions.Compiled);
     private const string ServiceConfigurationIconTag = "ServiceConfigurationIcon";
     private const string ReorderButtonEmoji = "\u2195\uFE0F";
+    private const int PasswordTailVisibleLength = 3;
+    private const double PasswordTailHintMaxWidth = 72;
+    private const double PasswordTailHintTrailingMargin = 44;
+    private const string PasswordTailHintPrefix = "...";
     private static readonly (string BrushKey, string ColorKey)[] ScopedThemeResourceBrushes =
     [
         ("ApplicationPageBackgroundThemeBrush", "FloatingWindowBackgroundColor"),
@@ -223,6 +227,7 @@ public sealed partial class SettingsPage : Page
     private bool _isFixedWindowReorderModeEnabled;
     private bool _themeChromeRefreshQueued;
     private readonly Dictionary<PasswordBox, bool> _visiblePasswordBoxes = new();
+    private readonly Dictionary<PasswordBox, PasswordTailHint> _passwordTailHints = new();
     private ContentDialog? _currentDialog; // Track open dialog to prevent COMException
     private readonly CancellationTokenSource _lifetimeCts = new();
 
@@ -252,6 +257,8 @@ public sealed partial class SettingsPage : Page
         new() { Id = SettingsTabId.About, IconGlyph = "\uE946" }
     ];
     private readonly HashSet<SettingsTabId> _initializedSettingsTabData = [];
+
+    private sealed record PasswordTailHint(Border Container, TextBlock Text);
 
 
 #if DEBUG
@@ -381,6 +388,7 @@ public sealed partial class SettingsPage : Page
         this.InitializeComponent();
         ApplyThemeChrome();
         InitializeServiceConfigurationHeaderIcons();
+        InitializePasswordTailHints();
 #if DEBUG
         PerfLog("ctor: end InitializeComponent");
         MemoryDiagnostics.LogSnapshot("SettingsPage.ctor after InitializeComponent");
@@ -526,6 +534,7 @@ public sealed partial class SettingsPage : Page
         }
 
         RefreshSettingsControlChrome(chrome);
+        UpdateAllPasswordTailHints();
     }
 
     private void RefreshSettingsControlChrome(SettingsThemeChrome chrome)
@@ -1429,6 +1438,48 @@ public sealed partial class SettingsPage : Page
         yield return OcrApiKeyRevealButton;
     }
 
+    private void InitializePasswordTailHints()
+    {
+        foreach (var button in GetPasswordRevealButtons())
+        {
+            if (button.Tag is not PasswordBox passwordBox
+                || _passwordTailHints.ContainsKey(passwordBox)
+                || passwordBox.Parent is not Grid grid)
+            {
+                continue;
+            }
+
+            var hintText = new TextBlock
+            {
+                FontSize = 12,
+                MaxWidth = PasswordTailHintMaxWidth,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            AutomationProperties.SetAccessibilityView(hintText, AccessibilityView.Raw);
+
+            var hintContainer = new Border
+            {
+                Child = hintText,
+                CornerRadius = new CornerRadius(2),
+                HorizontalAlignment = HorizontalAlignment.Right,
+                IsHitTestVisible = false,
+                Margin = new Thickness(0, 0, PasswordTailHintTrailingMargin, 0),
+                Padding = new Thickness(4, 0, 4, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+                Visibility = Visibility.Collapsed
+            };
+            AutomationProperties.SetAccessibilityView(hintContainer, AccessibilityView.Raw);
+
+            Canvas.SetZIndex(hintContainer, 1);
+            Canvas.SetZIndex(button, 2);
+            grid.Children.Add(hintContainer);
+            _passwordTailHints[passwordBox] = new PasswordTailHint(hintContainer, hintText);
+            passwordBox.PasswordChanged += OnPasswordTailHintPasswordChanged;
+            UpdatePasswordTailHint(passwordBox);
+        }
+    }
+
     private void UpdatePasswordRevealButtonState(Button button, LocalizationService loc)
     {
         if (button.Tag is not PasswordBox passwordBox)
@@ -1446,6 +1497,60 @@ public sealed partial class SettingsPage : Page
         var label = loc.GetString(isVisible ? "HideSecretFormat" : "ShowSecretFormat", secretName);
         AutomationProperties.SetName(button, label);
         ToolTipService.SetToolTip(button, label);
+        UpdatePasswordTailHint(passwordBox);
+    }
+
+    private void OnPasswordTailHintPasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is PasswordBox passwordBox)
+        {
+            UpdatePasswordTailHint(passwordBox);
+        }
+    }
+
+    private void UpdateAllPasswordTailHints()
+    {
+        foreach (var passwordBox in _passwordTailHints.Keys)
+        {
+            UpdatePasswordTailHint(passwordBox);
+        }
+    }
+
+    private void UpdatePasswordTailHint(PasswordBox passwordBox)
+    {
+        if (!_passwordTailHints.TryGetValue(passwordBox, out var hint))
+        {
+            return;
+        }
+
+        var password = passwordBox.Password ?? string.Empty;
+        var isFullyVisible = _visiblePasswordBoxes.TryGetValue(passwordBox, out var visible) && visible;
+        if (isFullyVisible || password.Length == 0)
+        {
+            hint.Container.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var tailLength = Math.Min(PasswordTailVisibleLength, password.Length);
+        hint.Text.Text = PasswordTailHintPrefix + password.Substring(password.Length - tailLength);
+        hint.Text.Foreground = CreateThemeBrush("ServiceResultHeaderSecondaryForegroundColor")
+            ?? CreateThemeBrush("QueryTextColor");
+        hint.Container.Background = CreateThemeBrush("FloatingInputBackgroundColor");
+        hint.Container.Visibility = Visibility.Visible;
+    }
+
+    private void UnregisterPasswordTailHints()
+    {
+        foreach (var (passwordBox, hint) in _passwordTailHints.ToList())
+        {
+            passwordBox.PasswordChanged -= OnPasswordTailHintPasswordChanged;
+            if (hint.Container.Parent is Grid grid)
+            {
+                grid.Children.Remove(hint.Container);
+            }
+        }
+
+        _passwordTailHints.Clear();
     }
 
     private string GetPasswordRevealSecretResourceKey(PasswordBox passwordBox)
@@ -1513,6 +1618,8 @@ public sealed partial class SettingsPage : Page
 
     private void OnPageLoaded(object sender, RoutedEventArgs e)
     {
+        InitializePasswordTailHints();
+
         if (_isUnloaded || _isInitialized)
         {
             return;
@@ -1756,6 +1863,7 @@ public sealed partial class SettingsPage : Page
         this.Unloaded -= OnPageUnloaded;
         this.ActualThemeChanged -= OnActualThemeChanged;
 
+        UnregisterPasswordTailHints();
         UnregisterChangeHandlers();
         UnregisterLanguageCheckboxHandlers();
         TeardownPhiSilicaPanel();

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/AppLauncher.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/AppLauncher.cs
@@ -37,7 +37,17 @@ public sealed class AppLauncher : IDisposable
             throw new FileNotFoundException($"App executable not found: {exePath}");
 
         var resolvedTimeout = ResolveLaunchTimeout(timeout ?? TimeSpan.FromSeconds(30));
-        LaunchWithRetry(() => Application.Launch(exePath), resolvedTimeout);
+        LaunchWithRetry(() =>
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = exePath,
+                UseShellExecute = false,
+                WorkingDirectory = Path.GetDirectoryName(exePath) ?? Environment.CurrentDirectory
+            };
+            UiaSettingsIsolation.ApplyTo(startInfo);
+            return Application.Launch(startInfo);
+        }, resolvedTimeout);
     }
 
     /// <summary>

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/ScrollHelper.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/ScrollHelper.cs
@@ -1,5 +1,7 @@
 using System.Drawing;
+using System.Runtime.InteropServices;
 using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Exceptions;
 using FlaUI.Core.Input;
 
 namespace Easydict.UIAutomation.Tests.Infrastructure;
@@ -25,6 +27,11 @@ public static class ScrollHelper
     /// </summary>
     private const int ScanSettleMs = 500;
 
+    private const int MouseFallbackScrollStep = 5;
+    private const int MouseFallbackSettleMs = 40;
+    private const int MouseFallbackMaxWheelTicks = 30;
+    private const double MouseFallbackPercentTolerance = 4;
+
     /// <summary>
     /// Scroll a ScrollViewer to the specified vertical percentage.
     /// </summary>
@@ -48,15 +55,13 @@ public static class ScrollHelper
             catch (InvalidOperationException ex)
             {
                 log?.Invoke($"ScrollPattern failed ({ex.Message}), falling back to Mouse.Scroll");
-                MoveMouseToScrollTarget(scrollViewer, log);
-                Mouse.Scroll(GetMouseScrollDeltaForTargetPercent(verticalPercent));
+                ScrollByMouseToPercent(scrollViewer, verticalPercent, log);
             }
         }
         else
         {
             log?.Invoke("ScrollPattern not available, falling back to Mouse.Scroll");
-            MoveMouseToScrollTarget(scrollViewer, log);
-            Mouse.Scroll(GetMouseScrollDeltaForTargetPercent(verticalPercent));
+            ScrollByMouseToPercent(scrollViewer, verticalPercent, log);
         }
 
         Thread.Sleep(ScrollSettleMs);
@@ -173,6 +178,87 @@ public static class ScrollHelper
 
     private static int GetMouseScrollDeltaForTargetPercent(double verticalPercent)
     {
-        return verticalPercent <= 0 ? 15 : -15;
+        return verticalPercent <= 0 ? MouseFallbackScrollStep : -MouseFallbackScrollStep;
+    }
+
+    private static int GetMouseScrollTickCountForTargetPercent(double verticalPercent)
+    {
+        if (verticalPercent <= 0)
+        {
+            return MouseFallbackMaxWheelTicks;
+        }
+
+        return Math.Clamp(
+            (int)Math.Ceiling(verticalPercent / ScanStepPercent),
+            1,
+            MouseFallbackMaxWheelTicks);
+    }
+
+    private static void ScrollByMouseToPercent(
+        AutomationElement scrollViewer,
+        double verticalPercent,
+        Action<string>? log)
+    {
+        var targetPercent = Math.Clamp(verticalPercent, 0, 100);
+        MoveMouseToScrollTarget(scrollViewer, log);
+
+        var fallbackDelta = GetMouseScrollDeltaForTargetPercent(targetPercent);
+        var wheelTicks = GetMouseScrollTickCountForTargetPercent(targetPercent);
+
+        for (var i = 0; i < wheelTicks; i++)
+        {
+            if (TryGetVerticalScrollPercent(scrollViewer, out var currentPercent))
+            {
+                var remaining = targetPercent - currentPercent;
+                if (Math.Abs(remaining) <= MouseFallbackPercentTolerance)
+                {
+                    log?.Invoke($"Mouse.Scroll fallback reached {currentPercent:F1}%");
+                    return;
+                }
+
+                fallbackDelta = remaining > 0
+                    ? -MouseFallbackScrollStep
+                    : MouseFallbackScrollStep;
+            }
+
+            Mouse.Scroll(fallbackDelta);
+            Thread.Sleep(MouseFallbackSettleMs);
+        }
+
+        if (TryGetVerticalScrollPercent(scrollViewer, out var finalPercent))
+        {
+            log?.Invoke($"Mouse.Scroll fallback stopped at {finalPercent:F1}% after {wheelTicks} wheel tick(s)");
+        }
+        else
+        {
+            log?.Invoke($"Mouse.Scroll fallback used {wheelTicks} wheel tick(s) toward {targetPercent}%");
+        }
+    }
+
+    private static bool TryGetVerticalScrollPercent(
+        AutomationElement scrollViewer,
+        out double verticalPercent)
+    {
+        verticalPercent = 0;
+        if (!scrollViewer.Patterns.Scroll.IsSupported)
+        {
+            return false;
+        }
+
+        try
+        {
+            var current = scrollViewer.Patterns.Scroll.Pattern.VerticalScrollPercent.Value;
+            if (double.IsNaN(current) || current < 0)
+            {
+                return false;
+            }
+
+            verticalPercent = current;
+            return true;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or COMException or PropertyNotSupportedException)
+        {
+            return false;
+        }
     }
 }

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/ScrollHelper.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/ScrollHelper.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Input;
 
@@ -37,16 +38,25 @@ public static class ScrollHelper
     {
         if (scrollViewer.Patterns.Scroll.IsSupported)
         {
-            var scrollPattern = scrollViewer.Patterns.Scroll.Pattern;
-            // -1 means "do not change" for horizontal scroll
-            scrollPattern.SetScrollPercent(-1, verticalPercent);
-            log?.Invoke($"ScrollPattern: scrolled to {verticalPercent}%");
+            try
+            {
+                var scrollPattern = scrollViewer.Patterns.Scroll.Pattern;
+                // -1 means "do not change" for horizontal scroll
+                scrollPattern.SetScrollPercent(-1, verticalPercent);
+                log?.Invoke($"ScrollPattern: scrolled to {verticalPercent}%");
+            }
+            catch (InvalidOperationException ex)
+            {
+                log?.Invoke($"ScrollPattern failed ({ex.Message}), falling back to Mouse.Scroll");
+                MoveMouseToScrollTarget(scrollViewer, log);
+                Mouse.Scroll(GetMouseScrollDeltaForTargetPercent(verticalPercent));
+            }
         }
         else
         {
             log?.Invoke("ScrollPattern not available, falling back to Mouse.Scroll");
-            Mouse.MoveTo(scrollViewer.GetClickablePoint());
-            Mouse.Scroll(-15);
+            MoveMouseToScrollTarget(scrollViewer, log);
+            Mouse.Scroll(GetMouseScrollDeltaForTargetPercent(verticalPercent));
         }
 
         Thread.Sleep(ScrollSettleMs);
@@ -70,56 +80,99 @@ public static class ScrollHelper
         Func<AutomationElement?> finder,
         Action<string>? log = null)
     {
+        var currentResult = finder();
+        if (IsVisible(currentResult))
+        {
+            return currentResult;
+        }
+
         if (scrollViewer.Patterns.Scroll.IsSupported)
         {
-            var scrollPattern = scrollViewer.Patterns.Scroll.Pattern;
-
-            // Jump to the expected location first
-            scrollPattern.SetScrollPercent(-1, startPercent);
-            log?.Invoke($"ScrollPattern: jumped to {startPercent}%");
-            Thread.Sleep(ScrollSettleMs);
-
-            var result = finder();
-            if (result != null) return result;
-
-            // Scan forward from startPercent to 100% in small steps
-            for (var percent = startPercent + ScanStepPercent; percent <= 100; percent += ScanStepPercent)
+            try
             {
-                scrollPattern.SetScrollPercent(-1, percent);
-                log?.Invoke($"ScrollPattern: scanning at {percent}%");
-                Thread.Sleep(ScanSettleMs);
+                var scrollPattern = scrollViewer.Patterns.Scroll.Pattern;
 
-                result = finder();
-                if (result != null) return result;
-            }
-
-            // If not found scanning forward, scan backward from startPercent to 0%
-            for (var percent = startPercent - ScanStepPercent; percent >= 0; percent -= ScanStepPercent)
-            {
-                scrollPattern.SetScrollPercent(-1, percent);
-                log?.Invoke($"ScrollPattern: scanning back at {percent}%");
-                Thread.Sleep(ScanSettleMs);
-
-                result = finder();
-                if (result != null) return result;
-            }
-        }
-        else
-        {
-            log?.Invoke("ScrollPattern not available, falling back to Mouse.Scroll");
-            Mouse.MoveTo(scrollViewer.GetClickablePoint());
-
-            // Scroll down incrementally and check at each step
-            for (int i = 0; i < 20; i++)
-            {
-                Mouse.Scroll(-5);
-                Thread.Sleep(ScanSettleMs);
+                scrollPattern.SetScrollPercent(-1, startPercent);
+                log?.Invoke($"ScrollPattern: jumped to {startPercent}%");
+                Thread.Sleep(ScrollSettleMs);
 
                 var result = finder();
-                if (result != null) return result;
+                if (IsVisible(result)) return result;
+
+                for (var percent = startPercent + ScanStepPercent; percent <= 100; percent += ScanStepPercent)
+                {
+                    scrollPattern.SetScrollPercent(-1, percent);
+                    log?.Invoke($"ScrollPattern: scanning at {percent}%");
+                    Thread.Sleep(ScanSettleMs);
+
+                    result = finder();
+                    if (IsVisible(result)) return result;
+                }
+
+                for (var percent = startPercent - ScanStepPercent; percent >= 0; percent -= ScanStepPercent)
+                {
+                    scrollPattern.SetScrollPercent(-1, percent);
+                    log?.Invoke($"ScrollPattern: scanning back at {percent}%");
+                    Thread.Sleep(ScanSettleMs);
+
+                    result = finder();
+                    if (IsVisible(result)) return result;
+                }
             }
+            catch (InvalidOperationException ex)
+            {
+                log?.Invoke($"ScrollPattern failed ({ex.Message}), falling back to Mouse.Scroll");
+            }
+        }
+
+        log?.Invoke("ScrollPattern not available or failed, falling back to Mouse.Scroll");
+        MoveMouseToScrollTarget(scrollViewer, log);
+
+        // Scroll down incrementally and check at each step
+        for (int i = 0; i < 20; i++)
+        {
+            Mouse.Scroll(-5);
+            Thread.Sleep(ScanSettleMs);
+
+            var result = finder();
+            if (IsVisible(result)) return result;
         }
 
         return null;
+    }
+
+    private static bool IsVisible(AutomationElement? element)
+    {
+        return element is { IsOffscreen: false };
+    }
+
+    private static void MoveMouseToScrollTarget(
+        AutomationElement scrollViewer,
+        Action<string>? log)
+    {
+        try
+        {
+            Mouse.MoveTo(scrollViewer.GetClickablePoint());
+            return;
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"Clickable point unavailable ({ex.Message}), using element center");
+        }
+
+        var bounds = scrollViewer.BoundingRectangle;
+        if (bounds.Width <= 0 || bounds.Height <= 0)
+        {
+            return;
+        }
+
+        Mouse.MoveTo(new Point(
+            bounds.Left + (bounds.Width / 2),
+            bounds.Top + (bounds.Height / 2)));
+    }
+
+    private static int GetMouseScrollDeltaForTargetPercent(double verticalPercent)
+    {
+        return verticalPercent <= 0 ? 15 : -15;
     }
 }

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/UiaSettingsIsolation.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/UiaSettingsIsolation.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+
+namespace Easydict.UIAutomation.Tests.Infrastructure;
+
+internal static class UiaSettingsIsolation
+{
+    private const string ExePathEnvironmentVariable = "EASYDICT_EXE_PATH";
+    private const string SettingsDirectoryEnvironmentVariable = "EASYDICT_SETTINGS_DIR";
+
+    public static void ApplyTo(ProcessStartInfo startInfo)
+    {
+        if (TryEnsureSettingsDirectory() is { } settingsDirectory)
+        {
+            startInfo.Environment[SettingsDirectoryEnvironmentVariable] = settingsDirectory;
+        }
+    }
+
+    public static string? TryGetSettingsFilePath()
+    {
+        return TryEnsureSettingsDirectory() is { } settingsDirectory
+            ? Path.Combine(settingsDirectory, "settings.json")
+            : null;
+    }
+
+    private static string? TryEnsureSettingsDirectory()
+    {
+        var settingsDirectory = Environment.GetEnvironmentVariable(SettingsDirectoryEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(settingsDirectory))
+        {
+            return EnsureDirectory(settingsDirectory);
+        }
+
+        var exePath = Environment.GetEnvironmentVariable(ExePathEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(exePath))
+        {
+            return null;
+        }
+
+        settingsDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "Easydict.UIAutomation.Tests",
+            Process.GetCurrentProcess().Id.ToString(),
+            "settings");
+        settingsDirectory = EnsureDirectory(settingsDirectory);
+        Environment.SetEnvironmentVariable(SettingsDirectoryEnvironmentVariable, settingsDirectory);
+        return settingsDirectory;
+    }
+
+    private static string EnsureDirectory(string path)
+    {
+        var fullPath = Path.GetFullPath(Environment.ExpandEnvironmentVariables(path));
+        Directory.CreateDirectory(fullPath);
+        return fullPath;
+    }
+}

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DarkModeTests.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Tests/DarkModeTests.cs
@@ -286,6 +286,12 @@ public class DarkModeTests : IDisposable
 
     private static IEnumerable<string> GetSettingsFileCandidates()
     {
+        if (UiaSettingsIsolation.TryGetSettingsFilePath() is { } isolatedSettingsPath)
+        {
+            yield return isolatedSettingsPath;
+            yield break;
+        }
+
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         var packageFamilyName = Environment.GetEnvironmentVariable("EASYDICT_PACKAGE_FAMILY_NAME");
 

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Tests/ThemeContrastTests.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Tests/ThemeContrastTests.cs
@@ -1048,6 +1048,12 @@ public sealed class ThemeContrastTests : IDisposable
 
     private static IEnumerable<string> GetSettingsFileCandidates()
     {
+        if (UiaSettingsIsolation.TryGetSettingsFilePath() is { } isolatedSettingsPath)
+        {
+            yield return isolatedSettingsPath;
+            yield break;
+        }
+
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         var packageFamilyName = Environment.GetEnvironmentVariable("EASYDICT_PACKAGE_FAMILY_NAME");
 

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Tests/ThemeContrastTests.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Tests/ThemeContrastTests.cs
@@ -1,0 +1,1284 @@
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Easydict.UIAutomation.Tests.Infrastructure;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Input;
+using FlaUI.Core.Tools;
+using FluentAssertions;
+using Microsoft.Win32;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Easydict.UIAutomation.Tests.Tests;
+
+[Trait("Category", "UIAutomation")]
+[Collection("UIAutomation")]
+public sealed class ThemeContrastTests : IDisposable
+{
+    private const string PersonalizeRegistryPath =
+        @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+    private const string AppsUseLightThemeValue = "AppsUseLightTheme";
+    private const string SystemUsesLightThemeValue = "SystemUsesLightTheme";
+    private const string ThemeContrastScreenshotRootName = "theme-contrast-regression";
+    private const string ThemeMatrixScreenshotDirectoryName = "theme-matrix";
+    private const string ThemeContrastScreenshotFilePrefix = "theme-contrast";
+    private static readonly ThemeMatrixCase[] ThemeMatrixCases =
+    [
+        new("light", true, "light", "Light", 1, true),
+        new("light", true, "dark", "Dark", 2, false),
+        new("dark", false, "light", "Light", 1, true),
+        new("dark", false, "dark", "Dark", 2, false)
+    ];
+    private static readonly SettingsTabScreenshot[] ThemeMatrixSettingsTabs =
+    [
+        new(
+            "SettingsTab_Services",
+            "DeepLKeyRevealButton",
+            "settings-services-credentials",
+            "DeepL API key reveal button",
+            "DeepLServiceExpander",
+            45),
+        new("SettingsTab_Views", "MainWindowReorderModeButton", "settings-views", "views reorder button"),
+        new("SettingsTab_Hotkeys", "ShowHotkeyBox", "settings-hotkeys", "hotkey text box"),
+        new("SettingsTab_Language", "FirstLanguageCombo", "settings-language", "language combo"),
+        new("SettingsTab_Advanced", "OcrEngineCombo", "settings-advanced", "advanced OCR engine combo")
+    ];
+
+    private readonly ITestOutputHelper _output;
+    private readonly Dictionary<string, int?> _originalThemeValues = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string?> _settingsSnapshots = new(StringComparer.OrdinalIgnoreCase);
+    private AppLauncher? _launcher;
+
+    public ThemeContrastTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void SettingsPage_ExplicitLightTheme_OnDarkWindowsTheme_ShouldRenderLightControls()
+    {
+        SnapshotAndSetPersistedAppTheme("System");
+        ForceWindowsTheme(light: false);
+
+        _launcher = new AppLauncher();
+        _launcher.LaunchAuto(TimeSpan.FromSeconds(45));
+
+        var window = _launcher.GetMainWindow();
+        Thread.Sleep(2000);
+
+        var themeCombo = FindAppThemeCombo(window);
+        SelectThemeComboItem(themeCombo, themeIndex: 1);
+
+        WaitForPersistedAppTheme("Light", TimeSpan.FromSeconds(5))
+            .Should().Be("Light", "explicit Light must persist before screenshot validation");
+
+        Thread.Sleep(1200);
+        PrepareSettingsWindowForScreenshot(window);
+
+        var path = ScreenshotHelper.CaptureWindowPhysical(
+            window,
+            "40_settings_light_on_dark_system_contrast");
+        _output.WriteLine($"Light-on-dark-system settings screenshot saved: {path}");
+
+        AssertSettingsLightPalette(window, path);
+        CaptureSettingsTabAndAssertElementLight(
+            window,
+            "SettingsTab_Services",
+            "DeepLKeyRevealButton",
+            "42_settings_services_credentials_light_on_dark_system_contrast",
+            "DeepL API key reveal button",
+            "DeepLServiceExpander",
+            45);
+        CaptureSettingsTabAndAssertElementLight(
+            window,
+            "SettingsTab_Views",
+            "MainWindowReorderModeButton",
+            "43_settings_views_light_on_dark_system_contrast",
+            "views reorder button");
+        CaptureSettingsTabAndAssertElementLight(
+            window,
+            "SettingsTab_Hotkeys",
+            "ShowHotkeyBox",
+            "44_settings_hotkeys_light_on_dark_system_contrast",
+            "hotkey text box");
+        CaptureSettingsTabAndAssertElementLight(
+            window,
+            "SettingsTab_Language",
+            "FirstLanguageCombo",
+            "45_settings_language_light_on_dark_system_contrast",
+            "language combo");
+        CaptureSettingsTabAndAssertElementLight(
+            window,
+            "SettingsTab_Advanced",
+            "OcrEngineCombo",
+            "46_settings_advanced_light_on_dark_system_contrast",
+            "advanced OCR engine combo");
+    }
+
+    [Fact]
+    public void MainWindow_ExplicitLightTheme_OnDarkWindowsTheme_ShouldRenderLightChrome()
+    {
+        SnapshotAndSetPersistedAppTheme("System");
+        ForceWindowsTheme(light: false);
+
+        _launcher = new AppLauncher();
+        _launcher.LaunchAuto(TimeSpan.FromSeconds(45));
+
+        var window = _launcher.GetMainWindow();
+        Thread.Sleep(2000);
+
+        var themeCombo = FindAppThemeCombo(window);
+        SelectThemeComboItem(themeCombo, themeIndex: 1);
+
+        WaitForPersistedAppTheme("Light", TimeSpan.FromSeconds(5))
+            .Should().Be("Light", "explicit Light must persist before main-window screenshot validation");
+
+        Thread.Sleep(1200);
+        NavigateBackToMain(window);
+        WaitForMainPage(window);
+        PrepareMainWindowForScreenshot(window);
+
+        var path = ScreenshotHelper.CaptureWindowPhysical(
+            window,
+            "41_main_light_on_dark_system_contrast");
+        _output.WriteLine($"Light-on-dark-system main screenshot saved: {path}");
+
+        AssertMainLightPalette(window, path);
+    }
+
+    [Fact]
+    public void ThemeMatrix_LightAndDarkAppThemes_OnLightAndDarkWindowsThemes_ShouldCaptureNamedScreenshots()
+    {
+        var previousOutputDir = ScreenshotHelper.OutputDir;
+        ScreenshotHelper.OutputDir = PrepareThemeMatrixScreenshotDirectory();
+
+        try
+        {
+            foreach (var testCase in ThemeMatrixCases)
+            {
+                CaptureThemeMatrixCase(testCase);
+            }
+        }
+        finally
+        {
+            ScreenshotHelper.OutputDir = previousOutputDir;
+        }
+    }
+
+    private void CaptureThemeMatrixCase(ThemeMatrixCase testCase)
+    {
+        _output.WriteLine(
+            $"Theme matrix case: Windows={testCase.OsSlug}, App={testCase.AppSlug}");
+
+        _launcher?.Dispose();
+        _launcher = null;
+
+        SnapshotAndSetPersistedAppTheme("System");
+        ForceWindowsTheme(testCase.WindowsLight);
+
+        _launcher = new AppLauncher();
+        _launcher.LaunchAuto(TimeSpan.FromSeconds(45));
+
+        var window = _launcher.GetMainWindow();
+        Thread.Sleep(2000);
+
+        var themeCombo = FindAppThemeCombo(window);
+        SelectThemeComboItem(themeCombo, testCase.ThemeIndex);
+
+        WaitForPersistedAppTheme(testCase.AppTheme, TimeSpan.FromSeconds(5))
+            .Should().Be(
+                testCase.AppTheme,
+                "the app theme must persist before theme-matrix screenshots are captured");
+
+        Thread.Sleep(1200);
+        CaptureThemeMatrixSettingsGeneral(window, testCase);
+        foreach (var tab in ThemeMatrixSettingsTabs)
+        {
+            CaptureThemeMatrixSettingsTab(window, testCase, tab);
+        }
+
+        NavigateBackToMain(window);
+        WaitForMainPage(window);
+        PrepareMainWindowForScreenshot(window);
+
+        var mainPath = ScreenshotHelper.CaptureWindowPhysical(
+            window,
+            $"{testCase.ScreenshotPrefix}_page-main");
+        _output.WriteLine($"Theme matrix main screenshot saved: {mainPath}");
+        AssertMainPalette(window, mainPath, testCase.ExpectedLight);
+
+        _launcher.Dispose();
+        _launcher = null;
+    }
+
+    private void CaptureThemeMatrixSettingsGeneral(Window window, ThemeMatrixCase testCase)
+    {
+        PrepareSettingsWindowForScreenshot(window);
+
+        var path = ScreenshotHelper.CaptureWindowPhysical(
+            window,
+            $"{testCase.ScreenshotPrefix}_page-settings-general");
+        _output.WriteLine($"Theme matrix settings General screenshot saved: {path}");
+        AssertSettingsPalette(window, path, testCase.ExpectedLight);
+    }
+
+    private void CaptureThemeMatrixSettingsTab(
+        Window window,
+        ThemeMatrixCase testCase,
+        SettingsTabScreenshot tab)
+    {
+        var tabElement = FindRequired(window, tab.TabAutomationId);
+        InvokeOrClick(tabElement);
+        Thread.Sleep(1200);
+        PrepareSettingsWindowForScreenshot(window);
+        ExpandSettingsExpanderIfNeeded(window, tab.ExpanderAutomationId);
+        ScrollSettingsElementIntoView(window, tab.ElementAutomationId, tab.InitialScrollPercent);
+        MoveFocusAwayFromTabs(window, tab.ElementAutomationId);
+
+        var path = ScreenshotHelper.CaptureWindowPhysical(
+            window,
+            $"{testCase.ScreenshotPrefix}_page-{tab.PageSlug}");
+        _output.WriteLine($"Theme matrix {tab.PageSlug} screenshot saved: {path}");
+
+        using var bitmap = new Bitmap(path);
+        var windowBounds = ScreenshotHelper.GetWindowPhysicalBounds(window);
+        var dpiScale = ScreenshotHelper.GetWindowDpiScale(window);
+        AssertElementRegionMatchesPalette(
+            tab.Label,
+            FindRequired(window, tab.ElementAutomationId),
+            bitmap,
+            windowBounds,
+            dpiScale,
+            relativeX: 0.12,
+            relativeY: 0.20,
+            relativeWidth: 0.48,
+            relativeHeight: 0.50,
+            expectedLight: testCase.ExpectedLight,
+            minLightBrightness: 150,
+            maxDarkBrightness: 130);
+    }
+
+    private ComboBox FindAppThemeCombo(Window window)
+    {
+        ScreenshotHelper.TrySetWindowPhysicalBounds(window, new Rectangle(0, 0, 900, 900));
+        window.SetForeground();
+        Thread.Sleep(500);
+
+        var settingsButton = Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByAutomationId("SettingsButton")),
+            TimeSpan.FromSeconds(5)).Result;
+
+        settingsButton.Should().NotBeNull("main page SettingsButton must be available");
+        InvokeOrClick(settingsButton!);
+        Thread.Sleep(2000);
+
+        var scrollViewer = Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByAutomationId("MainScrollViewer")),
+            TimeSpan.FromSeconds(15)).Result;
+
+        scrollViewer.Should().NotBeNull("settings MainScrollViewer must appear after opening settings");
+
+        var element = Retry.WhileNull(
+            () =>
+            {
+                var combo = window.FindFirstDescendant(cf => cf.ByAutomationId("AppThemeCombo"));
+                return combo is { IsOffscreen: false } ? combo : null;
+            },
+            TimeSpan.FromSeconds(5)).Result;
+
+        if (element is null)
+        {
+            try
+            {
+                element = ScrollHelper.ScrollToFind(
+                    scrollViewer!,
+                    startPercent: 70,
+                    () => window.FindFirstDescendant(cf => cf.ByAutomationId("AppThemeCombo")),
+                    _output.WriteLine);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _output.WriteLine($"ScrollToFind AppThemeCombo failed, falling back to existing UIA element: {ex.Message}");
+                element = window.FindFirstDescendant(cf => cf.ByAutomationId("AppThemeCombo"));
+                TryScrollIntoView(element);
+            }
+        }
+
+        var themeCombo = element?.AsComboBox();
+
+        themeCombo.Should().NotBeNull("AppThemeCombo must be visible on the General settings tab");
+        return themeCombo!;
+    }
+
+    private void TryScrollIntoView(AutomationElement? element)
+    {
+        if (element is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (element.Patterns.ScrollItem.IsSupported)
+            {
+                element.Patterns.ScrollItem.Pattern.ScrollIntoView();
+                Thread.Sleep(800);
+            }
+        }
+        catch (Exception ex)
+        {
+            _output.WriteLine($"ScrollItem fallback failed: {ex.Message}");
+        }
+    }
+
+    private void SelectThemeComboItem(ComboBox themeCombo, int themeIndex)
+    {
+        themeCombo.Expand();
+        Thread.Sleep(500);
+
+        var items = themeCombo.Items;
+        _output.WriteLine(
+            $"AppThemeCombo exposed {items.Length} item(s): {string.Join(", ", items.Select(i => $"'{i.Name}'"))}");
+
+        items.Length.Should().BeGreaterThan(themeIndex, "Light theme item must be available at index 1");
+        items[themeIndex].Click();
+    }
+
+    private void PrepareSettingsWindowForScreenshot(Window window)
+    {
+        ScreenshotHelper.TrySetWindowPhysicalBounds(window, new Rectangle(0, 0, 900, 900));
+        Thread.Sleep(500);
+        window.SetForeground();
+        MovePointerAwayFromTabs(window);
+        Thread.Sleep(500);
+    }
+
+    private void ExpandSettingsExpanderIfNeeded(Window window, string? expanderAutomationId)
+    {
+        if (string.IsNullOrWhiteSpace(expanderAutomationId))
+        {
+            return;
+        }
+
+        var expander = Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByAutomationId(expanderAutomationId)),
+            TimeSpan.FromSeconds(5)).Result;
+
+        expander.Should().NotBeNull($"{expanderAutomationId} expander must be available before screenshot capture");
+        TryScrollIntoView(expander);
+        if (expander!.Patterns.ExpandCollapse.IsSupported)
+        {
+            expander.Patterns.ExpandCollapse.Pattern.Expand();
+        }
+        else
+        {
+            InvokeOrClick(expander);
+        }
+
+        Thread.Sleep(1000);
+    }
+
+    private void ScrollSettingsElementIntoView(
+        Window window,
+        string automationId,
+        double? initialScrollPercent = null)
+    {
+        var scrollViewer = window.FindFirstDescendant(cf => cf.ByAutomationId("MainScrollViewer"));
+        if (scrollViewer is not null)
+        {
+            try
+            {
+                if (initialScrollPercent.HasValue)
+                {
+                    ScrollHelper.ScrollToPercent(scrollViewer, initialScrollPercent.Value, _output.WriteLine);
+                }
+
+                var element = ScrollHelper.ScrollToFind(
+                    scrollViewer,
+                    startPercent: initialScrollPercent ?? 45,
+                    () => FindVisibleInWindow(window, automationId),
+                    _output.WriteLine);
+
+                if (element is not null)
+                {
+                    return;
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                _output.WriteLine($"ScrollToFind {automationId} failed, falling back to ScrollItem: {ex.Message}");
+            }
+        }
+
+        TryScrollIntoView(window.FindFirstDescendant(cf => cf.ByAutomationId(automationId)));
+    }
+
+    private static AutomationElement? FindVisibleInWindow(Window window, string automationId)
+    {
+        var element = window.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
+        if (element is null || element.IsOffscreen)
+        {
+            return null;
+        }
+
+        var windowBounds = window.BoundingRectangle;
+        var elementBounds = element.BoundingRectangle;
+        return elementBounds.Top >= windowBounds.Top
+            && elementBounds.Bottom <= windowBounds.Bottom
+            && elementBounds.Left >= windowBounds.Left
+            && elementBounds.Right <= windowBounds.Right
+            ? element
+            : null;
+    }
+
+    private void CaptureSettingsTabAndAssertElementLight(
+        Window window,
+        string tabAutomationId,
+        string elementAutomationId,
+        string screenshotName,
+        string label,
+        string? expanderAutomationId = null,
+        double? initialScrollPercent = null)
+    {
+        var tab = FindRequired(window, tabAutomationId);
+        InvokeOrClick(tab);
+        Thread.Sleep(1200);
+        PrepareSettingsWindowForScreenshot(window);
+        ExpandSettingsExpanderIfNeeded(window, expanderAutomationId);
+        ScrollSettingsElementIntoView(window, elementAutomationId, initialScrollPercent);
+        MoveFocusAwayFromTabs(window, elementAutomationId);
+
+        var path = ScreenshotHelper.CaptureWindowPhysical(window, screenshotName);
+        _output.WriteLine($"{label} settings screenshot saved: {path}");
+
+        using var bitmap = new Bitmap(path);
+        var windowBounds = ScreenshotHelper.GetWindowPhysicalBounds(window);
+        var dpiScale = ScreenshotHelper.GetWindowDpiScale(window);
+        AssertElementRegionIsLight(
+            label,
+            FindRequired(window, elementAutomationId),
+            bitmap,
+            windowBounds,
+            dpiScale,
+            relativeX: 0.12,
+            relativeY: 0.20,
+            relativeWidth: 0.48,
+            relativeHeight: 0.50,
+            minBrightness: 150);
+    }
+
+    private void PrepareMainWindowForScreenshot(Window window)
+    {
+        ScreenshotHelper.TrySetWindowPhysicalBounds(window, new Rectangle(0, 0, 900, 900));
+        Thread.Sleep(500);
+        window.SetForeground();
+        MovePointerAwayFromTabs(window);
+        Thread.Sleep(500);
+    }
+
+    private static void MovePointerAwayFromTabs(Window window)
+    {
+        try
+        {
+            var bounds = window.BoundingRectangle;
+            Mouse.MoveTo(new Point(bounds.Left + 20, bounds.Bottom - 20));
+        }
+        catch
+        {
+            // The screenshot assertions do not depend on pointer placement.
+        }
+    }
+
+    private void MoveFocusAwayFromTabs(Window window, string fallbackAutomationId)
+    {
+        var focusTarget = window.FindFirstDescendant(cf => cf.ByAutomationId("MainScrollViewer"))
+            ?? window.FindFirstDescendant(cf => cf.ByAutomationId(fallbackAutomationId));
+
+        try
+        {
+            focusTarget?.Focus();
+        }
+        catch (Exception ex)
+        {
+            _output.WriteLine($"Unable to move focus away from settings tab: {ex.Message}");
+        }
+
+        MovePointerAwayFromTabs(window);
+        Thread.Sleep(1000);
+    }
+
+    private void NavigateBackToMain(Window window)
+    {
+        var scrollViewer = window.FindFirstDescendant(cf => cf.ByAutomationId("MainScrollViewer"));
+        if (scrollViewer is not null)
+        {
+            ScrollHelper.ScrollToPercent(scrollViewer, 0, _output.WriteLine);
+            Thread.Sleep(500);
+        }
+
+        var backButton = window.FindFirstDescendant(cf => cf.ByAutomationId("FloatingBackButton"))
+            ?? window.FindFirstDescendant(cf => cf.ByAutomationId("BackButton"));
+
+        backButton.Should().NotBeNull("settings back button must be available before returning to the main page");
+        InvokeOrClick(backButton!);
+        Thread.Sleep(1000);
+        DismissUnsavedChangesDialog(window);
+    }
+
+    private void WaitForMainPage(Window window)
+    {
+        var settingsButton = Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByAutomationId("SettingsButton")),
+            TimeSpan.FromSeconds(10)).Result;
+
+        settingsButton.Should().NotBeNull("SettingsButton must be visible on the main page before screenshot validation");
+        Thread.Sleep(700);
+    }
+
+    private void DismissUnsavedChangesDialog(Window window)
+    {
+        var dontSaveButton = Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByName("Don't Save"))
+                ?? window.FindFirstDescendant(cf => cf.ByName("不保存")),
+            TimeSpan.FromSeconds(3)).Result;
+
+        if (dontSaveButton is not null)
+        {
+            _output.WriteLine("Unsaved changes dialog detected - clicking Don't Save");
+            dontSaveButton.Click();
+            Thread.Sleep(1000);
+        }
+    }
+
+    private void AssertSettingsLightPalette(Window window, string screenshotPath)
+    {
+        AssertSettingsPalette(window, screenshotPath, expectedLight: true);
+    }
+
+    private void AssertSettingsPalette(Window window, string screenshotPath, bool expectedLight)
+    {
+        using var bitmap = new Bitmap(screenshotPath);
+        var windowBounds = ScreenshotHelper.GetWindowPhysicalBounds(window);
+        var dpiScale = ScreenshotHelper.GetWindowDpiScale(window);
+        _output.WriteLine($"Settings theme-matrix DPI scale: {dpiScale:0.###}");
+
+        AssertElementRegionMatchesPalette(
+            "selected General settings tab",
+            FindRequired(window, "SettingsTab_General"),
+            bitmap,
+            windowBounds,
+            dpiScale,
+            relativeX: 0.12,
+            relativeY: 0.12,
+            relativeWidth: 0.25,
+            relativeHeight: 0.25,
+            expectedLight: expectedLight,
+            minLightBrightness: 170,
+            maxDarkBrightness: 130);
+
+        AssertElementRegionMatchesPalette(
+            "unselected Services settings tab",
+            FindRequired(window, "SettingsTab_Services"),
+            bitmap,
+            windowBounds,
+            dpiScale,
+            relativeX: 0.12,
+            relativeY: 0.12,
+            relativeWidth: 0.25,
+            relativeHeight: 0.25,
+            expectedLight: expectedLight,
+            minLightBrightness: 170,
+            maxDarkBrightness: 130);
+
+        AssertElementRegionMatchesPalette(
+            "AppThemeCombo field",
+            FindRequired(window, "AppThemeCombo"),
+            bitmap,
+            windowBounds,
+            dpiScale,
+            relativeX: 0.12,
+            relativeY: 0.20,
+            relativeWidth: 0.52,
+            relativeHeight: 0.55,
+            expectedLight: expectedLight,
+            minLightBrightness: 150,
+            maxDarkBrightness: 130);
+    }
+
+    private void AssertMainLightPalette(Window window, string screenshotPath)
+    {
+        AssertMainPalette(window, screenshotPath, expectedLight: true);
+    }
+
+    private void AssertMainPalette(Window window, string screenshotPath, bool expectedLight)
+    {
+        using var bitmap = new Bitmap(screenshotPath);
+        var windowBounds = ScreenshotHelper.GetWindowPhysicalBounds(window);
+        var dpiScale = ScreenshotHelper.GetWindowDpiScale(window);
+        _output.WriteLine($"Main theme-matrix DPI scale: {dpiScale:0.###}");
+
+        AssertElementRegionMatchesPalette(
+            "source input field",
+            FindRequired(window, "InputTextBox"),
+            bitmap,
+            windowBounds,
+            dpiScale,
+            relativeX: 0.12,
+            relativeY: 0.42,
+            relativeWidth: 0.42,
+            relativeHeight: 0.26,
+            expectedLight: expectedLight,
+            minLightBrightness: 175,
+            maxDarkBrightness: 130);
+
+        if (expectedLight)
+        {
+            AssertElementRegionHasDarkPixels(
+                "main mode title",
+                FindRequired(window, "ModeTitleText"),
+                bitmap,
+                windowBounds,
+                dpiScale,
+                minDarkPixelRatio: 0.04);
+        }
+        else
+        {
+            AssertElementRegionHasLightPixels(
+                "main mode title",
+                FindRequired(window, "ModeTitleText"),
+                bitmap,
+                windowBounds,
+                dpiScale,
+                minLightPixelRatio: 0.04);
+        }
+
+        AssertElementRegionMatchesPalette(
+            "source language combo",
+            FindRequired(window, "SourceLangCombo"),
+            bitmap,
+            windowBounds,
+            dpiScale,
+            relativeX: 0.14,
+            relativeY: 0.22,
+            relativeWidth: 0.40,
+            relativeHeight: 0.46,
+            expectedLight: expectedLight,
+            minLightBrightness: 150,
+            maxDarkBrightness: 130);
+
+        AssertBitmapRegionMatchesPalette(
+            "quick output card",
+            bitmap,
+            relativeX: 0.12,
+            relativeY: 0.72,
+            relativeWidth: 0.24,
+            relativeHeight: 0.045,
+            expectedLight: expectedLight,
+            minLightBrightness: 175,
+            maxDarkBrightness: 130);
+    }
+
+    private static AutomationElement FindRequired(Window window, string automationId)
+    {
+        var element = Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByAutomationId(automationId)),
+            TimeSpan.FromSeconds(5)).Result;
+
+        element.Should().NotBeNull($"{automationId} must be present for screenshot palette validation");
+        return element!;
+    }
+
+    private void AssertElementRegionIsLight(
+        string label,
+        AutomationElement element,
+        Bitmap bitmap,
+        Rectangle windowBounds,
+        double dpiScale,
+        double relativeX,
+        double relativeY,
+        double relativeWidth,
+        double relativeHeight,
+        double minBrightness)
+    {
+        var elementRect = ToScreenshotPixelRect(bitmap, element.BoundingRectangle, windowBounds, dpiScale);
+        var sampleRect = ToRelativeSampleRect(
+            bitmap,
+            elementRect,
+            relativeX,
+            relativeY,
+            relativeWidth,
+            relativeHeight);
+        var sample = AverageRegion(bitmap, sampleRect);
+
+        _output.WriteLine(
+            $"{label}: element={elementRect}, sample={sampleRect}, avg rgb=({sample.R:0.0}, {sample.G:0.0}, {sample.B:0.0}), brightness={sample.Brightness:0.0}");
+
+        sample.Brightness.Should().BeGreaterThan(
+            minBrightness,
+            $"{label} must use the explicit Light palette when Windows app theme is dark");
+    }
+
+    private void AssertElementRegionMatchesPalette(
+        string label,
+        AutomationElement element,
+        Bitmap bitmap,
+        Rectangle windowBounds,
+        double dpiScale,
+        double relativeX,
+        double relativeY,
+        double relativeWidth,
+        double relativeHeight,
+        bool expectedLight,
+        double minLightBrightness,
+        double maxDarkBrightness)
+    {
+        var elementRect = ToScreenshotPixelRect(bitmap, element.BoundingRectangle, windowBounds, dpiScale);
+        var sampleRect = ToRelativeSampleRect(
+            bitmap,
+            elementRect,
+            relativeX,
+            relativeY,
+            relativeWidth,
+            relativeHeight);
+        var sample = AverageRegion(bitmap, sampleRect);
+
+        _output.WriteLine(
+            $"{label}: element={elementRect}, sample={sampleRect}, avg rgb=({sample.R:0.0}, {sample.G:0.0}, {sample.B:0.0}), brightness={sample.Brightness:0.0}, expected={(expectedLight ? "Light" : "Dark")}");
+
+        if (expectedLight)
+        {
+            sample.Brightness.Should().BeGreaterThan(
+                minLightBrightness,
+                $"{label} must use the explicit Light palette");
+            return;
+        }
+
+        sample.Brightness.Should().BeLessThan(
+            maxDarkBrightness,
+            $"{label} must use the explicit Dark palette");
+    }
+
+    private void AssertBitmapRegionIsLight(
+        string label,
+        Bitmap bitmap,
+        double relativeX,
+        double relativeY,
+        double relativeWidth,
+        double relativeHeight,
+        double minBrightness)
+    {
+        var rect = new Rectangle(
+            (int)Math.Round(bitmap.Width * relativeX),
+            (int)Math.Round(bitmap.Height * relativeY),
+            Math.Max(1, (int)Math.Round(bitmap.Width * relativeWidth)),
+            Math.Max(1, (int)Math.Round(bitmap.Height * relativeHeight)));
+        rect = ClipRect(rect, bitmap.Width, bitmap.Height);
+        var sample = AverageRegion(bitmap, rect);
+
+        _output.WriteLine(
+            $"{label}: sample={rect}, avg rgb=({sample.R:0.0}, {sample.G:0.0}, {sample.B:0.0}), brightness={sample.Brightness:0.0}");
+
+        sample.Brightness.Should().BeGreaterThan(
+            minBrightness,
+            $"{label} must use the explicit Light palette when Windows app theme is dark");
+    }
+
+    private void AssertBitmapRegionMatchesPalette(
+        string label,
+        Bitmap bitmap,
+        double relativeX,
+        double relativeY,
+        double relativeWidth,
+        double relativeHeight,
+        bool expectedLight,
+        double minLightBrightness,
+        double maxDarkBrightness)
+    {
+        var rect = new Rectangle(
+            (int)Math.Round(bitmap.Width * relativeX),
+            (int)Math.Round(bitmap.Height * relativeY),
+            Math.Max(1, (int)Math.Round(bitmap.Width * relativeWidth)),
+            Math.Max(1, (int)Math.Round(bitmap.Height * relativeHeight)));
+        rect = ClipRect(rect, bitmap.Width, bitmap.Height);
+        var sample = AverageRegion(bitmap, rect);
+
+        _output.WriteLine(
+            $"{label}: sample={rect}, avg rgb=({sample.R:0.0}, {sample.G:0.0}, {sample.B:0.0}), brightness={sample.Brightness:0.0}, expected={(expectedLight ? "Light" : "Dark")}");
+
+        if (expectedLight)
+        {
+            sample.Brightness.Should().BeGreaterThan(
+                minLightBrightness,
+                $"{label} must use the explicit Light palette");
+            return;
+        }
+
+        sample.Brightness.Should().BeLessThan(
+            maxDarkBrightness,
+            $"{label} must use the explicit Dark palette");
+    }
+
+    private void AssertElementRegionHasDarkPixels(
+        string label,
+        AutomationElement element,
+        Bitmap bitmap,
+        Rectangle windowBounds,
+        double dpiScale,
+        double minDarkPixelRatio)
+    {
+        var elementRect = ToScreenshotPixelRect(bitmap, element.BoundingRectangle, windowBounds, dpiScale);
+        var darkPixels = 0;
+        var count = 0;
+
+        for (var y = elementRect.Top; y < elementRect.Bottom; y++)
+        {
+            for (var x = elementRect.Left; x < elementRect.Right; x++)
+            {
+                var color = bitmap.GetPixel(x, y);
+                var brightness = (0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B);
+                if (brightness < 130)
+                {
+                    darkPixels++;
+                }
+
+                count++;
+            }
+        }
+
+        var ratio = count == 0 ? 0 : darkPixels / (double)count;
+        _output.WriteLine($"{label}: element={elementRect}, dark-pixel ratio={ratio:0.000}");
+
+        ratio.Should().BeGreaterThan(
+            minDarkPixelRatio,
+            $"{label} must render dark foreground text on the explicit Light main window");
+    }
+
+    private void AssertElementRegionHasLightPixels(
+        string label,
+        AutomationElement element,
+        Bitmap bitmap,
+        Rectangle windowBounds,
+        double dpiScale,
+        double minLightPixelRatio)
+    {
+        var elementRect = ToScreenshotPixelRect(bitmap, element.BoundingRectangle, windowBounds, dpiScale);
+        var lightPixels = 0;
+        var count = 0;
+
+        for (var y = elementRect.Top; y < elementRect.Bottom; y++)
+        {
+            for (var x = elementRect.Left; x < elementRect.Right; x++)
+            {
+                var color = bitmap.GetPixel(x, y);
+                var brightness = (0.299 * color.R) + (0.587 * color.G) + (0.114 * color.B);
+                if (brightness > 170)
+                {
+                    lightPixels++;
+                }
+
+                count++;
+            }
+        }
+
+        var ratio = count == 0 ? 0 : lightPixels / (double)count;
+        _output.WriteLine($"{label}: element={elementRect}, light-pixel ratio={ratio:0.000}");
+
+        ratio.Should().BeGreaterThan(
+            minLightPixelRatio,
+            $"{label} must render light foreground text on the explicit Dark main window");
+    }
+
+    private static Rectangle ToScreenshotPixelRect(
+        Bitmap bitmap,
+        Rectangle elementBounds,
+        Rectangle windowBounds,
+        double dpiScale)
+    {
+        var left = (int)Math.Round((elementBounds.Left - windowBounds.Left) * dpiScale);
+        var top = (int)Math.Round((elementBounds.Top - windowBounds.Top) * dpiScale);
+        var right = (int)Math.Round((elementBounds.Right - windowBounds.Left) * dpiScale);
+        var bottom = (int)Math.Round((elementBounds.Bottom - windowBounds.Top) * dpiScale);
+
+        return ClipRect(Rectangle.FromLTRB(left, top, right, bottom), bitmap.Width, bitmap.Height);
+    }
+
+    private static Rectangle ToRelativeSampleRect(
+        Bitmap bitmap,
+        Rectangle elementRect,
+        double relativeX,
+        double relativeY,
+        double relativeWidth,
+        double relativeHeight)
+    {
+        var sample = new Rectangle(
+            elementRect.Left + (int)Math.Round(elementRect.Width * relativeX),
+            elementRect.Top + (int)Math.Round(elementRect.Height * relativeY),
+            Math.Max(1, (int)Math.Round(elementRect.Width * relativeWidth)),
+            Math.Max(1, (int)Math.Round(elementRect.Height * relativeHeight)));
+
+        return ClipRect(sample, bitmap.Width, bitmap.Height);
+    }
+
+    private static Rectangle ClipRect(Rectangle rect, int maxWidth, int maxHeight)
+    {
+        var left = Math.Clamp(rect.Left, 0, maxWidth - 1);
+        var top = Math.Clamp(rect.Top, 0, maxHeight - 1);
+        var right = Math.Clamp(rect.Right, left + 1, maxWidth);
+        var bottom = Math.Clamp(rect.Bottom, top + 1, maxHeight);
+        return Rectangle.FromLTRB(left, top, right, bottom);
+    }
+
+    private static PaletteSample AverageRegion(Bitmap bitmap, Rectangle rect)
+    {
+        double r = 0;
+        double g = 0;
+        double b = 0;
+        var count = 0;
+
+        for (var y = rect.Top; y < rect.Bottom; y++)
+        {
+            for (var x = rect.Left; x < rect.Right; x++)
+            {
+                var color = bitmap.GetPixel(x, y);
+                r += color.R;
+                g += color.G;
+                b += color.B;
+                count++;
+            }
+        }
+
+        r /= count;
+        g /= count;
+        b /= count;
+        var brightness = (0.299 * r) + (0.587 * g) + (0.114 * b);
+        return new PaletteSample(r, g, b, brightness);
+    }
+
+    private void SnapshotAndSetPersistedAppTheme(string theme)
+    {
+        var candidates = GetSettingsFileCandidates()
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        foreach (var path in candidates)
+        {
+            if (!_settingsSnapshots.ContainsKey(path))
+            {
+                _settingsSnapshots[path] = File.Exists(path) ? File.ReadAllText(path) : null;
+            }
+
+            if (File.Exists(path))
+            {
+                WriteAppTheme(path, theme);
+            }
+        }
+
+        if (candidates.LastOrDefault() is { } localSettingsPath)
+        {
+            WriteAppTheme(localSettingsPath, theme);
+        }
+    }
+
+    private static void WriteAppTheme(string path, string theme)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        JsonNode root;
+        try
+        {
+            root = JsonNode.Parse(File.ReadAllText(path)) ?? new JsonObject();
+        }
+        catch
+        {
+            root = new JsonObject();
+        }
+
+        root["AppTheme"] = theme;
+        File.WriteAllText(path, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static string WaitForPersistedAppTheme(string expectedTheme, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        string current;
+        do
+        {
+            current = ReadPersistedAppTheme();
+            if (string.Equals(current, expectedTheme, StringComparison.OrdinalIgnoreCase))
+            {
+                return current;
+            }
+
+            Thread.Sleep(200);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        return current;
+    }
+
+    private static string ReadPersistedAppTheme()
+    {
+        try
+        {
+            var settingsPath = GetSettingsFileCandidates()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault(File.Exists);
+            if (!File.Exists(settingsPath))
+            {
+                return "<missing settings.json>";
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllText(settingsPath));
+            if (!document.RootElement.TryGetProperty("AppTheme", out var appTheme))
+            {
+                return "<missing AppTheme>";
+            }
+
+            return appTheme.ValueKind == JsonValueKind.String
+                ? appTheme.GetString() ?? "<missing AppTheme>"
+                : "<unreadable AppTheme>";
+        }
+        catch (Exception ex)
+        {
+            return $"<error: {ex.Message}>";
+        }
+    }
+
+    private static IEnumerable<string> GetSettingsFileCandidates()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var packageFamilyName = Environment.GetEnvironmentVariable("EASYDICT_PACKAGE_FAMILY_NAME");
+
+        foreach (var familyName in GetPackageFamilyNameCandidates(localAppData, packageFamilyName))
+        {
+            yield return Path.Combine(
+                localAppData,
+                "Packages",
+                familyName,
+                "LocalCache",
+                "Local",
+                "Easydict",
+                "settings.json");
+        }
+
+        yield return Path.Combine(localAppData, "Easydict", "settings.json");
+    }
+
+    private static IEnumerable<string> GetPackageFamilyNameCandidates(
+        string localAppData,
+        string? packageFamilyName)
+    {
+        if (!string.IsNullOrWhiteSpace(packageFamilyName))
+        {
+            yield return packageFamilyName;
+        }
+
+        var packagesRoot = Path.Combine(localAppData, "Packages");
+        if (!Directory.Exists(packagesRoot))
+        {
+            yield break;
+        }
+
+        string[] packagePaths;
+        try
+        {
+            packagePaths = Directory.GetDirectories(packagesRoot, "xiaocang.EasydictforWindows_*");
+        }
+        catch
+        {
+            yield break;
+        }
+
+        foreach (var path in packagePaths)
+        {
+            var familyName = Path.GetFileName(path);
+            if (!string.IsNullOrWhiteSpace(familyName))
+            {
+                yield return familyName;
+            }
+        }
+    }
+
+    private static string PrepareThemeMatrixScreenshotDirectory()
+    {
+        var screenshotRoot = Environment.GetEnvironmentVariable("SCREENSHOT_OUTPUT_DIR");
+        if (string.IsNullOrWhiteSpace(screenshotRoot))
+        {
+            screenshotRoot = Path.Combine(FindRepositoryRoot(), "artifacts");
+        }
+
+        var outputDir = Path.Combine(
+            screenshotRoot,
+            ThemeContrastScreenshotRootName,
+            ThemeMatrixScreenshotDirectoryName);
+        Directory.CreateDirectory(outputDir);
+
+        foreach (var path in Directory.GetFiles(outputDir, $"{ThemeContrastScreenshotFilePrefix}_*.png"))
+        {
+            File.Delete(path);
+        }
+
+        return outputDir;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var gitPath = Path.Combine(directory.FullName, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+
+    private void ForceWindowsTheme(bool light)
+    {
+        CaptureOriginalThemeValues();
+
+        using var key = Registry.CurrentUser.CreateSubKey(PersonalizeRegistryPath);
+        key.Should().NotBeNull("Windows theme registry key must be writable for UI regression setup");
+
+        var value = light ? 1 : 0;
+        key!.SetValue(AppsUseLightThemeValue, value, RegistryValueKind.DWord);
+        key.SetValue(SystemUsesLightThemeValue, value, RegistryValueKind.DWord);
+        BroadcastThemeChange();
+    }
+
+    private void CaptureOriginalThemeValues()
+    {
+        if (_originalThemeValues.Count > 0)
+        {
+            return;
+        }
+
+        _originalThemeValues[AppsUseLightThemeValue] = ReadThemeDword(AppsUseLightThemeValue);
+        _originalThemeValues[SystemUsesLightThemeValue] = ReadThemeDword(SystemUsesLightThemeValue);
+    }
+
+    private static int? ReadThemeDword(string name)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(PersonalizeRegistryPath);
+        return key?.GetValue(name) is int value ? value : null;
+    }
+
+    private void RestoreWindowsTheme()
+    {
+        if (_originalThemeValues.Count == 0)
+        {
+            return;
+        }
+
+        using var key = Registry.CurrentUser.CreateSubKey(PersonalizeRegistryPath);
+        if (key is null)
+        {
+            return;
+        }
+
+        foreach (var (name, value) in _originalThemeValues)
+        {
+            if (value.HasValue)
+            {
+                key.SetValue(name, value.Value, RegistryValueKind.DWord);
+            }
+            else
+            {
+                key.DeleteValue(name, throwOnMissingValue: false);
+            }
+        }
+
+        BroadcastThemeChange();
+    }
+
+    private void RestoreSettingsSnapshots()
+    {
+        foreach (var (path, content) in _settingsSnapshots)
+        {
+            if (content is null)
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content);
+        }
+    }
+
+    private static void InvokeOrClick(AutomationElement element)
+    {
+        if (element.Patterns.Invoke.IsSupported)
+        {
+            element.Patterns.Invoke.Pattern.Invoke();
+            return;
+        }
+
+        element.Click();
+    }
+
+    private static void BroadcastThemeChange()
+    {
+        SendMessageTimeout(
+            new IntPtr(0xffff),
+            0x001a,
+            UIntPtr.Zero,
+            "ImmersiveColorSet",
+            0x0002,
+            1000,
+            out _);
+    }
+
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    private static extern IntPtr SendMessageTimeout(
+        IntPtr hWnd,
+        uint msg,
+        UIntPtr wParam,
+        string lParam,
+        uint flags,
+        uint timeout,
+        out UIntPtr result);
+
+    private readonly record struct ThemeMatrixCase(
+        string OsSlug,
+        bool WindowsLight,
+        string AppSlug,
+        string AppTheme,
+        int ThemeIndex,
+        bool ExpectedLight)
+    {
+        public string ScreenshotPrefix => $"{ThemeContrastScreenshotFilePrefix}_os-{OsSlug}_app-{AppSlug}";
+    }
+
+    private readonly record struct SettingsTabScreenshot(
+        string TabAutomationId,
+        string ElementAutomationId,
+        string PageSlug,
+        string Label,
+        string? ExpanderAutomationId = null,
+        double? InitialScrollPercent = null);
+
+    private readonly record struct PaletteSample(
+        double R,
+        double G,
+        double B,
+        double Brightness);
+
+    public void Dispose()
+    {
+        _launcher?.Dispose();
+        RestoreSettingsSnapshots();
+        RestoreWindowsTheme();
+    }
+}

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/LanguageDetectionServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/LanguageDetectionServiceTests.cs
@@ -86,6 +86,17 @@ public class LanguageDetectionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task DetectAsync_WhenCancellationRequested_ThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = () => _service.DetectAsync("This text is long enough to trigger language detection.", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public void GetTargetLanguage_WhenSourceMatchesFirst_ReturnsSecond()
     {
         var firstLang = LanguageExtensions.FromCode(_settings.FirstLanguage);

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/LocalCredentialProtectorTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/LocalCredentialProtectorTests.cs
@@ -1,0 +1,182 @@
+using Easydict.WinUI.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+[Trait("Category", "WinUI")]
+public sealed class LocalCredentialProtectorTests
+{
+    [Fact]
+    public void Protect_WithCurrentUserScope_ShouldRoundTripWithoutPlaintextStorage()
+    {
+        const string plaintext = "sk-test-local-api-key";
+
+        var protectedValue = LocalCredentialProtector.Protect(plaintext);
+
+        protectedValue.Should().StartWith("edcred1:user:");
+        protectedValue.Should().NotContain(plaintext);
+        LocalCredentialProtector.TryUnprotect(protectedValue, out var unprotected)
+            .Should().BeTrue();
+        unprotected.Should().Be(plaintext);
+    }
+
+    [Fact]
+    public void Protect_WithLocalMachineScope_ShouldRecordMachineScope()
+    {
+        const string plaintext = "sk-test-shared-api-key";
+
+        var protectedValue = LocalCredentialProtector.Protect(
+            plaintext,
+            LocalCredentialProtector.CredentialProtectionScope.LocalMachine);
+
+        protectedValue.Should().StartWith("edcred1:machine:");
+        protectedValue.Should().NotContain(plaintext);
+        LocalCredentialProtector.TryUnprotect(protectedValue, out var unprotected)
+            .Should().BeTrue();
+        unprotected.Should().Be(plaintext);
+    }
+
+    [Fact]
+    public void TryUnprotect_WithTamperedProtectedValue_ShouldFail()
+    {
+        var protectedValue = LocalCredentialProtector.Protect("sk-test-local-api-key");
+        var tamperedValue = protectedValue[..^4] + "AAAA";
+
+        LocalCredentialProtector.TryUnprotect(tamperedValue, out var unprotected)
+            .Should().BeFalse();
+        unprotected.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void IsProtected_ShouldOnlyMatchVersionedProtectedValues()
+    {
+        LocalCredentialProtector.IsProtected("plain-old-api-key").Should().BeFalse();
+        LocalCredentialProtector.IsProtected("").Should().BeFalse();
+        LocalCredentialProtector.IsProtected(null).Should().BeFalse();
+
+        var protectedValue = LocalCredentialProtector.Protect("plain-old-api-key");
+        LocalCredentialProtector.IsProtected(protectedValue).Should().BeTrue();
+    }
+
+    [Fact]
+    public void UnprotectOrReturnPlaintext_WithLegacyPlaintext_ShouldRequestMigration()
+    {
+        var value = LocalCredentialProtector.UnprotectOrReturnPlaintext(
+            "plain-old-api-key",
+            "stable-machine-id",
+            out var needsMigration,
+            out var decryptFailed);
+
+        value.Should().Be("plain-old-api-key");
+        needsMigration.Should().BeTrue();
+        decryptFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnprotectOrReturnPlaintext_WithProtectedValue_ShouldReturnPlaintextWithoutMigration()
+    {
+        var protectedValue = LocalCredentialProtector.Protect("sk-test-local-api-key");
+
+        var value = LocalCredentialProtector.UnprotectOrReturnPlaintext(
+            protectedValue,
+            "stable-machine-id",
+            out var needsMigration,
+            out var decryptFailed);
+
+        value.Should().Be("sk-test-local-api-key");
+        needsMigration.Should().BeFalse();
+        decryptFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnprotectOrReturnPlaintext_WithLegacyProtectedValue_ShouldRequestMigration()
+    {
+        var protectedValue = LocalCredentialProtector.ProtectLegacy(
+            "sk-test-local-api-key",
+            "stable-machine-id");
+
+        var value = LocalCredentialProtector.UnprotectOrReturnPlaintext(
+            protectedValue,
+            "stable-machine-id",
+            out var needsMigration,
+            out var decryptFailed);
+
+        value.Should().Be("sk-test-local-api-key");
+        needsMigration.Should().BeTrue();
+        decryptFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryUnprotectLegacy_WithDifferentMachineId_ShouldFail()
+    {
+        var protectedValue = LocalCredentialProtector.ProtectLegacy(
+            "sk-test-local-api-key",
+            "stable-machine-id");
+
+        LocalCredentialProtector.TryUnprotectLegacy(
+                protectedValue,
+                "different-machine-id",
+                out var unprotected)
+            .Should().BeFalse();
+        unprotected.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetOrCreatePersistedMachineId_WithExistingMachineIdFile_ShouldReturnExistingValue()
+    {
+        using var testDirectory = new TemporaryDirectory();
+        var path = Path.Combine(testDirectory.Path, LocalCredentialProtector.MachineIdFileName);
+        File.WriteAllText(path, "persisted-machine-id");
+
+        var machineId = LocalCredentialProtector.GetOrCreatePersistedMachineId(testDirectory.Path);
+
+        machineId.Should().Be("persisted-machine-id");
+    }
+
+    [Fact]
+    public void GetOrCreatePersistedMachineId_WithLegacyMachineIdFile_ShouldMigrateValue()
+    {
+        using var testDirectory = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(testDirectory.Path, "local-machine-id"), "legacy-machine-id");
+
+        var machineId = LocalCredentialProtector.GetOrCreatePersistedMachineId(testDirectory.Path);
+
+        machineId.Should().Be("legacy-machine-id");
+        File.ReadAllText(Path.Combine(testDirectory.Path, LocalCredentialProtector.MachineIdFileName))
+            .Should().Be("legacy-machine-id");
+    }
+
+    [Fact]
+    public void GetOrCreatePersistedMachineId_WithoutExistingFile_ShouldCreateMachineIdFile()
+    {
+        using var testDirectory = new TemporaryDirectory();
+
+        var machineId = LocalCredentialProtector.GetOrCreatePersistedMachineId(testDirectory.Path);
+
+        machineId.Should().NotBeNullOrWhiteSpace();
+        File.ReadAllText(Path.Combine(testDirectory.Path, LocalCredentialProtector.MachineIdFileName))
+            .Should().Be(machineId);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"easydict-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/LocalCredentialProtectorTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/LocalCredentialProtectorTests.cs
@@ -90,6 +90,53 @@ public sealed class LocalCredentialProtectorTests
     }
 
     [Fact]
+    public void UnprotectOrReturnPlaintext_WithNestedProtectedValue_ShouldReturnPlaintextAndRequestMigration()
+    {
+        var innerProtectedValue = LocalCredentialProtector.Protect("sk-test-local-api-key");
+        var nestedProtectedValue = LocalCredentialProtector.Protect(innerProtectedValue);
+
+        var value = LocalCredentialProtector.UnprotectOrReturnPlaintext(
+            nestedProtectedValue,
+            "stable-machine-id",
+            out var needsMigration,
+            out var decryptFailed);
+
+        value.Should().Be("sk-test-local-api-key");
+        needsMigration.Should().BeTrue();
+        decryptFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryUnprotect_WithNestedProtectedValue_ShouldReturnFinalPlaintext()
+    {
+        var innerProtectedValue = LocalCredentialProtector.Protect("sk-test-local-api-key");
+        var nestedProtectedValue = LocalCredentialProtector.Protect(innerProtectedValue);
+
+        LocalCredentialProtector.TryUnprotect(nestedProtectedValue, out var unprotected)
+            .Should().BeTrue();
+        unprotected.Should().Be("sk-test-local-api-key");
+    }
+
+    [Fact]
+    public void UnprotectOrReturnPlaintext_WithTooManyNestedProtectedValues_ShouldFail()
+    {
+        var nestedValue = "sk-test-local-api-key";
+        for (var i = 0; i <= LocalCredentialProtector.MaxNestedProtectedValueDepth; i++)
+        {
+            nestedValue = LocalCredentialProtector.Protect(nestedValue);
+        }
+
+        var value = LocalCredentialProtector.UnprotectOrReturnPlaintext(
+            nestedValue,
+            "stable-machine-id",
+            out _,
+            out var decryptFailed);
+
+        value.Should().BeNull();
+        decryptFailed.Should().BeTrue();
+    }
+
+    [Fact]
     public void UnprotectOrReturnPlaintext_WithLegacyProtectedValue_ShouldRequestMigration()
     {
         var protectedValue = LocalCredentialProtector.ProtectLegacy(

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/LocalizationServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/LocalizationServiceTests.cs
@@ -150,6 +150,15 @@ public class LocalizationServiceTests
     [InlineData("EnableInternationalServices")]
     [InlineData("EnableInternationalServicesDescription")]
     [InlineData("InternationalServiceUnavailableHint")]
+    [InlineData("ServiceResult_PendingQueryStatus")]
+    [InlineData("ServiceResult_PendingQueryHint")]
+    [InlineData("ServiceResult_Checking")]
+    [InlineData("ServiceResult_Streaming")]
+    [InlineData("ServiceResult_NoResult")]
+    [InlineData("ServiceResult_Cached")]
+    [InlineData("ServiceResult_WaitingForResponse")]
+    [InlineData("ServiceResult_TranslationErrorTooltip")]
+    [InlineData("ServiceResult_Retry")]
     public void AllLanguages_HaveRequiredKey(string key)
     {
         foreach (var lang in SupportedLanguages)

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/MainPageLifecycleLeakTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/MainPageLifecycleLeakTests.cs
@@ -15,6 +15,11 @@ public class MainPageLifecycleLeakTests
     private static readonly string PhiSilicaPromptServicePath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Services", "PhiSilicaModelPreparationPromptService.cs");
     private static readonly string PhiSilicaPreparationCoordinatorPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Services", "PhiSilicaModelPreparationCoordinator.cs");
     private static readonly string ServiceResultViewHostPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "ServiceResultViewHost.cs");
+    private static readonly string ServiceResultStatusTextProviderPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "ServiceResultStatusTextProvider.cs");
+    private static readonly string ServiceResultItemXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "ServiceResultItem.xaml");
+    private static readonly string ServiceResultItemPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "ServiceResultItem.xaml.cs");
+    private static readonly string MinimalServiceResultItemXamlPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "MinimalServiceResultItem.xaml");
+    private static readonly string MinimalServiceResultItemPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Views", "Controls", "MinimalServiceResultItem.xaml.cs");
 
     [Fact]
     public void MainPage_ReleasesServiceResultControlsBeforeRebuild()
@@ -48,6 +53,78 @@ public class MainPageLifecycleLeakTests
             "profiling should be able to isolate MainPage result-panel rebuild costs");
         content.Should().Contain("InitializeServiceResults(skipRebuildWhenDebugFlagSet: true, reason: \"OnPageLoaded\");",
             "MainPage reload should explicitly opt into the debug rebuild-skip behavior");
+    }
+
+    [Fact]
+    public void MainPage_ReusesCachedResultControlsWhenServicesAreUnchanged()
+    {
+        var content = File.ReadAllText(MainPagePath);
+
+        content.Should().Contain("TryReuseServiceResultControls(descriptors, reason)",
+            "cached MainPage navigation should avoid releasing and recreating result controls when settings still match");
+        content.Should().Contain("InitializeServiceResults reused cached controls",
+            "reuse decisions should be explicit in DEBUG output");
+    }
+
+    [Fact]
+    public void MainPage_EntersTranslatingStateBeforeDetection()
+    {
+        var content = File.ReadAllText(MainPagePath);
+
+        content.Should().Contain("var translatingStatus = loc.GetString(\"StatusTranslating\");",
+            "SetLoading should use the localized translating status");
+        content.Should().Contain("UpdateStatus(null, translatingStatus);",
+            "the header status should show translating while a query is active");
+        content.Should().Contain("PrepareServiceResultsForQueryStart();",
+            "service rows should also enter their loading state before language detection can block");
+        content.Should().Contain("serviceResult.IsLoading = true;",
+            "auto-query service rows should show their StatusText loading label immediately");
+
+        var loadingIndex = content.IndexOf("SetLoading(true);", StringComparison.Ordinal);
+        var rowLoadingIndex = content.IndexOf("PrepareServiceResultsForQueryStart();", StringComparison.Ordinal);
+        var detectionIndex = content.IndexOf("DetectSourceLanguageForQueryAsync(inputText, detectionService, ct)", StringComparison.Ordinal);
+        loadingIndex.Should().BeGreaterThanOrEqualTo(0);
+        rowLoadingIndex.Should().BeGreaterThanOrEqualTo(0);
+        detectionIndex.Should().BeGreaterThanOrEqualTo(0);
+        loadingIndex.Should().BeLessThan(detectionIndex,
+            "clicking Translate or pressing Enter should enter the querying UI before language detection can block");
+        rowLoadingIndex.Should().BeLessThan(detectionIndex,
+            "service rows should show Translating before language detection can block");
+    }
+
+    [Fact]
+    public void ServiceRowsUseLocalizedStatusTextProvider()
+    {
+        var richControl = File.ReadAllText(ServiceResultItemPath);
+        var richXaml = File.ReadAllText(ServiceResultItemXamlPath);
+        var minimalControl = File.ReadAllText(MinimalServiceResultItemPath);
+        var minimalXaml = File.ReadAllText(MinimalServiceResultItemXamlPath);
+        var provider = File.ReadAllText(ServiceResultStatusTextProviderPath);
+
+        richControl.Should().Contain("StatusText.Text = ServiceResultStatusTextProvider.GetStatusText(_serviceResult);",
+            "rich service rows should localize StatusText from the UI layer");
+        minimalControl.Should().Contain("ServiceResultStatusTextProvider.GetStatusText(serviceResult)",
+            "minimal service rows should share the same localized status mapping");
+        provider.Should().Contain("StatusTranslating",
+            "translation loading rows should reuse the existing localized translating status");
+        provider.Should().Contain("ServiceResult_Checking",
+            "grammar checking rows should have a resource-backed status");
+        provider.Should().Contain("ServiceResult_WaitingForResponse",
+            "streaming placeholders should be resource-backed");
+        richControl.Should().NotContain("StatusText.Text = _serviceResult.StatusText;",
+            "model-layer status text is English-only and should not be displayed directly");
+        minimalControl.Should().NotContain("return serviceResult.StatusText;",
+            "model-layer status text is English-only and should not be displayed directly");
+        richControl.Should().NotContain("\"Click to query\"");
+        minimalControl.Should().NotContain("\"Click to query\"");
+        richControl.Should().NotContain("\"Waiting for response...\"");
+        minimalControl.Should().NotContain("\"Waiting for response...\"");
+        richXaml.Should().NotContain("Click header to query");
+        minimalXaml.Should().NotContain("Click header to query");
+        richControl.Should().NotContain("StatusText.Text = \"Loading\";",
+            "loading rows should not replace Translating... with a generic label");
+        minimalControl.Should().NotContain("return \"Loading\";",
+            "minimal rows should not replace Translating... with a generic label");
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/SettingsPageLifecycleLeakTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/SettingsPageLifecycleLeakTests.cs
@@ -171,6 +171,17 @@ public class SettingsPageLifecycleLeakTests
             "deferred I/O logging should distinguish dispatcher scheduling from actual cache execution");
     }
 
+    [Fact]
+    public void SettingsPage_LogsDeferredOnnxStartOnlyFromRunner()
+    {
+        var content = File.ReadAllText(SettingsPagePath);
+
+        content.Should().Contain("Deferred I/O: dispatching queued work",
+            "the queue callback should log dispatch instead of duplicating the runner's ONNX start message");
+        CountOccurrences(content, "Deferred I/O: begin UpdateOnnxModelStatus").Should().Be(1,
+            "only RunDeferredSettingsIo should emit the ONNX start marker");
+    }
+
     private static string FindProjectRoot()
     {
         var current = AppDomain.CurrentDomain.BaseDirectory;
@@ -186,5 +197,18 @@ public class SettingsPageLifecycleLeakTests
         }
 
         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..");
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
     }
 }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/SettingsServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/SettingsServiceTests.cs
@@ -3,6 +3,8 @@ using Easydict.WindowsAI;
 using Easydict.WinUI.Models;
 using Easydict.WinUI.Services;
 using FluentAssertions;
+using System.Reflection;
+using System.Text.Json;
 using Xunit;
 
 namespace Easydict.WinUI.Tests.Services;
@@ -21,6 +23,91 @@ public class SettingsServiceTests
     public SettingsServiceTests()
     {
         _settings = SettingsService.Instance;
+    }
+
+    [Fact]
+    public void Migration_ShouldPreserveAlreadyProtectedSensitiveSettings()
+    {
+        using var testDirectory = new TemporaryDirectory();
+        var settingsPath = Path.Combine(testDirectory.Path, "settings.json");
+        var alreadyProtected = LocalCredentialProtector.Protect("sk-already-protected");
+        var nestedProtected = LocalCredentialProtector.Protect(
+            LocalCredentialProtector.Protect("sk-nested-protected"));
+
+        File.WriteAllText(
+            settingsPath,
+            JsonSerializer.Serialize(
+                new Dictionary<string, object?>
+                {
+                    [nameof(SettingsService.OpenAIApiKey)] = alreadyProtected,
+                    [nameof(SettingsService.CustomOpenAIApiKey)] = nestedProtected,
+                    [nameof(SettingsService.DeepLApiKey)] = "plain-legacy-key"
+                },
+                new JsonSerializerOptions { WriteIndented = true }));
+
+        var previousSettingsDirectory = Environment.GetEnvironmentVariable("EASYDICT_SETTINGS_DIR");
+        try
+        {
+            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", testDirectory.Path);
+            CreateIsolatedSettingsService();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", previousSettingsDirectory);
+        }
+
+        using var migratedSettings = JsonDocument.Parse(File.ReadAllText(settingsPath));
+        var root = migratedSettings.RootElement;
+        var openAiValue = root.GetProperty(nameof(SettingsService.OpenAIApiKey)).GetString();
+        var customOpenAiValue = root.GetProperty(nameof(SettingsService.CustomOpenAIApiKey)).GetString();
+        var deepLValue = root.GetProperty(nameof(SettingsService.DeepLApiKey)).GetString();
+
+        openAiValue.Should().Be(alreadyProtected);
+        customOpenAiValue.Should().NotBe(nestedProtected);
+        customOpenAiValue.Should().StartWith("edcred1:user:");
+        var customOpenAiPlaintext = LocalCredentialProtector.UnprotectOrReturnPlaintext(
+            customOpenAiValue,
+            "stable-machine-id",
+            out var customOpenAiNeedsMigration,
+            out var customOpenAiDecryptFailed);
+        customOpenAiPlaintext.Should().Be("sk-nested-protected");
+        customOpenAiNeedsMigration.Should().BeFalse();
+        customOpenAiDecryptFailed.Should().BeFalse();
+        deepLValue.Should().NotBe("plain-legacy-key");
+        deepLValue.Should().StartWith("edcred1:user:");
+        LocalCredentialProtector.TryUnprotect(deepLValue!, out var migratedDeepL)
+            .Should().BeTrue();
+        migratedDeepL.Should().Be("plain-legacy-key");
+    }
+
+    [Fact]
+    public void Save_WithNoChanges_ShouldNotRewriteSettingsFile()
+    {
+        using var testDirectory = new TemporaryDirectory();
+        var settingsPath = Path.Combine(testDirectory.Path, "settings.json");
+        var previousSettingsDirectory = Environment.GetEnvironmentVariable("EASYDICT_SETTINGS_DIR");
+        SettingsService settings;
+        try
+        {
+            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", testDirectory.Path);
+            settings = CreateIsolatedSettingsService();
+            settings.OpenAIApiKey = "sk-stable-no-rewrite";
+            settings.Save();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", previousSettingsDirectory);
+        }
+
+        var savedJson = File.ReadAllText(settingsPath);
+        var fixedTimestamp = new DateTime(2024, 01, 01, 00, 00, 00, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(settingsPath, fixedTimestamp);
+        var unchangedTimestamp = File.GetLastWriteTimeUtc(settingsPath);
+
+        settings.Save();
+
+        File.ReadAllText(settingsPath).Should().Be(savedJson);
+        File.GetLastWriteTimeUtc(settingsPath).Should().Be(unchangedTimestamp);
     }
 
     [Fact]
@@ -846,4 +933,42 @@ public class SettingsServiceTests
     }
 
     #endregion
+
+    private static SettingsService CreateIsolatedSettingsService()
+    {
+        var constructor = typeof(SettingsService).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            Type.EmptyTypes,
+            modifiers: null);
+
+        constructor.Should().NotBeNull();
+        return (SettingsService)constructor!.Invoke(null);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "Easydict.WinUI.Tests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup only.
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fix https://github.com/xiaocang/easydict_win32/issues/157

Bind settings tab brushes to per-item properties resolved from the active theme so switching themes repaints tabs without an app restart, and walk the settings page visual tree to reapply card/combo/text input chrome. Also harden ScrollHelper against InvalidOperationException from ScrollPattern and missing clickable points by falling back to mouse scroll over the element center.