### PR TITLE
Fix clipboard restore logic and add retry mechanism (issue #168)

### DIFF
--- a/dotnet/scripts/memory/Invoke-PrMemoryGate.ps1
+++ b/dotnet/scripts/memory/Invoke-PrMemoryGate.ps1
@@ -115,14 +115,51 @@ function Wait-File([string]$Path, [int]$TimeoutSeconds, $GuardProcess) {
 }
 
 function Get-ProcessCounterInstance([int]$ProcessId) {
-    $counter = Get-Counter "\Process(*)\ID Process"
-    foreach ($sample in $counter.CounterSamples) {
-        if ([int]$sample.CookedValue -ne $ProcessId) {
-            continue
+    # Get-Counter "\Process(*)\ID Process" snapshots every process at once. On busy
+    # CI runners a process can exit while the snapshot is being taken, which makes the
+    # whole call fail with "The data in one of the performance counter samples is not
+    # valid" (and with $ErrorActionPreference='Stop' that aborts the entire gate).
+    # Retry the snapshot a few times and skip individual invalid samples instead of
+    # letting one transient bad sample fail the run.
+    $attempts = 5
+    for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+        $counter = $null
+        try {
+            $counter = Get-Counter "\Process(*)\ID Process" -ErrorAction Stop
+        }
+        catch {
+            Write-Warning "Get-ProcessCounterInstance: Get-Counter attempt $attempt/$attempts failed: $($_.Exception.Message)"
+            $counter = $null
         }
 
-        if ($sample.Path -match "\\Process\((?<name>.+)\)\\ID Process$") {
-            return $Matches["name"]
+        if ($null -ne $counter) {
+            foreach ($sample in $counter.CounterSamples) {
+                # Skip samples whose data is invalid (Status != 0); reading CookedValue
+                # on those is what raises the "performance counter sample is not valid" error.
+                if ($sample.Status -ne 0) {
+                    continue
+                }
+
+                $samplePid = $null
+                try {
+                    $samplePid = [int]$sample.CookedValue
+                }
+                catch {
+                    continue
+                }
+
+                if ($samplePid -ne $ProcessId) {
+                    continue
+                }
+
+                if ($sample.Path -match "\\Process\((?<name>.+)\)\\ID Process$") {
+                    return $Matches["name"]
+                }
+            }
+        }
+
+        if ($attempt -lt $attempts) {
+            Start-Sleep -Milliseconds 500
         }
     }
 

--- a/dotnet/src/Easydict.WinUI/Services/TextInsertionService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TextInsertionService.cs
@@ -193,20 +193,24 @@ public static class TextInsertionService
         // Ctrl down
         inputs[0].type = INPUT_KEYBOARD;
         inputs[0].U.ki.wVk = VK_CONTROL;
+        inputs[0].U.ki.dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY;
 
         // V down
         inputs[1].type = INPUT_KEYBOARD;
         inputs[1].U.ki.wVk = VK_V;
+        inputs[1].U.ki.dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY;
 
         // V up
         inputs[2].type = INPUT_KEYBOARD;
         inputs[2].U.ki.wVk = VK_V;
         inputs[2].U.ki.dwFlags = KEYEVENTF_KEYUP;
+        inputs[2].U.ki.dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY;
 
         // Ctrl up
         inputs[3].type = INPUT_KEYBOARD;
         inputs[3].U.ki.wVk = VK_CONTROL;
         inputs[3].U.ki.dwFlags = KEYEVENTF_KEYUP;
+        inputs[3].U.ki.dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY;
 
         var inputSize = Marshal.SizeOf<INPUT>();
         uint result = SendInput(4, inputs, inputSize);

--- a/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
@@ -540,22 +540,30 @@ public static class TextSelectionService
                 return (null, ClipWaitResult.Timeout);
             }
 
-            // 1. Save current clipboard content (awaitable — guarantees completion)
+            // 1. Save current clipboard content (awaitable — guarantees completion).
+            // Capture both the text (if any) and whether the clipboard was *genuinely
+            // empty* (zero formats), so the restore step can tell an empty clipboard
+            // apart from a non-text payload (e.g. an image) — see issue #168.
             string? originalClipboard = null;
+            bool originalWasEmpty = false;
             try
             {
-                originalClipboard = await RunOnDispatcherAsync<string?>(dispatcherQueue, async () =>
+                var snapshot = await RunOnDispatcherAsync<ClipboardProbe?>(dispatcherQueue, async () =>
                 {
                     var dataPackage = Clipboard.GetContent();
+                    var formatCount = dataPackage.AvailableFormats?.Count ?? 0;
                     if (dataPackage.Contains(StandardDataFormats.Text))
                     {
                         var text = await dataPackage.GetTextAsync();
                         Debug.WriteLine($"[TextSelectionService] Original clipboard: '{text?.Substring(0, Math.Min(50, text?.Length ?? 0))}...'");
-                        return text;
+                        return new ClipboardProbe(true, text, formatCount);
                     }
-                    Debug.WriteLine("[TextSelectionService] Original clipboard has no text");
-                    return null;
+                    Debug.WriteLine($"[TextSelectionService] Original clipboard has no text (formats={formatCount})");
+                    return new ClipboardProbe(false, null, formatCount);
                 }, cancellationToken);
+
+                originalClipboard = snapshot?.Text;
+                originalWasEmpty = snapshot != null && snapshot.AvailableFormatCount == 0;
             }
             catch (Exception ex)
             {
@@ -647,19 +655,29 @@ public static class TextSelectionService
 
             Debug.WriteLine($"[TextSelectionService] Clipboard changed: {originalClipboard != selectedText}");
 
-            // 5. Restore original clipboard content (best-effort, but reliable).
-            // Only restore when we actually saved text that differs from what Ctrl+C
-            // produced. We deliberately NEVER clear the clipboard: a saved null means
-            // the original had no text format (e.g. an image), and clearing it would
-            // destroy the user's clipboard on every selection (issue #168). The restore
-            // is awaited and retried (and intentionally not cancellable) so a transient
-            // lock held by another app (Office frequently holds the clipboard open) no
-            // longer silently loses the user's copied text, and a late user action cannot
-            // leave the foreign (just-copied) text stranded on the clipboard.
-            var textToRestore = ResolveClipboardRestore(originalClipboard, selectedText);
-            if (textToRestore != null)
+            // 5. Restore the original clipboard state (best-effort, but reliable).
+            // We restore saved text, or clear back to empty ONLY when the clipboard was
+            // genuinely empty to begin with. We deliberately never clear a non-text
+            // payload (e.g. an image): clearing it on every selection is exactly the
+            // corruption reported in issue #168, and the payload can't be restored anyway.
+            // The write is awaited and retried (and intentionally not cancellable) so a
+            // transient lock held by another app (Office frequently holds the clipboard
+            // open) no longer silently loses the user's clipboard, and a late user action
+            // cannot leave the foreign (just-copied) text stranded on the clipboard.
+            var (restoreAction, textToRestore) = ResolveClipboardRestore(originalClipboard, originalWasEmpty, selectedText);
+            switch (restoreAction)
             {
-                await RestoreClipboardAsync(dispatcherQueue, textToRestore);
+                case ClipboardRestoreAction.RestoreText:
+                    await RunClipboardWriteWithRetryAsync(dispatcherQueue, () =>
+                    {
+                        var dataPackage = new DataPackage();
+                        dataPackage.SetText(textToRestore!);
+                        Clipboard.SetContent(dataPackage);
+                    }, "Clipboard restore");
+                    break;
+                case ClipboardRestoreAction.ClearToEmpty:
+                    await RunClipboardWriteWithRetryAsync(dispatcherQueue, Clipboard.Clear, "Clipboard clear-to-empty");
+                    break;
             }
 
             var outcome = string.IsNullOrWhiteSpace(selectedText) ? ClipWaitResult.Timeout : ClipWaitResult.Success;
@@ -679,22 +697,52 @@ public static class TextSelectionService
     }
 
     /// <summary>
-    /// Decides what (if anything) should be written back to the clipboard after a
-    /// Ctrl+C selection capture. Returns the original text to restore, or null to
-    /// leave the clipboard untouched. Crucially this never signals a clear: a null
-    /// <paramref name="originalClipboard"/> means the user's clipboard held a
-    /// non-text payload, and wiping it on every selection corrupted unrelated
-    /// copy/paste flows (issue #168).
+    /// How the clipboard should be restored after a Ctrl+C selection capture.
     /// </summary>
-    internal static string? ResolveClipboardRestore(string? originalClipboard, string? copiedText)
-        => originalClipboard != null && originalClipboard != copiedText ? originalClipboard : null;
+    internal enum ClipboardRestoreAction
+    {
+        /// <summary>Leave the clipboard as-is (e.g. a non-text payload we can't restore).</summary>
+        None,
+        /// <summary>Write the saved original text back to the clipboard.</summary>
+        RestoreText,
+        /// <summary>Clear the clipboard back to its original empty state.</summary>
+        ClearToEmpty,
+    }
 
     /// <summary>
-    /// Restores <paramref name="text"/> to the clipboard, retrying a few times to
-    /// ride out transient locks held by other apps (e.g. Office holding the clipboard
-    /// open). Best-effort: never throws and never clears the clipboard.
+    /// Decides how the clipboard should be restored after a Ctrl+C selection capture.
+    /// <list type="bullet">
+    /// <item>Original had text → restore it (when Ctrl+C actually changed the clipboard).</item>
+    /// <item>Original was genuinely empty (zero formats) → clear back to empty.</item>
+    /// <item>Original had a non-text payload (e.g. an image) → leave it alone: it can't
+    /// be restored, and clearing it on every selection is the corruption reported in
+    /// issue #168.</item>
+    /// </list>
     /// </summary>
-    private static async Task RestoreClipboardAsync(DispatcherQueue dispatcherQueue, string text)
+    internal static (ClipboardRestoreAction Action, string? Text) ResolveClipboardRestore(
+        string? originalText, bool originalWasEmpty, string? copiedText)
+    {
+        if (originalText != null)
+        {
+            return originalText != copiedText
+                ? (ClipboardRestoreAction.RestoreText, originalText)
+                : (ClipboardRestoreAction.None, null);
+        }
+
+        if (originalWasEmpty && copiedText != null)
+        {
+            return (ClipboardRestoreAction.ClearToEmpty, null);
+        }
+
+        return (ClipboardRestoreAction.None, null);
+    }
+
+    /// <summary>
+    /// Runs a clipboard write (set or clear) on the UI thread, retrying a few times to
+    /// ride out transient locks held by other apps (e.g. Office holding the clipboard
+    /// open). Best-effort: never throws.
+    /// </summary>
+    private static async Task RunClipboardWriteWithRetryAsync(DispatcherQueue dispatcherQueue, Action clipboardOp, string opName)
     {
         const int maxAttempts = 3;
         const int retryDelayMs = 50;
@@ -703,17 +751,12 @@ public static class TextSelectionService
         {
             try
             {
-                await RunOnDispatcherAsync(dispatcherQueue, () =>
-                {
-                    var dataPackage = new DataPackage();
-                    dataPackage.SetText(text);
-                    Clipboard.SetContent(dataPackage);
-                });
+                await RunOnDispatcherAsync(dispatcherQueue, clipboardOp);
                 return;
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[TextSelectionService] Clipboard restore attempt {attempt}/{maxAttempts} failed: {ex.Message}");
+                Debug.WriteLine($"[TextSelectionService] {opName} attempt {attempt}/{maxAttempts} failed: {ex.Message}");
             }
 
             if (attempt < maxAttempts)
@@ -722,7 +765,7 @@ public static class TextSelectionService
             }
         }
 
-        Debug.WriteLine("[TextSelectionService] Clipboard restore gave up after retries");
+        Debug.WriteLine($"[TextSelectionService] {opName} gave up after retries");
     }
 
     /// <summary>

--- a/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
@@ -674,7 +674,7 @@ public static class TextSelectionService
                 var clipboardChanged = GetClipboardSequenceNumber() != baselineSequence;
                 Debug.WriteLine($"[TextSelectionService] Clipboard changed: {clipboardChanged}");
 
-                var (restoreAction, textToRestore) = ResolveClipboardRestore(originalClipboard, originalWasEmpty, clipboardChanged);
+                var (restoreAction, textToRestore) = ResolveClipboardRestore(originalClipboard, originalWasEmpty, clipboardChanged, selectedText);
                 switch (restoreAction)
                 {
                     case ClipboardRestoreAction.RestoreText:
@@ -728,13 +728,16 @@ public static class TextSelectionService
 
     /// <summary>
     /// Decides how the clipboard should be restored after a Ctrl+C selection capture,
-    /// given the original clipboard state and whether Ctrl+C actually changed the
-    /// clipboard (<paramref name="clipboardChanged"/>, observed via the clipboard
-    /// sequence number).
+    /// given the original clipboard state, whether Ctrl+C actually changed the clipboard
+    /// (<paramref name="clipboardChanged"/>, observed via the clipboard sequence number),
+    /// and the text Ctrl+C placed on the clipboard (<paramref name="copiedText"/>).
     /// <list type="bullet">
     /// <item>Clipboard unchanged (e.g. an empty cell that copied nothing) → do nothing;
     /// the original is still intact.</item>
-    /// <item>Original had text → restore it.</item>
+    /// <item>Original had text, but Ctrl+C produced the identical text → do nothing.
+    /// Re-writing a plain-text <c>DataPackage</c> would needlessly strip any richer
+    /// formats (HTML/RTF) that accompany the same text now on the clipboard.</item>
+    /// <item>Original had text that differs from what was copied → restore it.</item>
     /// <item>Original was genuinely empty (zero formats) → clear back to empty.</item>
     /// <item>Original had a non-text payload (e.g. an image/RTF) → leave the clipboard as
     /// is. We only captured the text form of the original, so we cannot faithfully
@@ -745,7 +748,7 @@ public static class TextSelectionService
     /// </list>
     /// </summary>
     internal static (ClipboardRestoreAction Action, string? Text) ResolveClipboardRestore(
-        string? originalText, bool originalWasEmpty, bool clipboardChanged)
+        string? originalText, bool originalWasEmpty, bool clipboardChanged, string? copiedText)
     {
         if (!clipboardChanged)
         {
@@ -754,7 +757,11 @@ public static class TextSelectionService
 
         if (originalText != null)
         {
-            return (ClipboardRestoreAction.RestoreText, originalText);
+            // Identical text already on the clipboard — skip the restore so we don't
+            // strip richer formats by overwriting with a plain-text package.
+            return originalText == copiedText
+                ? (ClipboardRestoreAction.None, null)
+                : (ClipboardRestoreAction.RestoreText, originalText);
         }
 
         if (originalWasEmpty)

--- a/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
@@ -647,29 +647,19 @@ public static class TextSelectionService
 
             Debug.WriteLine($"[TextSelectionService] Clipboard changed: {originalClipboard != selectedText}");
 
-            // 5. Restore original clipboard content
-            // If original had text and it's different from what we copied, restore it
-            // If original was empty (null) and copy succeeded, clear clipboard to restore empty state
-            var shouldRestore = (originalClipboard != null && originalClipboard != selectedText) ||
-                                (originalClipboard == null && selectedText != null);
-            if (shouldRestore)
+            // 5. Restore original clipboard content (best-effort, but reliable).
+            // Only restore when we actually saved text that differs from what Ctrl+C
+            // produced. We deliberately NEVER clear the clipboard: a saved null means
+            // the original had no text format (e.g. an image), and clearing it would
+            // destroy the user's clipboard on every selection (issue #168). The restore
+            // is awaited and retried (and intentionally not cancellable) so a transient
+            // lock held by another app (Office frequently holds the clipboard open) no
+            // longer silently loses the user's copied text, and a late user action cannot
+            // leave the foreign (just-copied) text stranded on the clipboard.
+            var textToRestore = ResolveClipboardRestore(originalClipboard, selectedText);
+            if (textToRestore != null)
             {
-                // Fire-and-forget is acceptable for restore — it's non-critical.
-                _ = RunOnDispatcherAsync(dispatcherQueue, () =>
-                {
-                    if (originalClipboard != null)
-                    {
-                        var dataPackage = new DataPackage();
-                        dataPackage.SetText(originalClipboard);
-                        Clipboard.SetContent(dataPackage);
-                    }
-                    else
-                    {
-                        Clipboard.Clear();
-                    }
-                }).ContinueWith(
-                    task => Debug.WriteLine($"[TextSelectionService] Clipboard restore failed: {task.Exception?.GetBaseException().Message}"),
-                    TaskContinuationOptions.OnlyOnFaulted);
+                await RestoreClipboardAsync(dispatcherQueue, textToRestore);
             }
 
             var outcome = string.IsNullOrWhiteSpace(selectedText) ? ClipWaitResult.Timeout : ClipWaitResult.Success;
@@ -686,6 +676,53 @@ public static class TextSelectionService
             Debug.WriteLine($"[TextSelectionService] Clipboard method failed: {ex}");
             return (null, ClipWaitResult.Timeout);
         }
+    }
+
+    /// <summary>
+    /// Decides what (if anything) should be written back to the clipboard after a
+    /// Ctrl+C selection capture. Returns the original text to restore, or null to
+    /// leave the clipboard untouched. Crucially this never signals a clear: a null
+    /// <paramref name="originalClipboard"/> means the user's clipboard held a
+    /// non-text payload, and wiping it on every selection corrupted unrelated
+    /// copy/paste flows (issue #168).
+    /// </summary>
+    internal static string? ResolveClipboardRestore(string? originalClipboard, string? copiedText)
+        => originalClipboard != null && originalClipboard != copiedText ? originalClipboard : null;
+
+    /// <summary>
+    /// Restores <paramref name="text"/> to the clipboard, retrying a few times to
+    /// ride out transient locks held by other apps (e.g. Office holding the clipboard
+    /// open). Best-effort: never throws and never clears the clipboard.
+    /// </summary>
+    private static async Task RestoreClipboardAsync(DispatcherQueue dispatcherQueue, string text)
+    {
+        const int maxAttempts = 3;
+        const int retryDelayMs = 50;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                await RunOnDispatcherAsync(dispatcherQueue, () =>
+                {
+                    var dataPackage = new DataPackage();
+                    dataPackage.SetText(text);
+                    Clipboard.SetContent(dataPackage);
+                });
+                return;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[TextSelectionService] Clipboard restore attempt {attempt}/{maxAttempts} failed: {ex.Message}");
+            }
+
+            if (attempt < maxAttempts)
+            {
+                await Task.Delay(retryDelayMs);
+            }
+        }
+
+        Debug.WriteLine("[TextSelectionService] Clipboard restore gave up after retries");
     }
 
     /// <summary>

--- a/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
@@ -579,6 +579,8 @@ public static class TextSelectionService
             uint currentThreadId = 0;
             uint targetThreadId = 0;
             bool attached = false;
+            bool ctrlCSent = false;
+            var waitOutcome = ClipWaitResult.Timeout;
 
             try
             {
@@ -604,6 +606,7 @@ public static class TextSelectionService
                     if (actualForeground != targetWindow)
                     {
                         Debug.WriteLine($"[TextSelectionService] Focus verification failed: expected {targetWindow}, got {actualForeground}");
+                        // Ctrl+C was never sent, so the clipboard is untouched — nothing to restore.
                         return (null, ClipWaitResult.Timeout);
                     }
 
@@ -611,13 +614,13 @@ public static class TextSelectionService
                 }
 
                 SendCtrlC();
+                ctrlCSent = true;
 
                 // Use ClipWait with baseline sequence - polls for clipboard readiness
-                var waitOutcome = await WaitForClipboardTextAsync(dispatcherQueue, timeoutMs, pollIntervalMs, baselineSequence, cancellationToken);
+                waitOutcome = await WaitForClipboardTextAsync(dispatcherQueue, timeoutMs, pollIntervalMs, baselineSequence, cancellationToken);
                 if (waitOutcome != ClipWaitResult.Success)
                 {
                     Debug.WriteLine($"[TextSelectionService] ClipWait result={waitOutcome} after up to {timeoutMs}ms");
-                    return (null, waitOutcome);
                 }
             }
             finally
