### PR TITLE
feat(grammar): pin grammar-capable services in correction mode instead of hiding others

### DIFF
--- a/dotnet/src/Easydict.TranslationService/Models/ServiceQueryResult.cs
+++ b/dotnet/src/Easydict.TranslationService/Models/ServiceQueryResult.cs
@@ -37,6 +37,13 @@ public sealed class ServiceQueryResult : INotifyPropertyChanged
     public string ServiceIconPath => $"ms-appx:///Assets/ServiceIcons/{ServiceId}.png";
 
     /// <summary>
+    /// Whether this service is capable of grammar correction for the source
+    /// language under which this row was initialized. Set once at row creation
+    /// time by the window's InitializeServiceResults().
+    /// </summary>
+    public bool IsGrammarCapable { get; init; }
+
+    /// <summary>
     /// The translation result if successful.
     /// </summary>
     public TranslationResult? Result

--- a/dotnet/src/Easydict.WinUI/Services/ServiceResultDemotionHelper.cs
+++ b/dotnet/src/Easydict.WinUI/Services/ServiceResultDemotionHelper.cs
@@ -42,4 +42,42 @@ internal static class ServiceResultDemotionHelper
         kept.AddRange(demoted);
         return kept;
     }
+
+    /// <summary>
+    /// Stable partition with optional grammar-capable pinning. When
+    /// <paramref name="pinGrammarCapable"/> is true (correction mode active),
+    /// produces a four-bucket order:
+    /// grammar+kept → non-grammar+kept → grammar+demoted → non-grammar+demoted.
+    /// Order within each bucket follows the input order.
+    /// When false, falls back to the two-bucket overload.
+    /// </summary>
+    public static IReadOnlyList<int> StablePartitionIndices(
+        IReadOnlyList<ServiceQueryResult> results,
+        bool hideEmptySetting,
+        bool pinGrammarCapable)
+    {
+        if (!pinGrammarCapable)
+        {
+            return StablePartitionIndices(results, hideEmptySetting);
+        }
+
+        var grammarKept = new List<int>();
+        var otherKept = new List<int>();
+        var grammarDemoted = new List<int>();
+        var otherDemoted = new List<int>();
+        for (int i = 0; i < results.Count; i++)
+        {
+            var r = results[i];
+            var demoted = IsDemoted(r, hideEmptySetting);
+            var grammar = r?.IsGrammarCapable == true;
+            if (!demoted && grammar) grammarKept.Add(i);
+            else if (!demoted) otherKept.Add(i);
+            else if (grammar) grammarDemoted.Add(i);
+            else otherDemoted.Add(i);
+        }
+        grammarKept.AddRange(otherKept);
+        grammarKept.AddRange(grammarDemoted);
+        grammarKept.AddRange(otherDemoted);
+        return grammarKept;
+    }
 }

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultViewHost.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultViewHost.cs
@@ -123,14 +123,16 @@ internal static class ServiceResultViewHost
         IReadOnlyList<ServiceQueryResult> results,
         IReadOnlyList<IServiceResultView> controls,
         ItemsControl resultsPanel,
-        bool hideEmptySetting)
+        bool hideEmptySetting,
+        bool pinGrammarCapable = false)
     {
         if (controls.Count == 0)
         {
             return;
         }
 
-        var order = ServiceResultDemotionHelper.StablePartitionIndices(results, hideEmptySetting);
+        var order = ServiceResultDemotionHelper.StablePartitionIndices(
+            results, hideEmptySetting, pinGrammarCapable);
 
         var orderMatches = resultsPanel.Items.Count == controls.Count;
         for (int i = 0; orderMatches && i < order.Count; i++)

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -328,10 +328,8 @@ public sealed partial class FixedWindow : Window
                 ? service.DisplayName
                 : serviceId;
 
-            if (_currentMode == QueryMode.GrammarCorrection &&
-                (service is null ||
-                 !GrammarCorrectionServiceAvailability.IsAvailable(service, grammarSourceLanguage)))
-                continue;
+            var isGrammarCapable = service is not null
+                && GrammarCorrectionServiceAvailability.IsAvailable(service, grammarSourceLanguage);
 
             // Get EnabledQuery setting (default true if not found)
             var enabledQuery = enabledQuerySettings.TryGetValue(serviceId, out var eq) ? eq : true;
@@ -342,7 +340,8 @@ public sealed partial class FixedWindow : Window
                 ServiceDisplayName = displayName,
                 EnabledQuery = enabledQuery,
                 IsExpanded = enabledQuery, // Manual-query services start collapsed
-                CurrentMode = _currentMode
+                CurrentMode = _currentMode,
+                IsGrammarCapable = isGrammarCapable,
             };
 
             _serviceResults.Add(result);