@@ -630,7 +633,8 @@ public static class TextSelectionService
                 }
             }
 
-            // 4. Read copied text from clipboard (awaitable — guarantees completion)
+            // 4. Read whatever Ctrl+C placed on the clipboard (the captured selection),
+            // BEFORE restoring so the read isn't clobbered by the restore write.
             string? selectedText = null;
             try
             {
@@ -650,34 +654,47 @@ public static class TextSelectionService
             catch (Exception ex)
             {
                 Debug.WriteLine($"[TextSelectionService] Failed to read clipboard: {ex.Message}");
-                return (null, ClipWaitResult.Timeout);
+                // Fall through to restore regardless — selectedText stays null.
             }
 
-            Debug.WriteLine($"[TextSelectionService] Clipboard changed: {originalClipboard != selectedText}");
-
-            // 5. Restore the original clipboard state (best-effort, but reliable).
-            // We restore saved text, or clear back to empty ONLY when the clipboard was
-            // genuinely empty to begin with. We deliberately never clear a non-text
-            // payload (e.g. an image): clearing it on every selection is exactly the
-            // corruption reported in issue #168, and the payload can't be restored anyway.
+            // 5. Restore the original clipboard state. This runs on EVERY path where Ctrl+C
+            // may have changed the clipboard — success, timeout, or non-text payload — not
+            // just the success path. Restoring only on success used to leave an empty or
+            // non-text Ctrl+C result stranded on the clipboard, re-introducing the data
+            // loss from issue #168. We drive the decision off the clipboard sequence number
+            // (did Ctrl+C actually change anything?) rather than the wait outcome. We restore
+            // saved text, or clear back to empty only when the clipboard was genuinely empty
+            // to begin with; a non-text original (image/RTF/etc.) can't be restored here
+            // because we only captured its text form, so we leave it rather than clearing it.
             // The write is awaited and retried (and intentionally not cancellable) so a
-            // transient lock held by another app (Office frequently holds the clipboard
-            // open) no longer silently loses the user's clipboard, and a late user action
-            // cannot leave the foreign (just-copied) text stranded on the clipboard.
-            var (restoreAction, textToRestore) = ResolveClipboardRestore(originalClipboard, originalWasEmpty, selectedText);
-            switch (restoreAction)
+            // transient lock held by another app (Office frequently holds the clipboard open)
+            // no longer silently loses the user's clipboard.
+            if (ctrlCSent)
             {
-                case ClipboardRestoreAction.RestoreText:
-                    await RunClipboardWriteWithRetryAsync(dispatcherQueue, () =>
-                    {
-                        var dataPackage = new DataPackage();
-                        dataPackage.SetText(textToRestore!);
-                        Clipboard.SetContent(dataPackage);
-                    }, "Clipboard restore");
-                    break;
-                case ClipboardRestoreAction.ClearToEmpty:
-                    await RunClipboardWriteWithRetryAsync(dispatcherQueue, Clipboard.Clear, "Clipboard clear-to-empty");
-                    break;
+                var clipboardChanged = GetClipboardSequenceNumber() != baselineSequence;
+                Debug.WriteLine($"[TextSelectionService] Clipboard changed: {clipboardChanged}");
+
+                var (restoreAction, textToRestore) = ResolveClipboardRestore(originalClipboard, originalWasEmpty, clipboardChanged);
+                switch (restoreAction)
+                {
+                    case ClipboardRestoreAction.RestoreText:
+                        await RunClipboardWriteWithRetryAsync(dispatcherQueue, () =>
+                        {
+                            var dataPackage = new DataPackage();
+                            dataPackage.SetText(textToRestore!);
+                            Clipboard.SetContent(dataPackage);
+                        }, "Clipboard restore");
+                        break;
+                    case ClipboardRestoreAction.ClearToEmpty:
+                        await RunClipboardWriteWithRetryAsync(dispatcherQueue, Clipboard.Clear, "Clipboard clear-to-empty");
+                        break;
+                }
+            }
+
+            // 6. Produce the return value based on the wait outcome.
+            if (waitOutcome != ClipWaitResult.Success)
+            {
+                return (null, waitOutcome);
             }
 
             var outcome = string.IsNullOrWhiteSpace(selectedText) ? ClipWaitResult.Timeout : ClipWaitResult.Success;
@@ -710,26 +727,37 @@ public static class TextSelectionService
     }
 
     /// <summary>
-    /// Decides how the clipboard should be restored after a Ctrl+C selection capture.
+    /// Decides how the clipboard should be restored after a Ctrl+C selection capture,
+    /// given the original clipboard state and whether Ctrl+C actually changed the
+    /// clipboard (<paramref name="clipboardChanged"/>, observed via the clipboard
+    /// sequence number).
     /// <list type="bullet">
-    /// <item>Original had text → restore it (when Ctrl+C actually changed the clipboard).</item>
+    /// <item>Clipboard unchanged (e.g. an empty cell that copied nothing) → do nothing;
+    /// the original is still intact.</item>
+    /// <item>Original had text → restore it.</item>
     /// <item>Original was genuinely empty (zero formats) → clear back to empty.</item>
-    /// <item>Original had a non-text payload (e.g. an image) → leave it alone: it can't
-    /// be restored, and clearing it on every selection is the corruption reported in
-    /// issue #168.</item>
+    /// <item>Original had a non-text payload (e.g. an image/RTF) → leave the clipboard as
+    /// is. We only captured the text form of the original, so we cannot faithfully
+    /// restore the payload; clearing it would still lose data and re-introduce the
+    /// corruption reported in issue #168. This is a known limitation of clipboard-based
+    /// selection capture: a non-text payload present at capture time is overwritten by
+    /// Ctrl+C and cannot be recovered here.</item>
     /// </list>
     /// </summary>
     internal static (ClipboardRestoreAction Action, string? Text) ResolveClipboardRestore(
-        string? originalText, bool originalWasEmpty, string? copiedText)
+        string? originalText, bool originalWasEmpty, bool clipboardChanged)
     {
-        if (originalText != null)
+        if (!clipboardChanged)
         {
-            return originalText != copiedText
-                ? (ClipboardRestoreAction.RestoreText, originalText)
-                : (ClipboardRestoreAction.None, null);
+            return (ClipboardRestoreAction.None, null);
         }
 
-        if (originalWasEmpty && copiedText != null)
+        if (originalText != null)
+        {
+            return (ClipboardRestoreAction.RestoreText, originalText);
+        }
+
+        if (originalWasEmpty)
         {
             return (ClipboardRestoreAction.ClearToEmpty, null);
         }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceTests.cs
@@ -248,4 +248,41 @@ public class TextSelectionServiceTests
             .Should().BeFalse(
                 "terminal apps already skip the clipboard path; the suppression layer must not double-block them");
     }