@@ -567,7 +566,8 @@ public sealed partial class FixedWindow : Window
                 HasEnabledGrammarCorrectionService(detectedLanguage));
             serviceResult.CurrentMode = resolution.EffectiveMode;
 
-            if (resolution.EffectiveMode == QueryMode.GrammarCorrection)
+            if (resolution.EffectiveMode == QueryMode.GrammarCorrection
+                && serviceResult.IsGrammarCapable)
             {
                 var grammarRequest = new GrammarCorrectionRequest
                 {
@@ -987,7 +987,8 @@ public sealed partial class FixedWindow : Window
 
             if (resolution.EffectiveMode == QueryMode.GrammarCorrection)
             {
-                await StartGrammarCorrectionInternalAsync(inputText, detectedLanguage, ct);
+                await StartGrammarCorrectionInternalAsync(
+                    inputText, detectedLanguage, targetLanguage, ct);
                 return;
             }
 
@@ -1156,23 +1157,35 @@ public sealed partial class FixedWindow : Window
     }
 
     /// <summary>
-    /// Execute grammar correction for all enabled LLM services in parallel.
+    /// Execute the correction-mode query in parallel. Grammar-capable services
+    /// run grammar correction; remaining services fall back to normal translation
+    /// using the user-selected target language.
     /// </summary>
     private async Task StartGrammarCorrectionInternalAsync(
         string inputText,
         TranslationLanguage detectedLang,
+        TranslationLanguage targetLanguage,
         CancellationToken ct)
     {
-        var request = new GrammarCorrectionRequest
+        var grammarRequest = new GrammarCorrectionRequest
         {
             Text = inputText,
             Language = detectedLang,
             IncludeExplanations = _settings.GrammarIncludeExplanations,
         };
 
+        var translationRequest = new TranslationRequest
+        {
+            Text = inputText,
+            FromLanguage = detectedLang,
+            ToLanguage = targetLanguage,
+        };
+
         var tasks = _serviceResults
             .Where(sr => sr.EnabledQuery)
-            .Select(sr => ExecuteGrammarCorrectionForServiceAsync(sr, request, ct))
+            .Select(sr => sr.IsGrammarCapable
+                ? ExecuteGrammarCorrectionForServiceAsync(sr, grammarRequest, ct)
+                : ExecuteTranslationForServiceAsync(sr, translationRequest, detectedLang, targetLanguage, ct))
             .ToArray();
 
         var taskResults = await Task.WhenAll(tasks);
@@ -1184,6 +1197,93 @@ public sealed partial class FixedWindow : Window
         StatusText.Text = successCount > 0
             ? string.Format(loc.GetString("ServiceResultsComplete") ?? "{0} service(s) completed", successCount)
             : errorCount > 0 ? (loc.GetString("TranslationFailed") ?? "Check failed") : "";
+    }
+
+    /// <summary>
+    /// Execute regular translation for a single service inside the mixed
+    /// correction-mode flow. Mirrors <see cref="ExecuteGrammarCorrectionForServiceAsync"/>'s
+    /// return contract: true on success, false on error, null on cancelled/skipped.
+    /// </summary>
+    private async Task<bool?> ExecuteTranslationForServiceAsync(
+        ServiceQueryResult serviceResult,
+        TranslationRequest request,
+        TranslationLanguage detectedLanguage,
+        TranslationLanguage targetLanguage,
+        CancellationToken ct)
+    {
+        serviceResult.MarkQueried();
+
+        try
+        {
+            using var handle = TranslationManagerService.Instance.AcquireHandle();
+            var manager = handle.Manager;
+
+            if (manager.IsStreamingService(serviceResult.ServiceId))
+            {
+                await ExecuteStreamingTranslationForServiceAsync(
+                    manager, serviceResult, request, detectedLanguage, targetLanguage, ct);
+                return true;
+            }
+
+            var result = await Task.Run(
+                () => manager.TranslateAsync(request, ct, serviceResult.ServiceId), ct);
+
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                serviceResult.Result = result;
+                serviceResult.IsLoading = false;
+                serviceResult.ApplyAutoCollapseLogic();
+                UpdatePhoneticDeduplication();
+                ReorderResultsPanel();
+                RequestResize();
+            });
+
+            return result.ResultKind == TranslationResultKind.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                serviceResult.IsLoading = false;
+                serviceResult.IsStreaming = false;
+                serviceResult.ClearQueried();
+            });
+            return null;
+        }
+        catch (TranslationException ex)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                serviceResult.Error = ex;
+                serviceResult.IsLoading = false;
+                serviceResult.IsStreaming = false;
+                serviceResult.ApplyAutoCollapseLogic();
+                RequestResize();
+            });
+            SettingsService.Instance.ClearServiceTestStatus(serviceResult.ServiceId);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                serviceResult.Error = new TranslationException(ex.Message, ex)
+                {
+                    ErrorCode = TranslationErrorCode.Unknown,
+                    ServiceId = serviceResult.ServiceId,
+                };
+                serviceResult.IsLoading = false;
+                serviceResult.IsStreaming = false;
+                serviceResult.ApplyAutoCollapseLogic();
+                RequestResize();
+            });
+            SettingsService.Instance.ClearServiceTestStatus(serviceResult.ServiceId);
+            return false;
+        }
     }
 
     /// <summary>