+
+    // ---- Clipboard restore decision (issue #168) ----
+    // After a Ctrl+C selection capture we must restore the user's original
+    // clipboard but must NEVER clear it: clearing on every selection corrupted
+    // unrelated copy/paste flows (e.g. pasting in Excel).
+
+    [Fact]
+    public void ResolveClipboardRestore_RestoresOriginal_WhenItDiffersFromCopiedText()
+    {
+        TextSelectionService.ResolveClipboardRestore("user copied text", "selected cell text")
+            .Should().Be("user copied text");
+    }
+
+    [Fact]
+    public void ResolveClipboardRestore_ReturnsNull_WhenOriginalWasNonText()
+    {
+        // A null original means the clipboard held a non-text payload (e.g. an image).
+        // We must leave the clipboard alone rather than wiping it.
+        TextSelectionService.ResolveClipboardRestore(null, "selected cell text")
+            .Should().BeNull("a non-text original must never trigger a clear (issue #168)");
+    }
+
+    [Fact]
+    public void ResolveClipboardRestore_ReturnsNull_WhenCopiedTextMatchesOriginal()
+    {
+        // Nothing changed — no need to write the same value back.
+        TextSelectionService.ResolveClipboardRestore("same text", "same text")
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveClipboardRestore_RestoresOriginal_WhenNothingWasCopied()
+    {
+        // Ctrl+C produced no text (e.g. empty cell) but the user still had a copy.
+        TextSelectionService.ResolveClipboardRestore("user copied text", null)
+            .Should().Be("user copied text");
+    }
 }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceTests.cs
@@ -250,64 +250,56 @@ public class TextSelectionServiceTests
     }
 
     // ---- Clipboard restore decision (issue #168) ----
-    // After a Ctrl+C selection capture we restore the user's original clipboard
-    // STATE: put saved text back, or clear to empty only when the clipboard was
-    // genuinely empty. We must never clear a non-text payload (e.g. an image),
-    // because clearing on every selection corrupted unrelated copy/paste flows.
+    // After a Ctrl+C selection capture we restore the user's original clipboard STATE
+    // whenever Ctrl+C actually changed the clipboard (tracked via the sequence number):
+    // put saved text back, or clear to empty only when the clipboard was genuinely empty.
+    // We never clear a non-text payload (e.g. an image) — clearing on every selection
+    // corrupted unrelated copy/paste flows.
 
     [Fact]
-    public void ResolveClipboardRestore_RestoresOriginal_WhenTextDiffersFromCopiedText()
+    public void ResolveClipboardRestore_RestoresText_WhenClipboardChanged_AndOriginalHadText()
     {
         var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            "user copied text", originalWasEmpty: false, copiedText: "selected cell text");
+            "user copied text", originalWasEmpty: false, clipboardChanged: true);
 
         action.Should().Be(TextSelectionService.ClipboardRestoreAction.RestoreText);
         text.Should().Be("user copied text");
     }
 
     [Fact]