@@ -1855,7 +1955,8 @@ public sealed partial class FixedWindow : Window
             _serviceResults,
             _resultControls,
             ResultsPanel,
-            SettingsService.Instance.HideEmptyServiceResults);
+            SettingsService.Instance.HideEmptyServiceResults,
+            pinGrammarCapable: _currentMode == QueryMode.GrammarCorrection);
     }
 
     private void OnHideEmptyServiceResultsChanged(object? sender, EventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -1135,21 +1135,14 @@ namespace Easydict.WinUI.Views
             {
                 // Use service-provided DisplayName, fallback to serviceId if not found
                 var displayName = serviceId;
-                if (manager.Services.TryGetValue(serviceId, out var service))
+                ITranslationService? service = null;
+                if (manager.Services.TryGetValue(serviceId, out service))
                 {
                     displayName = service.DisplayName;
+                }
 
-                    // In grammar correction, only show services that can correct grammar.
-                    if (_currentQuickQueryMode == QueryMode.GrammarCorrection &&
-                        !GrammarCorrectionServiceAvailability.IsAvailable(service, grammarSourceLanguage))
-                    {
-                        continue;
-                    }
-                }
-                else if (_currentQuickQueryMode == QueryMode.GrammarCorrection)
-                {
-                    continue;
-                }
+                var isGrammarCapable = service is not null
+                    && GrammarCorrectionServiceAvailability.IsAvailable(service, grammarSourceLanguage);
 
                 // Get EnabledQuery setting (default true if not found)
                 var enabledQuery = enabledQuerySettings.TryGetValue(serviceId, out var eq) ? eq : true;
@@ -1160,7 +1153,8 @@ namespace Easydict.WinUI.Views
                     ServiceDisplayName = displayName,
                     EnabledQuery = enabledQuery,
                     IsExpanded = enabledQuery, // Manual-query services start collapsed
-                    CurrentMode = _currentQuickQueryMode
+                    CurrentMode = _currentQuickQueryMode,
+                    IsGrammarCapable = isGrammarCapable,
                 };
 
                 _serviceResults.Add(result);