-    public void ResolveClipboardRestore_RestoresOriginal_WhenNothingWasCopied()
+    public void ResolveClipboardRestore_DoesNothing_WhenClipboardUnchanged()
     {
-        // Ctrl+C produced no text (e.g. empty cell) but the user still had a copy.
+        // Ctrl+C copied nothing (e.g. an empty cell) — the original is still intact,
+        // so there is nothing to put back regardless of what it held.
         var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            "user copied text", originalWasEmpty: false, copiedText: null);
-
-        action.Should().Be(TextSelectionService.ClipboardRestoreAction.RestoreText);
-        text.Should().Be("user copied text");
-    }
-
-    [Fact]
-    public void ResolveClipboardRestore_DoesNothing_WhenCopiedTextMatchesOriginal()
-    {
-        // Nothing changed — no need to write the same value back.
-        var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            "same text", originalWasEmpty: false, copiedText: "same text");
+            "user copied text", originalWasEmpty: false, clipboardChanged: false);
 
         action.Should().Be(TextSelectionService.ClipboardRestoreAction.None);
         text.Should().BeNull();
     }
 
     [Fact]
-    public void ResolveClipboardRestore_ClearsToEmpty_WhenOriginalWasGenuinelyEmpty()
+    public void ResolveClipboardRestore_ClearsToEmpty_WhenClipboardChanged_AndOriginalWasGenuinelyEmpty()
     {
         // The clipboard had no formats at all; Ctrl+C polluted it with the selection.
         // Restoring the true (empty) original state means clearing it back to empty.
         var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            null, originalWasEmpty: true, copiedText: "selected cell text");