@@ -1273,7 +1267,8 @@ namespace Easydict.WinUI.Views
                 _serviceResults,
                 _resultControls,
                 ResultsPanel,
-                SettingsService.Instance.HideEmptyServiceResults);
+                SettingsService.Instance.HideEmptyServiceResults,
+                pinGrammarCapable: _currentQuickQueryMode == QueryMode.GrammarCorrection);
         }
 
         private void OnHideEmptyServiceResultsChanged(object? sender, EventArgs e)
@@ -1530,8 +1525,10 @@ namespace Easydict.WinUI.Views
                     HasEnabledGrammarCorrectionService(detectedLanguage));
                 serviceResult.CurrentMode = resolution.EffectiveMode;
 
-                // Grammar mode: route to grammar correction instead of translation
-                if (resolution.EffectiveMode == QueryMode.GrammarCorrection)
+                // Grammar mode: route to grammar correction for capable services only.
+                // Non-grammar-capable services fall through to normal translation below.
+                if (resolution.EffectiveMode == QueryMode.GrammarCorrection
+                    && serviceResult.IsGrammarCapable)
                 {
                     var grammarRequest = new GrammarCorrectionRequest
                     {
@@ -1946,7 +1943,8 @@ namespace Easydict.WinUI.Views
                 // Route based on effective quick-query mode
                 if (resolution.EffectiveMode == QueryMode.GrammarCorrection)
                 {
-                    await StartGrammarCorrectionInternalAsync(inputText, detectedLanguage, ct);
+                    await StartGrammarCorrectionInternalAsync(
+                        inputText, detectedLanguage, targetLanguage, ct);
                     return;
                 }
 
@@ -2163,25 +2161,35 @@ namespace Easydict.WinUI.Views
         }
 
         /// <summary>
-        /// Execute grammar correction for all enabled LLM services in parallel.
-        /// Bypasses the translation pipeline entirely — no TargetLanguageSelector, no TranslationManager.
+        /// Execute the correction-mode query in parallel. Grammar-capable services
+        /// run grammar correction; remaining services fall back to normal translation
+        /// using the user-selected target language.
         /// </summary>
         private async Task StartGrammarCorrectionInternalAsync(
             string inputText,
             TranslationLanguage detectedLang,
+            TranslationLanguage targetLanguage,
             CancellationToken ct)
         {
-            var request = new GrammarCorrectionRequest
+            var grammarRequest = new GrammarCorrectionRequest
             {
                 Text = inputText,
                 Language = detectedLang,
                 IncludeExplanations = _settings.GrammarIncludeExplanations,
             };
 
-            // Parallel-execute all grammar-capable services
+            var translationRequest = new TranslationRequest
+            {
+                Text = inputText,
+                FromLanguage = detectedLang,
+                ToLanguage = targetLanguage,
+            };
+
             var tasks = _serviceResults
                 .Where(sr => sr.EnabledQuery)
-                .Select(sr => ExecuteGrammarCorrectionForServiceAsync(sr, request, ct))
+                .Select(sr => sr.IsGrammarCapable
+                    ? ExecuteGrammarCorrectionForServiceAsync(sr, grammarRequest, ct)
+                    : ExecuteTranslationForServiceAsync(sr, translationRequest, detectedLang, targetLanguage, ct))
                 .ToArray();
 
             var taskResults = await Task.WhenAll(tasks);
@@ -2213,6 +2221,105 @@ namespace Easydict.WinUI.Views
                     UpdateStatus(true, loc.GetString("StatusReady"));
                 }
             });