+            null, originalWasEmpty: true, clipboardChanged: true);
 
         action.Should().Be(TextSelectionService.ClipboardRestoreAction.ClearToEmpty);
         text.Should().BeNull();
     }
 
     [Fact]
-    public void ResolveClipboardRestore_DoesNothing_WhenOriginalHadNonTextPayload()
+    public void ResolveClipboardRestore_DoesNothing_WhenChanged_ButOriginalHadNonTextPayload()
     {
-        // Original had no text but DID have formats (e.g. an image). We can't restore the
-        // image, and we must not clear it on every selection (issue #168) — leave it alone.
+        // Original had no text but DID have formats (e.g. an image). We only captured the
+        // text form, so we can't restore the payload, and we must not clear it on every
+        // selection (issue #168) — leave the (overwritten) clipboard alone.
         var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            null, originalWasEmpty: false, copiedText: "selected cell text");
+            null, originalWasEmpty: false, clipboardChanged: true);
 
         action.Should().Be(TextSelectionService.ClipboardRestoreAction.None);
-        text.Should().BeNull("a non-text payload must never trigger a clear (issue #168)");
+        text.Should().BeNull("a non-text payload can't be restored and must never trigger a clear (issue #168)");
     }
 }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceTests.cs
@@ -257,13 +257,25 @@ public class TextSelectionServiceTests
     // corrupted unrelated copy/paste flows.
 
     [Fact]
-    public void ResolveClipboardRestore_RestoresText_WhenClipboardChanged_AndOriginalHadText()
+    public void ResolveClipboardRestore_RestoresText_WhenClipboardChanged_AndCopiedTextDiffers()
     {
         var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            "user copied text", originalWasEmpty: false, clipboardChanged: true);
+            "user copied text", originalWasEmpty: false, clipboardChanged: true, copiedText: "selected cell text");
 
         action.Should().Be(TextSelectionService.ClipboardRestoreAction.RestoreText);
         text.Should().Be("user copied text");
+    }
+
+    [Fact]
+    public void ResolveClipboardRestore_DoesNothing_WhenChanged_ButCopiedTextEqualsOriginal()
+    {
+        // Ctrl+C produced the same text already on the clipboard. Re-writing a plain-text
+        // package would needlessly strip richer formats (HTML/RTF) — so skip the restore.
+        var (action, text) = TextSelectionService.ResolveClipboardRestore(
+            "same text", originalWasEmpty: false, clipboardChanged: true, copiedText: "same text");
+
+        action.Should().Be(TextSelectionService.ClipboardRestoreAction.None);
+        text.Should().BeNull();
     }
 
     [Fact]
@@ -272,7 +284,7 @@ public class TextSelectionServiceTests
         // Ctrl+C copied nothing (e.g. an empty cell) — the original is still intact,
         // so there is nothing to put back regardless of what it held.
         var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            "user copied text", originalWasEmpty: false, clipboardChanged: false);
+            "user copied text", originalWasEmpty: false, clipboardChanged: false, copiedText: null);
 
         action.Should().Be(TextSelectionService.ClipboardRestoreAction.None);
         text.Should().BeNull();
@@ -284,7 +296,7 @@ public class TextSelectionServiceTests
         // The clipboard had no formats at all; Ctrl+C polluted it with the selection.
         // Restoring the true (empty) original state means clearing it back to empty.
         var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            null, originalWasEmpty: true, clipboardChanged: true);
+            null, originalWasEmpty: true, clipboardChanged: true, copiedText: "selected cell text");
 
         action.Should().Be(TextSelectionService.ClipboardRestoreAction.ClearToEmpty);
         text.Should().BeNull();
@@ -297,7 +309,7 @@ public class TextSelectionServiceTests
         // text form, so we can't restore the payload, and we must not clear it on every
         // selection (issue #168) — leave the (overwritten) clipboard alone.
         var (action, text) = TextSelectionService.ResolveClipboardRestore(
-            null, originalWasEmpty: false, clipboardChanged: true);
+            null, originalWasEmpty: false, clipboardChanged: true, copiedText: "selected cell text");
 
         action.Should().Be(TextSelectionService.ClipboardRestoreAction.None);
         text.Should().BeNull("a non-text payload can't be restored and must never trigger a clear (issue #168)");

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceTests.cs
@@ -250,39 +250,64 @@ public class TextSelectionServiceTests
     }
 
     // ---- Clipboard restore decision (issue #168) ----
-    // After a Ctrl+C selection capture we must restore the user's original
-    // clipboard but must NEVER clear it: clearing on every selection corrupted
-    // unrelated copy/paste flows (e.g. pasting in Excel).
+    // After a Ctrl+C selection capture we restore the user's original clipboard
+    // STATE: put saved text back, or clear to empty only when the clipboard was
+    // genuinely empty. We must never clear a non-text payload (e.g. an image),
+    // because clearing on every selection corrupted unrelated copy/paste flows.
 
     [Fact]