+        }
+
+        /// <summary>
+        /// Execute regular translation for a single service inside the mixed
+        /// correction-mode flow. Mirrors <see cref="ExecuteGrammarCorrectionForServiceAsync"/>'s
+        /// return contract: true on success, false on error, null on cancelled/skipped.
+        /// </summary>
+        private async Task<bool?> ExecuteTranslationForServiceAsync(
+            ServiceQueryResult serviceResult,
+            TranslationRequest request,
+            TranslationLanguage detectedLanguage,
+            TranslationLanguage targetLanguage,
+            CancellationToken ct)
+        {
+            serviceResult.MarkQueried();
+
+            try
+            {
+                using var handle = TranslationManagerService.Instance.AcquireHandle();
+                var manager = handle.Manager;
+
+                if (manager.IsStreamingService(serviceResult.ServiceId))
+                {
+                    await ExecuteStreamingTranslationForServiceAsync(
+                        manager, serviceResult, request, detectedLanguage, targetLanguage, ct);
+                    return true;
+                }
+
+                var result = await Task.Run(
+                    () => manager.TranslateAsync(request, ct, serviceResult.ServiceId), ct);
+
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (_isClosing) return;
+                    serviceResult.Result = result;
+                    serviceResult.IsLoading = false;
+                    serviceResult.ApplyAutoCollapseLogic();
+                    UpdatePhoneticDeduplication();
+                    ReorderResultsPanel();
+                    RefreshServiceResultView(serviceResult);
+
+                    if (result.ResultKind == TranslationResultKind.Success &&
+                        !_hasAutoPlayedCurrentQuery && SettingsService.Instance.AutoPlayTranslation)
+                    {
+                        var targetText = result.TranslatedText;
+                        if (!string.IsNullOrEmpty(targetText))
+                        {
+                            _hasAutoPlayedCurrentQuery = true;
+                            _ = TextToSpeechService.Instance.SpeakAsync(targetText, targetLanguage);
+                        }
+                    }
+                });
+
+                return result.ResultKind == TranslationResultKind.Success;
+            }
+            catch (OperationCanceledException)
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (_isClosing) return;
+                    serviceResult.IsLoading = false;
+                    serviceResult.IsStreaming = false;
+                    serviceResult.ClearQueried();
+                    RefreshServiceResultView(serviceResult);
+                });
+                return null;
+            }
+            catch (TranslationException ex)
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (_isClosing) return;
+                    serviceResult.Error = ex;
+                    serviceResult.IsLoading = false;
+                    serviceResult.IsStreaming = false;
+                    serviceResult.ApplyAutoCollapseLogic();
+                    RefreshServiceResultView(serviceResult);
+                });
+                SettingsService.Instance.ClearServiceTestStatus(serviceResult.ServiceId);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (_isClosing) return;
+                    serviceResult.Error = new TranslationException(ex.Message, ex)
+                    {
+                        ErrorCode = TranslationErrorCode.Unknown,
+                        ServiceId = serviceResult.ServiceId,
+                    };
+                    serviceResult.IsLoading = false;
+                    serviceResult.IsStreaming = false;
+                    serviceResult.ApplyAutoCollapseLogic();
+                    RefreshServiceResultView(serviceResult);
+                });
+                SettingsService.Instance.ClearServiceTestStatus(serviceResult.ServiceId);
+                return false;
+            }
         }
 
         /// <summary>

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -369,11 +369,8 @@ public sealed partial class MiniWindow : Window
                 ? service.DisplayName
                 : serviceId;
 
-            // In grammar mode, only show configured services that can correct grammar.
-            if (_currentMode == QueryMode.GrammarCorrection &&
-                (service is null ||
-                 !GrammarCorrectionServiceAvailability.IsAvailable(service, grammarSourceLanguage)))
-                continue;
+            var isGrammarCapable = service is not null
+                && GrammarCorrectionServiceAvailability.IsAvailable(service, grammarSourceLanguage);
 
             // Get EnabledQuery setting (default true if not found)
             var enabledQuery = enabledQuerySettings.TryGetValue(serviceId, out var eq) ? eq : true;
@@ -384,7 +381,8 @@ public sealed partial class MiniWindow : Window
                 ServiceDisplayName = displayName,
                 EnabledQuery = enabledQuery,
                 IsExpanded = enabledQuery, // Manual-query services start collapsed
-                CurrentMode = _currentMode
+                CurrentMode = _currentMode,
+                IsGrammarCapable = isGrammarCapable,
             };
 
             _serviceResults.Add(result);
@@ -617,8 +615,10 @@ public sealed partial class MiniWindow : Window
                 HasEnabledGrammarCorrectionService(detectedLanguage));
             serviceResult.CurrentMode = resolution.EffectiveMode;
 
-            // Grammar mode: route to grammar correction instead of translation
-            if (resolution.EffectiveMode == QueryMode.GrammarCorrection)
+            // Grammar mode: route to grammar correction for capable services only.
+            // Non-grammar-capable services fall through to normal translation below.
+            if (resolution.EffectiveMode == QueryMode.GrammarCorrection
+                && serviceResult.IsGrammarCapable)
             {
                 var grammarRequest = new GrammarCorrectionRequest
                 {
@@ -1154,7 +1154,8 @@ public sealed partial class MiniWindow : Window
             // Route based on effective quick-query mode
             if (resolution.EffectiveMode == QueryMode.GrammarCorrection)
             {
-                await StartGrammarCorrectionInternalAsync(inputText, detectedLanguage, ct);
+                await StartGrammarCorrectionInternalAsync(
+                    inputText, detectedLanguage, targetLanguage, ct);
                 return;
             }
 
@@ -1345,24 +1346,35 @@ public sealed partial class MiniWindow : Window
     }
 
     /// <summary>
-    /// Execute grammar correction for all enabled LLM services in parallel.
-    /// Bypasses the translation pipeline entirely.
+    /// Execute the correction-mode query in parallel. Grammar-capable services
+    /// run grammar correction; remaining services fall back to normal translation
+    /// using the user-selected target language.
     /// </summary>
     private async Task StartGrammarCorrectionInternalAsync(
         string inputText,
         TranslationLanguage detectedLang,
+        TranslationLanguage targetLanguage,
         CancellationToken ct)
     {
-        var request = new GrammarCorrectionRequest
+        var grammarRequest = new GrammarCorrectionRequest
         {
             Text = inputText,
             Language = detectedLang,
             IncludeExplanations = _settings.GrammarIncludeExplanations,
         };
 
+        var translationRequest = new TranslationRequest
+        {
+            Text = inputText,
+            FromLanguage = detectedLang,
+            ToLanguage = targetLanguage,
+        };
+
         var tasks = _serviceResults
             .Where(sr => sr.EnabledQuery)
-            .Select(sr => ExecuteGrammarCorrectionForServiceAsync(sr, request, ct))
+            .Select(sr => sr.IsGrammarCapable
+                ? ExecuteGrammarCorrectionForServiceAsync(sr, grammarRequest, ct)
+                : ExecuteTranslationForServiceAsync(sr, translationRequest, detectedLang, targetLanguage, ct))
             .ToArray();
 
         var taskResults = await Task.WhenAll(tasks);
@@ -1374,6 +1386,93 @@ public sealed partial class MiniWindow : Window
         StatusText.Text = successCount > 0
             ? string.Format(loc.GetString("ServiceResultsComplete") ?? "{0} service(s) completed", successCount)
             : errorCount > 0 ? (loc.GetString("TranslationFailed") ?? "Check failed") : "";
+    }
+
+    /// <summary>
+    /// Execute regular translation for a single service inside the mixed
+    /// correction-mode flow. Mirrors <see cref="ExecuteGrammarCorrectionForServiceAsync"/>'s
+    /// return contract: true on success, false on error, null on cancelled/skipped.
+    /// </summary>
+    private async Task<bool?> ExecuteTranslationForServiceAsync(
+        ServiceQueryResult serviceResult,
+        TranslationRequest request,
+        TranslationLanguage detectedLanguage,
+        TranslationLanguage targetLanguage,
+        CancellationToken ct)
+    {
+        serviceResult.MarkQueried();
+
+        try
+        {
+            using var handle = TranslationManagerService.Instance.AcquireHandle();
+            var manager = handle.Manager;
+
+            if (manager.IsStreamingService(serviceResult.ServiceId))
+            {
+                await ExecuteStreamingTranslationForServiceAsync(
+                    manager, serviceResult, request, detectedLanguage, targetLanguage, ct);
+                return true;
+            }
+
+            var result = await Task.Run(
+                () => manager.TranslateAsync(request, ct, serviceResult.ServiceId), ct);
+
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                serviceResult.Result = result;
+                serviceResult.IsLoading = false;
+                serviceResult.ApplyAutoCollapseLogic();
+                UpdatePhoneticDeduplication();
+                ReorderResultsPanel();
+                RequestResize();
+            });
+
+            return result.ResultKind == TranslationResultKind.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                serviceResult.IsLoading = false;
+                serviceResult.IsStreaming = false;
+                serviceResult.ClearQueried();
+            });
+            return null;
+        }
+        catch (TranslationException ex)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                serviceResult.Error = ex;
+                serviceResult.IsLoading = false;
+                serviceResult.IsStreaming = false;
+                serviceResult.ApplyAutoCollapseLogic();
+                RequestResize();
+            });
+            SettingsService.Instance.ClearServiceTestStatus(serviceResult.ServiceId);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosing) return;
+                serviceResult.Error = new TranslationException(ex.Message, ex)
+                {
+                    ErrorCode = TranslationErrorCode.Unknown,
+                    ServiceId = serviceResult.ServiceId,
+                };
+                serviceResult.IsLoading = false;
+                serviceResult.IsStreaming = false;
+                serviceResult.ApplyAutoCollapseLogic();
+                RequestResize();
+            });
+            SettingsService.Instance.ClearServiceTestStatus(serviceResult.ServiceId);
+            return false;
+        }
     }
 
     /// <summary>