-    public void ResolveClipboardRestore_RestoresOriginal_WhenItDiffersFromCopiedText()
+    public void ResolveClipboardRestore_RestoresOriginal_WhenTextDiffersFromCopiedText()
     {
-        TextSelectionService.ResolveClipboardRestore("user copied text", "selected cell text")
-            .Should().Be("user copied text");
-    }
+        var (action, text) = TextSelectionService.ResolveClipboardRestore(
+            "user copied text", originalWasEmpty: false, copiedText: "selected cell text");
 
-    [Fact]
-    public void ResolveClipboardRestore_ReturnsNull_WhenOriginalWasNonText()
-    {
-        // A null original means the clipboard held a non-text payload (e.g. an image).
-        // We must leave the clipboard alone rather than wiping it.
-        TextSelectionService.ResolveClipboardRestore(null, "selected cell text")
-            .Should().BeNull("a non-text original must never trigger a clear (issue #168)");
-    }
-
-    [Fact]
-    public void ResolveClipboardRestore_ReturnsNull_WhenCopiedTextMatchesOriginal()
-    {
-        // Nothing changed — no need to write the same value back.
-        TextSelectionService.ResolveClipboardRestore("same text", "same text")
-            .Should().BeNull();
+        action.Should().Be(TextSelectionService.ClipboardRestoreAction.RestoreText);
+        text.Should().Be("user copied text");
     }
 
     [Fact]
     public void ResolveClipboardRestore_RestoresOriginal_WhenNothingWasCopied()
     {
         // Ctrl+C produced no text (e.g. empty cell) but the user still had a copy.
-        TextSelectionService.ResolveClipboardRestore("user copied text", null)
-            .Should().Be("user copied text");
+        var (action, text) = TextSelectionService.ResolveClipboardRestore(
+            "user copied text", originalWasEmpty: false, copiedText: null);
+
+        action.Should().Be(TextSelectionService.ClipboardRestoreAction.RestoreText);
+        text.Should().Be("user copied text");
+    }
+
+    [Fact]
+    public void ResolveClipboardRestore_DoesNothing_WhenCopiedTextMatchesOriginal()
+    {
+        // Nothing changed — no need to write the same value back.
+        var (action, text) = TextSelectionService.ResolveClipboardRestore(
+            "same text", originalWasEmpty: false, copiedText: "same text");
+
+        action.Should().Be(TextSelectionService.ClipboardRestoreAction.None);
+        text.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveClipboardRestore_ClearsToEmpty_WhenOriginalWasGenuinelyEmpty()
+    {
+        // The clipboard had no formats at all; Ctrl+C polluted it with the selection.
+        // Restoring the true (empty) original state means clearing it back to empty.
+        var (action, text) = TextSelectionService.ResolveClipboardRestore(
+            null, originalWasEmpty: true, copiedText: "selected cell text");
+
+        action.Should().Be(TextSelectionService.ClipboardRestoreAction.ClearToEmpty);
+        text.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveClipboardRestore_DoesNothing_WhenOriginalHadNonTextPayload()
+    {
+        // Original had no text but DID have formats (e.g. an image). We can't restore the
+        // image, and we must not clear it on every selection (issue #168) — leave it alone.
+        var (action, text) = TextSelectionService.ResolveClipboardRestore(
+            null, originalWasEmpty: false, copiedText: "selected cell text");
+
+        action.Should().Be(TextSelectionService.ClipboardRestoreAction.None);
+        text.Should().BeNull("a non-text payload must never trigger a clear (issue #168)");
     }
 }


### PR DESCRIPTION
## Summary

Fixes clipboard corruption issue (#168) where clearing the clipboard on every text selection was destroying unrelated copy/paste flows (e.g., pasting images or formatted content in Excel). Refactors clipboard restore logic into dedicated methods with retry support to handle transient locks from other applications.

## Key Changes

- **Clipboard restore decision logic**: Extracted `ResolveClipboardRestore()` method that:
  - Only restores when original clipboard text differs from what `Ctrl+C` produced
  - **Never clears the clipboard** — a null original means non-text payload (image, etc.) was present and must be preserved
  - Returns null when no restore is needed (matching text or non-text original)

- **Retry mechanism**: New `RestoreClipboardAsync()` method that:
  - Retries up to 3 times with 50ms delays to overcome transient clipboard locks held by Office and other apps
  - Awaits the restore operation (no longer fire-and-forget) to ensure user's copied text isn't lost
  - Logs all failures for debugging but never throws

- **Synthetic key marking**: Updated `TextInsertionService.SendCtrlV()` to mark all injected keyboard events with `MouseHookService.EASYDICT_SYNTHETIC_KEY` flag, preventing the hook from processing our own synthetic input

- **Test coverage**: Added 4 unit tests validating the restore decision logic:
  - Restores when original differs from copied text
  - Never clears when original was non-text (null)
  - Skips restore when text unchanged
  - Restores when `Ctrl+C` produced no text but user had a prior copy

## Implementation Details

The core fix addresses the root cause: the old code called `Clipboard.Clear()` whenever `originalClipboard == null`, which destroyed the user's clipboard on every selection. The new logic recognizes that null means "no text format was present" (not "clipboard was empty") and leaves it untouched. Only when we have actual text to restore do we write back to the clipboard, with retries to handle transient locks.

https://claude.ai/code/session_01VY6fNCGkcvd92njQYkcpC2