@@ -2161,7 +2260,8 @@ public sealed partial class MiniWindow : Window
             _serviceResults,
             _resultControls,
             ResultsPanel,
-            SettingsService.Instance.HideEmptyServiceResults);
+            SettingsService.Instance.HideEmptyServiceResults,
+            pinGrammarCapable: _currentMode == QueryMode.GrammarCorrection);
     }
 
     private void OnHideEmptyServiceResultsChanged(object? sender, EventArgs e)

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/ServiceResultDemotionHelperTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/ServiceResultDemotionHelperTests.cs
@@ -12,13 +12,15 @@ public class ServiceResultDemotionHelperTests
         TranslationResultKind? kind = TranslationResultKind.NoResult,
         bool isLoading = false,
         bool isStreaming = false,
-        bool hasError = false)
+        bool hasError = false,
+        bool isGrammarCapable = false)
     {
         var r = new ServiceQueryResult
         {
             ServiceId = "test",
             IsLoading = isLoading,
             IsStreaming = isStreaming,
+            IsGrammarCapable = isGrammarCapable,
         };
         if (hasError)
         {
@@ -126,5 +128,80 @@ public class ServiceResultDemotionHelperTests
         var reordered = first.Select(i => results[i]).ToArray();
         var second = ServiceResultDemotionHelper.StablePartitionIndices(reordered, hideEmptySetting: true);
         second.Should().Equal(new[] { 0, 1, 2 });
+    }
+
+    [Fact]
+    public void StablePartitionIndices_PinsGrammarCapableFirst_PreservesOrderWithinBuckets()
+    {
+        var results = new[]
+        {
+            MakeResult(TranslationResultKind.Success, isGrammarCapable: false), // 0 non-grammar
+            MakeResult(TranslationResultKind.Success, isGrammarCapable: true),  // 1 grammar
+            MakeResult(TranslationResultKind.Success, isGrammarCapable: false), // 2 non-grammar
+            MakeResult(TranslationResultKind.Success, isGrammarCapable: true),  // 3 grammar
+        };
+
+        var order = ServiceResultDemotionHelper.StablePartitionIndices(
+            results, hideEmptySetting: false, pinGrammarCapable: true);
+
+        order.Should().Equal(new[] { 1, 3, 0, 2 });
+    }
+
+    [Fact]
+    public void StablePartitionIndices_LayersDemotionUnderGrammarPinning()
+    {
+        var results = new[]
+        {
+            MakeResult(TranslationResultKind.Success,  isGrammarCapable: false), // 0 NG kept
+            MakeResult(TranslationResultKind.NoResult, isGrammarCapable: true),  // 1 G  demoted
+            MakeResult(TranslationResultKind.Success,  isGrammarCapable: true),  // 2 G  kept
+            MakeResult(TranslationResultKind.NoResult, isGrammarCapable: false), // 3 NG demoted
+            MakeResult(TranslationResultKind.Success,  isGrammarCapable: true),  // 4 G  kept
+            MakeResult(TranslationResultKind.NoResult, isGrammarCapable: true),  // 5 G  demoted
+        };
+
+        var order = ServiceResultDemotionHelper.StablePartitionIndices(
+            results, hideEmptySetting: true, pinGrammarCapable: true);
+
+        // Four buckets: G-kept, NG-kept, G-demoted, NG-demoted
+        order.Should().Equal(new[] { 2, 4, 0, 1, 5, 3 });
+    }
+
+    [Fact]
+    public void StablePartitionIndices_FallsBackToTwoBucketWhenPinDisabled()
+    {
+        var results = new[]
+        {
+            MakeResult(TranslationResultKind.Success,  isGrammarCapable: false), // 0 kept
+            MakeResult(TranslationResultKind.NoResult, isGrammarCapable: true),  // 1 demoted
+            MakeResult(TranslationResultKind.Success,  isGrammarCapable: true),  // 2 kept
+            MakeResult(TranslationResultKind.NoResult, isGrammarCapable: false), // 3 demoted
+        };
+
+        var order = ServiceResultDemotionHelper.StablePartitionIndices(
+            results, hideEmptySetting: true, pinGrammarCapable: false);
+
+        // Grammar capability ignored; only demotion partitions.
+        order.Should().Equal(new[] { 0, 2, 1, 3 });
+    }
+
+    [Fact]
+    public void StablePartitionIndices_GrammarPinning_Idempotent()
+    {
+        var results = new[]
+        {
+            MakeResult(TranslationResultKind.Success,  isGrammarCapable: false),
+            MakeResult(TranslationResultKind.NoResult, isGrammarCapable: true),
+            MakeResult(TranslationResultKind.Success,  isGrammarCapable: true),
+            MakeResult(TranslationResultKind.NoResult, isGrammarCapable: false),
+        };
+
+        var first = ServiceResultDemotionHelper.StablePartitionIndices(
+            results, hideEmptySetting: true, pinGrammarCapable: true);
+        var reordered = first.Select(i => results[i]).ToArray();
+        var second = ServiceResultDemotionHelper.StablePartitionIndices(
+            reordered, hideEmptySetting: true, pinGrammarCapable: true);
+
+        second.Should().Equal(new[] { 0, 1, 2, 3 });
     }
 }


### PR DESCRIPTION
In correction mode, all enabled services now stay visible: grammar-capable
services are pinned to the top and run grammar correction, while other
services fall back to normal translation using the user-selected target
language. Existing HideEmptyServiceResults demotion still applies, layered
under the grammar pinning (four buckets: grammar+kept, non-grammar+kept,
grammar+demoted, non-grammar+demoted).

- Add IsGrammarCapable init-only flag on ServiceQueryResult, set once at
  row creation time so the demotion helper stays decoupled from
  TranslationManager.
- Add three-arg StablePartitionIndices overload on ServiceResultDemotionHelper
  and propagate pinGrammarCapable through ServiceResultViewHost.Reorder.
- Stop filtering non-grammar services out of MainPage / FixedWindow /
  MiniWindow result lists in correction mode; instead split execution by
  capability inside StartGrammarCorrectionInternalAsync (grammar
  correction vs. ExecuteTranslationForServiceAsync) and branch
  per-service in the manual single-service query path.
- Cover the new partition behavior in ServiceResultDemotionHelperTests.

https://claude.ai/code/session_01HMJoWK6E7MQT3P43tvMj4w