### PR TITLE
feat: compact UI, result font size, and quick-action buttons (#172)

### DIFF
--- a/dotnet/src/Easydict.WinUI/App.xaml
+++ b/dotnet/src/Easydict.WinUI/App.xaml
@@ -105,8 +105,8 @@
             </Style>
 
             <Style x:Key="EasydictIconButtonStyle" TargetType="Button" BasedOn="{StaticResource EasydictBaseButtonStyle}">
-                <Setter Property="Width" Value="36" />
-                <Setter Property="Height" Value="36" />
+                <Setter Property="Width" Value="32" />
+                <Setter Property="Height" Value="32" />
                 <Setter Property="Padding" Value="0" />
                 <Setter Property="Background" Value="Transparent" />
                 <Setter Property="BorderBrush" Value="{ThemeResource ControlStrokeColorDefaultBrush}" />
@@ -162,8 +162,8 @@
             </Style>
 
             <Style x:Key="EasydictPrimaryRoundButtonStyle" TargetType="Button" BasedOn="{StaticResource EasydictAccentButtonStyle}">
-                <Setter Property="Width" Value="40" />
-                <Setter Property="Height" Value="40" />
+                <Setter Property="Width" Value="36" />
+                <Setter Property="Height" Value="36" />
                 <Setter Property="Padding" Value="0" />
                 <Setter Property="CornerRadius" Value="{ThemeResource EasydictRoundButtonCornerRadius}" />
             </Style>
@@ -175,7 +175,7 @@
                 <Setter Property="TextWrapping" Value="Wrap" />
                 <Setter Property="AcceptsReturn" Value="True" />
                 <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-                <Setter Property="Padding" Value="8" />
+                <Setter Property="Padding" Value="6" />
                 <Setter Property="CornerRadius" Value="{ThemeResource EasydictControlCornerRadius}" />
                 <Setter Property="MinHeight" Value="80" />
             </Style>

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -824,7 +824,7 @@ namespace Easydict.WinUI
                 return Task.CompletedTask;
             }
 
-            dispatcher.TryEnqueue(async () =>
+            var enqueued = dispatcher.TryEnqueue(async () =>
             {
                 var ocrService = app.EnsureOcrTranslateService();
                 if (ocrService == null)
@@ -842,6 +842,12 @@ namespace Easydict.WinUI
                     System.Diagnostics.Debug.WriteLine($"[App] TriggerOcrTranslateAsync error: {ex.Message}");
                 }
             });
+
+            if (!enqueued)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    "[App] TriggerOcrTranslateAsync: failed to enqueue OCR action (dispatcher unavailable)");
+            }
 
             return Task.CompletedTask;
         }

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -811,6 +811,41 @@ namespace Easydict.WinUI
             return _ocrTranslateService;
         }
 
+        /// <summary>
+        /// Public entry point for the OCR quick-action button in the translation windows.
+        /// Runs the capture → OCR → translate flow on the UI thread (issue #172).
+        /// </summary>
+        public static Task TriggerOcrTranslateAsync()
+        {
+            var app = Instance;
+            var dispatcher = app._window?.DispatcherQueue;
+            if (dispatcher == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            dispatcher.TryEnqueue(async () =>
+            {
+                var ocrService = app.EnsureOcrTranslateService();
+                if (ocrService == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("[App] OCR service not available for button trigger");
+                    return;
+                }
+
+                try
+                {
+                    await ocrService.OcrTranslateAsync();
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[App] TriggerOcrTranslateAsync error: {ex.Message}");
+                }
+            });
+
+            return Task.CompletedTask;
+        }
+
         private async void OnBrowserSupportAction(string browser, bool isInstall)
         {
             try
@@ -1259,6 +1294,21 @@ namespace Easydict.WinUI
             Instance._popButtonService?.ApplyTheme(elementTheme, forceThemeResourceRefresh);
 
             System.Diagnostics.Debug.WriteLine($"[App] Applied theme: {theme} (ElementTheme.{elementTheme})");
+        }
+
+        /// <summary>
+        /// Re-apply appearance settings (result font size) and quick-action button
+        /// visibility to all windows. Mirrors the <see cref="ApplyTheme"/> fan-out (issue #172).
+        /// </summary>
+        public static void ApplyAppearance()
+        {
+            if (Instance._window?.Content is Frame frame && frame.Content is MainPage mainPage)
+            {
+                mainPage.ApplyAppearance();
+            }
+
+            MiniWindowService.Instance.ApplyAppearance();
+            FixedWindowService.Instance.ApplyAppearance();
         }
 
         private static bool IsSystemTheme(string? theme) =>

--- a/dotnet/src/Easydict.WinUI/Services/AppearanceService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/AppearanceService.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace Easydict.WinUI.Services;
+
+/// <summary>
+/// Immutable snapshot of the effective appearance metrics, computed from
+/// <see cref="SettingsService"/>. Passed into result-item controls so each
+/// one does not re-read the service. See issue #172.
+/// </summary>
+public readonly struct AppearanceSettings
+{
+    public double ResultFontSize { get; init; }
+    public double ServiceNameFontSize { get; init; }
+    public double StatusFontSize { get; init; }
+}
+
+/// <summary>
+/// Single source of truth for user-adjustable appearance (currently the result
+/// font scale). Mirrors the static-service pattern used by
+/// <see cref="MinimalThemeService"/>: it reads <see cref="SettingsService"/>,
+/// derives effective sizes, and raises <see cref="AppearanceChanged"/> so the
+/// app can re-broadcast to all windows.
+/// </summary>
+internal static class AppearanceService
+{
+    // Base font sizes hardcoded in the result-item XAML today.
+    private const double BaseResultFontSize = 13.0;
+    private const double BaseServiceNameFontSize = 12.0;
+    private const double BaseStatusFontSize = 10.0;
+
+    private const double MinFontScale = 0.85;
+    private const double MaxFontScale = 1.4;
+
+    /// <summary>
+    /// Minimum height (DIPs) the floating windows shrink to. Lowered from the
+    /// previous hardcoded 200 so short results take less screen space (issue #172).
+    /// </summary>
+    public const double MinFloatingWindowHeightDips = 110.0;
+
+    /// <summary>Clamped font-size multiplier from settings.</summary>
+    public static double FontScale =>
+        Math.Clamp(SettingsService.Instance.ResultFontScale, MinFontScale, MaxFontScale);
+
+    public static double ResultFontSize => BaseResultFontSize * FontScale;
+    public static double ServiceNameFontSize => BaseServiceNameFontSize * FontScale;
+    public static double StatusFontSize => BaseStatusFontSize * FontScale;
+
+    /// <summary>Captures the current effective metrics into an immutable snapshot.</summary>
+    public static AppearanceSettings CurrentSnapshot() => new()
+    {
+        ResultFontSize = ResultFontSize,
+        ServiceNameFontSize = ServiceNameFontSize,
+        StatusFontSize = StatusFontSize,
+    };
+
+    /// <summary>Raised when an appearance setting changes and windows must re-apply.</summary>
+    public static event EventHandler? AppearanceChanged;
+
+    /// <summary>Notify listeners that appearance settings changed.</summary>
+    public static void NotifyChanged() => AppearanceChanged?.Invoke(null, EventArgs.Empty);
+}

--- a/dotnet/src/Easydict.WinUI/Services/AppearanceService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/AppearanceService.cs
@@ -17,9 +17,10 @@ public readonly struct AppearanceSettings
 /// <summary>
 /// Single source of truth for user-adjustable appearance (currently the result
 /// font scale). Mirrors the static-service pattern used by
-/// <see cref="MinimalThemeService"/>: it reads <see cref="SettingsService"/>,
-/// derives effective sizes, and raises <see cref="AppearanceChanged"/> so the
-/// app can re-broadcast to all windows.
+/// <see cref="MinimalThemeService"/>: it reads <see cref="SettingsService"/> and
+/// exposes effective sizes as an on-demand snapshot (<see cref="CurrentSnapshot"/>).
+/// Callers pull the current values after a settings change (via
+/// <c>App.ApplyAppearance()</c>); there is no push/event flow.
 /// </summary>
 internal static class AppearanceService
 {
@@ -52,10 +53,4 @@ internal static class AppearanceService
         ServiceNameFontSize = ServiceNameFontSize,
         StatusFontSize = StatusFontSize,
     };
-
-    /// <summary>Raised when an appearance setting changes and windows must re-apply.</summary>
-    public static event EventHandler? AppearanceChanged;
-
-    /// <summary>Notify listeners that appearance settings changed.</summary>
-    public static void NotifyChanged() => AppearanceChanged?.Invoke(null, EventArgs.Empty);
 }

--- a/dotnet/src/Easydict.WinUI/Services/FixedWindowService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/FixedWindowService.cs
@@ -124,6 +124,14 @@ public sealed class FixedWindowService : IDisposable
     }
 
     /// <summary>
+    /// Re-apply appearance settings (result font size, button visibility) to the fixed window.
+    /// </summary>
+    public void ApplyAppearance()
+    {
+        _fixedWindow?.ApplyAppearance();
+    }
+
+    /// <summary>
     /// Ensure the fixed window instance exists.
     /// </summary>
     private void EnsureWindowCreated()

--- a/dotnet/src/Easydict.WinUI/Services/MiniWindowService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/MiniWindowService.cs
@@ -145,6 +145,14 @@ public sealed class MiniWindowService : IDisposable
     }
 
     /// <summary>
+    /// Re-apply appearance settings (result font size, button visibility) to the mini window.
+    /// </summary>
+    public void ApplyAppearance()
+    {
+        _miniWindow?.ApplyAppearance();
+    }
+
+    /// <summary>
     /// Ensure the mini window instance exists.
     /// </summary>
     private void EnsureWindowCreated()

--- a/dotnet/src/Easydict.WinUI/Services/MinimalThemeService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/MinimalThemeService.cs
@@ -186,7 +186,7 @@ internal static class MinimalThemeService
         surface.Padding = ThemeResourceService.GetResourceOrDefault(
             "FloatingWindowContentPadding",
             themeRoot,
-            new Thickness(16));
+            new Thickness(8));
         sourceContainer.Background = ThemeResourceService.GetBrush("TextControlBackground", themeRoot);
         sourceContainer.BorderBrush = ThemeResourceService.GetBrush("TextControlBorderBrush", themeRoot);
         sourceContainer.BorderThickness = new Thickness(1);
@@ -197,11 +197,11 @@ internal static class MinimalThemeService
         sourceContainer.Padding = ThemeResourceService.GetResourceOrDefault(
             "FloatingInputPadding",
             themeRoot,
-            new Thickness(10, 9, 10, 9));
+            new Thickness(6, 4, 6, 4));
         sourceContainer.Margin = ThemeResourceService.GetResourceOrDefault(
             "FloatingInputMargin",
             themeRoot,
-            new Thickness(0, 2, 0, 6));
+            new Thickness(0, 0, 0, 3));
     }
 
     public static void ApplyAccentIconForeground(

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -430,6 +430,9 @@ public sealed class SettingsService
     /// </summary>
     public double ResultFontScale { get; set; } = 1.0;
 
+    /// <summary>Hide secondary chrome and optional helper actions for a tighter translation surface.</summary>
+    public bool CompactMode { get; set; } = false;
+
     /// <summary>Show the OCR quick-action button in the translation windows.</summary>
     public bool ShowOcrButton { get; set; } = true;
 
@@ -790,6 +793,7 @@ public sealed class SettingsService
 
         // Appearance / personalization (issue #172)
         ResultFontScale = GetValue(nameof(ResultFontScale), 1.0);
+        CompactMode = GetValue(nameof(CompactMode), false);
         ShowOcrButton = GetValue(nameof(ShowOcrButton), true);
         ShowPinButton = GetValue(nameof(ShowPinButton), true);
         ShowSourcePlayButton = GetValue(nameof(ShowSourcePlayButton), true);
@@ -1029,6 +1033,7 @@ public sealed class SettingsService
 
         // Appearance / personalization (issue #172)
         _settings[nameof(ResultFontScale)] = ResultFontScale;
+        _settings[nameof(CompactMode)] = CompactMode;
         _settings[nameof(ShowOcrButton)] = ShowOcrButton;
         _settings[nameof(ShowPinButton)] = ShowPinButton;
         _settings[nameof(ShowSourcePlayButton)] = ShowSourcePlayButton;

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -423,6 +423,31 @@ public sealed class SettingsService
     // App Theme (System, Light, Dark, Minimal)
     public string AppTheme { get; set; } = "System"; // Default to system theme
 
+    // Appearance / personalization (issue #172)
+    /// <summary>
+    /// Font-size multiplier for translation result text across all windows.
+    /// 1.0 = default; clamped to [0.85, 1.4] when applied via AppearanceService.
+    /// </summary>
+    public double ResultFontScale { get; set; } = 1.0;
+
+    /// <summary>Show the OCR quick-action button in the translation windows.</summary>
+    public bool ShowOcrButton { get; set; } = true;
+
+    /// <summary>Show the pin / always-on-top toggle button.</summary>
+    public bool ShowPinButton { get; set; } = true;
+
+    /// <summary>Show the play-source-text (TTS) button.</summary>
+    public bool ShowSourcePlayButton { get; set; } = true;
+
+    /// <summary>Show the swap-languages button.</summary>
+    public bool ShowSwapButton { get; set; } = true;
+
+    /// <summary>
+    /// Keep the fixed window always on top. Default true (fixed window has always been topmost);
+    /// exposed so users can turn it off via the pin toggle.
+    /// </summary>
+    public bool FixedWindowIsPinned { get; set; } = true;
+
     // Startup settings
     public bool LaunchAtStartup { get; set; } = false;
 
@@ -762,6 +787,15 @@ public sealed class SettingsService
         AutoPlayTranslation = GetValue(nameof(AutoPlayTranslation), false);
         UILanguage = GetValue(nameof(UILanguage), "");
         AppTheme = GetValue(nameof(AppTheme), "System");
+
+        // Appearance / personalization (issue #172)
+        ResultFontScale = GetValue(nameof(ResultFontScale), 1.0);
+        ShowOcrButton = GetValue(nameof(ShowOcrButton), true);
+        ShowPinButton = GetValue(nameof(ShowPinButton), true);
+        ShowSourcePlayButton = GetValue(nameof(ShowSourcePlayButton), true);
+        ShowSwapButton = GetValue(nameof(ShowSwapButton), true);
+        FixedWindowIsPinned = GetValue(nameof(FixedWindowIsPinned), true);
+
         LaunchAtStartup = GetValue(nameof(LaunchAtStartup), false);
         MinimizeToTrayOnStartup = GetValue(nameof(MinimizeToTrayOnStartup), false);
         EnableDpiAwareness = GetValue(nameof(EnableDpiAwareness), true);
@@ -992,6 +1026,15 @@ public sealed class SettingsService
         _settings[nameof(AutoPlayTranslation)] = AutoPlayTranslation;
         _settings[nameof(UILanguage)] = UILanguage;
         _settings[nameof(AppTheme)] = AppTheme;
+
+        // Appearance / personalization (issue #172)
+        _settings[nameof(ResultFontScale)] = ResultFontScale;
+        _settings[nameof(ShowOcrButton)] = ShowOcrButton;
+        _settings[nameof(ShowPinButton)] = ShowPinButton;
+        _settings[nameof(ShowSourcePlayButton)] = ShowSourcePlayButton;
+        _settings[nameof(ShowSwapButton)] = ShowSwapButton;
+        _settings[nameof(FixedWindowIsPinned)] = FixedWindowIsPinned;
+
         _settings[nameof(LaunchAtStartup)] = LaunchAtStartup;
         _settings[nameof(MinimizeToTrayOnStartup)] = MinimizeToTrayOnStartup;
         _settings[nameof(EnableDpiAwareness)] = EnableDpiAwareness;

--- a/dotnet/src/Easydict.WinUI/Services/WindowDragHelper.cs
+++ b/dotnet/src/Easydict.WinUI/Services/WindowDragHelper.cs
@@ -1,0 +1,111 @@
+using System.Runtime.InteropServices;
+using Microsoft.UI.Input;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Windows.Graphics;
+using WinRT.Interop;
+
+namespace Easydict.WinUI.Services;
+
+internal static class WindowDragHelper
+{
+    [DllImport("user32.dll")]
+    private static extern bool GetCursorPos(out POINT lpPoint);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    public static bool TryBeginLeftButtonDrag(
+        Window window,
+        UIElement dragElement,
+        PointerRoutedEventArgs args,
+        out WindowDragSession? session)
+    {
+        session = null;
+
+        var point = args.GetCurrentPoint(dragElement);
+        if (point.PointerDeviceType != PointerDeviceType.Mouse
+            || !point.Properties.IsLeftButtonPressed
+            || !TryGetAppWindow(window, out var appWindow)
+            || !TryGetCursorPosition(out var cursorPosition)
+            || !dragElement.CapturePointer(args.Pointer))
+        {
+            return false;
+        }
+
+        session = new WindowDragSession(
+            args.Pointer.PointerId,
+            appWindow,
+            cursorPosition,
+            appWindow.Position);
+        return true;
+    }
+
+    public static bool TryUpdateLeftButtonDrag(
+        WindowDragSession session,
+        UIElement dragElement,
+        PointerRoutedEventArgs args)
+    {
+        if (args.Pointer.PointerId != session.PointerId)
+        {
+            return false;
+        }
+
+        var point = args.GetCurrentPoint(dragElement);
+        if (point.PointerDeviceType != PointerDeviceType.Mouse
+            || !point.Properties.IsLeftButtonPressed
+            || !TryGetCursorPosition(out var cursorPosition))
+        {
+            return false;
+        }
+
+        var deltaX = cursorPosition.X - session.StartCursorPosition.X;
+        var deltaY = cursorPosition.Y - session.StartCursorPosition.Y;
+        session.AppWindow.Move(new PointInt32(
+            session.StartWindowPosition.X + deltaX,
+            session.StartWindowPosition.Y + deltaY));
+        return true;
+    }
+
+    public static bool IsSessionPointer(WindowDragSession session, PointerRoutedEventArgs args)
+    {
+        return args.Pointer.PointerId == session.PointerId;
+    }
+
+    private static bool TryGetAppWindow(Window window, out AppWindow appWindow)
+    {
+        appWindow = null!;
+        var hWnd = WindowNative.GetWindowHandle(window);
+        if (hWnd == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        var windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
+        appWindow = AppWindow.GetFromWindowId(windowId);
+        return appWindow is not null;
+    }
+
+    private static bool TryGetCursorPosition(out PointInt32 cursorPosition)
+    {
+        if (!GetCursorPos(out var point))
+        {
+            cursorPosition = default;
+            return false;
+        }
+
+        cursorPosition = new PointInt32(point.X, point.Y);
+        return true;
+    }
+}
+
+internal sealed record WindowDragSession(
+    uint PointerId,
+    AppWindow AppWindow,
+    PointInt32 StartCursorPosition,
+    PointInt32 StartWindowPosition);

--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -1335,6 +1335,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>إظهار زر التشغيل</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>تشغيل النص المصدر</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>إظهار زر التبديل</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -1317,6 +1317,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>اضبط حجم خط نتائج الترجمة.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>الوضع المضغوط</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>إخفاء العناوين والحالة وأيقونات المساعدة والإجراءات السريعة الثانوية لجعل واجهة الترجمة أكثر إحكامًا.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>أزرار الإجراءات السريعة</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -1308,4 +1308,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>اختصار غير صالح. مثال: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>ترجمة OCR</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>حجم خط النتائج</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>اضبط حجم خط نتائج الترجمة.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>أزرار الإجراءات السريعة</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>إظهار زر OCR</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>إظهار زر التثبيت</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>إظهار زر التشغيل</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>إظهار زر التبديل</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -896,4 +896,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>Ugyldig genvejstast. Eksempel: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>OCR-oversættelse</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>Skriftstørrelse for resultater</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>Juster skriftstørrelsen for oversættelsesresultater.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>Knapper til hurtig handling</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>Vis OCR-knap</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>Vis fastgør-knap</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>Vis afspil-knap</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>Vis ombyt-knap</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -923,6 +923,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>Vis afspil-knap</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>Afspil kildetekst</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>Vis ombyt-knap</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -905,6 +905,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>Juster skriftstørrelsen for oversættelsesresultater.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>Kompakt tilstand</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>Skjuler titler, status, hjælpeikoner og ekstra hurtighandlinger for en mere kompakt oversættelsesvisning.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>Knapper til hurtig handling</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -1322,6 +1322,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>Passen Sie die Schriftgröße der Übersetzungsergebnisse an.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>Kompaktmodus</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>Blendet Titel, Status, Hilfesymbole und zusätzliche Schnellaktionen aus, damit die Übersetzungsansicht kompakter wird.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>Schaltflächen für Schnellaktionen</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -1313,4 +1313,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>Ungültige Tastenkombination. Beispiel: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>OCR-Übersetzung</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>Schriftgröße der Ergebnisse</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>Passen Sie die Schriftgröße der Übersetzungsergebnisse an.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>Schaltflächen für Schnellaktionen</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>OCR-Schaltfläche anzeigen</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>Anheften-Schaltfläche anzeigen</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>Wiedergabe-Schaltfläche anzeigen</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>Tausch-Schaltfläche anzeigen</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -1340,6 +1340,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>Wiedergabe-Schaltfläche anzeigen</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>Ausgangstext vorlesen</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>Tausch-Schaltfläche anzeigen</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -701,6 +701,30 @@
   <data name="PinWindowTooltip" xml:space="preserve">
     <value>Pin window (stay on top)</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>OCR translate</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>Result font size</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>Adjust the font size of translation results.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>Quick action buttons</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>Show OCR button</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>Show pin button</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>Show play button</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>Show swap button</value>
+  </data>
 
   <!-- UI Language -->
   <data name="UILanguage" xml:space="preserve">

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -728,6 +728,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>Show play button</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>Play source text</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>Show swap button</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -710,6 +710,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>Adjust the font size of translation results.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>Compact mode</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>Hide titles, status, help icons, and helper quick actions for a tighter translation surface.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>Quick action buttons</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -1313,4 +1313,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>Raccourci non valide. Exemple : Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>Traduction OCR</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>Taille de police des résultats</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>Ajustez la taille de police des résultats de traduction.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>Boutons d'action rapide</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>Afficher le bouton OCR</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>Afficher le bouton d'épinglage</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>Afficher le bouton de lecture</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>Afficher le bouton d'échange</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -1322,6 +1322,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>Ajustez la taille de police des résultats de traduction.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>Mode compact</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>Masque les titres, l&apos;état, les icônes d&apos;aide et les actions rapides secondaires pour une interface de traduction plus compacte.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>Boutons d'action rapide</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -1340,6 +1340,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>Afficher le bouton de lecture</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>Lire le texte source</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>Afficher le bouton d'échange</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -923,6 +923,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>प्ले बटन दिखाएं</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>स्रोत टेक्स्ट चलाएं</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>स्वैप बटन दिखाएं</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -896,4 +896,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>अमान्य हॉटकी। उदाहरण: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>OCR अनुवाद</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>परिणाम फ़ॉन्ट आकार</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>अनुवाद परिणामों के फ़ॉन्ट आकार को समायोजित करें।</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>त्वरित क्रिया बटन</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>OCR बटन दिखाएं</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>पिन बटन दिखाएं</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>प्ले बटन दिखाएं</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>स्वैप बटन दिखाएं</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -905,6 +905,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>अनुवाद परिणामों के फ़ॉन्ट आकार को समायोजित करें।</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>कॉम्पैक्ट मोड</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>अनुवाद दृश्य को अधिक सघन बनाने के लिए शीर्षक, स्थिति, सहायता आइकन और सहायक त्वरित कार्रवाइयां छिपाएं।</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>त्वरित क्रिया बटन</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -1281,6 +1281,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>Tampilkan tombol putar</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>Putar teks sumber</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>Tampilkan tombol tukar</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -1263,6 +1263,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>Sesuaikan ukuran font hasil terjemahan.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>Mode ringkas</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>Sembunyikan judul, status, ikon bantuan, dan tindakan cepat tambahan agar tampilan terjemahan lebih ringkas.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>Tombol aksi cepat</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -1254,4 +1254,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>Pintasan tidak valid. Contoh: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>Terjemahan OCR</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>Ukuran font hasil</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>Sesuaikan ukuran font hasil terjemahan.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>Tombol aksi cepat</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>Tampilkan tombol OCR</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>Tampilkan tombol sematkan</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>Tampilkan tombol putar</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>Tampilkan tombol tukar</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -1300,4 +1300,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>Scorciatoia non valida. Esempio: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>Traduzione OCR</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>Dimensione carattere dei risultati</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>Regola la dimensione del carattere dei risultati di traduzione.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>Pulsanti di azione rapida</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>Mostra pulsante OCR</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>Mostra pulsante blocca</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>Mostra pulsante riproduci</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>Mostra pulsante scambia</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -1327,6 +1327,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>Mostra pulsante riproduci</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>Riproduci testo sorgente</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>Mostra pulsante scambia</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -1309,6 +1309,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>Regola la dimensione del carattere dei risultati di traduzione.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>Modalità compatta</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>Nasconde titoli, stato, icone di aiuto e azioni rapide secondarie per rendere l&apos;interfaccia di traduzione più compatta.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>Pulsanti di azione rapida</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -1340,6 +1340,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>再生ボタンを表示</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>原文を再生</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>入れ替えボタンを表示</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -1322,6 +1322,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>翻訳結果のフォントサイズを調整します。</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>コンパクトモード</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>タイトル、ステータス、ヘルプアイコン、補助的なクイック操作を隠して翻訳画面をよりコンパクトにします。</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>クイック操作ボタン</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -1313,4 +1313,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>ホットキーが無効です。例: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>OCR 翻訳</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>結果のフォントサイズ</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>翻訳結果のフォントサイズを調整します。</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>クイック操作ボタン</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>OCR ボタンを表示</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>固定ボタンを表示</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>再生ボタンを表示</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>入れ替えボタンを表示</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -1340,6 +1340,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>재생 버튼 표시</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>원문 재생</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>교체 버튼 표시</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -1313,4 +1313,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>잘못된 단축키입니다. 예: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>OCR 번역</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>결과 글꼴 크기</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>번역 결과의 글꼴 크기를 조정합니다.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>빠른 작업 버튼</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>OCR 버튼 표시</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>고정 버튼 표시</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>재생 버튼 표시</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>교체 버튼 표시</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -1322,6 +1322,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>번역 결과의 글꼴 크기를 조정합니다.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>간결 모드</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>제목, 상태, 도움말 아이콘, 보조 빠른 동작을 숨겨 번역 화면을 더 간결하게 만듭니다.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>빠른 작업 버튼</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -923,6 +923,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>Tunjukkan butang main</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>Mainkan teks sumber</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>Tunjukkan butang tukar</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -896,4 +896,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>Pintasan tidak sah. Contoh: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>Terjemahan OCR</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>Saiz fon hasil</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>Laraskan saiz fon hasil terjemahan.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>Butang tindakan pantas</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>Tunjukkan butang OCR</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>Tunjukkan butang pin</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>Tunjukkan butang main</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>Tunjukkan butang tukar</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -905,6 +905,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>Laraskan saiz fon hasil terjemahan.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>Mod padat</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>Sembunyikan tajuk, status, ikon bantuan dan tindakan pantas tambahan untuk paparan terjemahan yang lebih padat.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>Butang tindakan pantas</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -1289,6 +1289,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>แสดงปุ่มเล่น</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>เล่นข้อความต้นฉบับ</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>แสดงปุ่มสลับ</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -1271,6 +1271,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>ปรับขนาดฟอนต์ของผลการแปล</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>โหมดกะทัดรัด</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>ซ่อนชื่อเรื่อง สถานะ ไอคอนช่วยเหลือ และปุ่มลัดเสริม เพื่อให้หน้าต่างแปลภาษากะทัดรัดขึ้น</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>ปุ่มการทำงานด่วน</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -1262,4 +1262,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>ปุ่มลัดไม่ถูกต้อง ตัวอย่าง: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>การแปล OCR</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>ขนาดฟอนต์ผลลัพธ์</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>ปรับขนาดฟอนต์ของผลการแปล</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>ปุ่มการทำงานด่วน</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>แสดงปุ่ม OCR</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>แสดงปุ่มปักหมุด</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>แสดงปุ่มเล่น</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>แสดงปุ่มสลับ</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -1308,4 +1308,28 @@
   <data name="InvalidHotkeyInlineError" xml:space="preserve">
     <value>Phím tắt không hợp lệ. Ví dụ: Ctrl+Alt+T</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>Dịch OCR</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>Cỡ chữ kết quả</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>Điều chỉnh cỡ chữ của kết quả dịch.</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>Nút thao tác nhanh</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>Hiển thị nút OCR</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>Hiển thị nút ghim</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>Hiển thị nút phát</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>Hiển thị nút hoán đổi</value>
+  </data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -1335,6 +1335,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>Hiển thị nút phát</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>Phát văn bản nguồn</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>Hiển thị nút hoán đổi</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -1317,6 +1317,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>Điều chỉnh cỡ chữ của kết quả dịch.</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>Chế độ thu gọn</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>Ẩn tiêu đề, trạng thái, biểu tượng trợ giúp và thao tác nhanh phụ để giao diện dịch gọn hơn.</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>Nút thao tác nhanh</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -728,6 +728,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>显示朗读按钮</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>朗读源文本</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>显示交换按钮</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -710,6 +710,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>调整翻译结果的字体大小。</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>紧凑模式</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>隐藏标题、状态、提示图标和辅助快捷按钮，让翻译界面更紧凑。</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>快捷操作按钮</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -701,6 +701,30 @@
   <data name="PinWindowTooltip" xml:space="preserve">
     <value>固定窗口（保持置顶）</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>OCR 翻译</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>结果字体大小</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>调整翻译结果的字体大小。</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>快捷操作按钮</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>显示 OCR 按钮</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>显示置顶按钮</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>显示朗读按钮</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>显示交换按钮</value>
+  </data>
 
   <!-- UI Language -->
   <data name="UILanguage" xml:space="preserve">

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -742,6 +742,30 @@
   <data name="PinWindowTooltip" xml:space="preserve">
     <value>釘選視窗（保持在最上層）</value>
   </data>
+  <data name="OcrButtonTooltip" xml:space="preserve">
+    <value>OCR 翻譯</value>
+  </data>
+  <data name="ResultFontSize" xml:space="preserve">
+    <value>結果字型大小</value>
+  </data>
+  <data name="ResultFontSizeDescription" xml:space="preserve">
+    <value>調整翻譯結果的字型大小。</value>
+  </data>
+  <data name="QuickActionsHeader" xml:space="preserve">
+    <value>快捷操作按鈕</value>
+  </data>
+  <data name="ShowOcrButton" xml:space="preserve">
+    <value>顯示 OCR 按鈕</value>
+  </data>
+  <data name="ShowPinButton" xml:space="preserve">
+    <value>顯示釘選按鈕</value>
+  </data>
+  <data name="ShowSourcePlayButton" xml:space="preserve">
+    <value>顯示朗讀按鈕</value>
+  </data>
+  <data name="ShowSwapButton" xml:space="preserve">
+    <value>顯示交換按鈕</value>
+  </data>
   <data name="Close" xml:space="preserve">
     <value>關閉</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -751,6 +751,12 @@
   <data name="ResultFontSizeDescription" xml:space="preserve">
     <value>調整翻譯結果的字型大小。</value>
   </data>
+  <data name="CompactMode" xml:space="preserve">
+    <value>緊湊模式</value>
+  </data>
+  <data name="CompactModeDescription" xml:space="preserve">
+    <value>隱藏標題、狀態、提示圖示和輔助快捷按鈕，讓翻譯介面更緊湊。</value>
+  </data>
   <data name="QuickActionsHeader" xml:space="preserve">
     <value>快捷操作按鈕</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -769,6 +769,9 @@
   <data name="ShowSourcePlayButton" xml:space="preserve">
     <value>顯示朗讀按鈕</value>
   </data>
+  <data name="PlaySourceTextTooltip" xml:space="preserve">
+    <value>朗讀原文</value>
+  </data>
   <data name="ShowSwapButton" xml:space="preserve">
     <value>顯示交換按鈕</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Themes/Colors.xaml
+++ b/dotnet/src/Easydict.WinUI/Themes/Colors.xaml
@@ -73,20 +73,20 @@
 
             <CornerRadius x:Key="ControlCornerRadius">10</CornerRadius>
             <CornerRadius x:Key="OverlayCornerRadius">10</CornerRadius>
-            <CornerRadius x:Key="EasydictCardCornerRadius">10</CornerRadius>
+            <CornerRadius x:Key="EasydictCardCornerRadius">6</CornerRadius>
             <CornerRadius x:Key="EasydictControlCornerRadius">10</CornerRadius>
             <CornerRadius x:Key="EasydictRoundButtonCornerRadius">20</CornerRadius>
             <CornerRadius x:Key="EasydictStatusCornerRadius">12</CornerRadius>
             <CornerRadius x:Key="FloatingWindowCornerRadius">0</CornerRadius>
-            <CornerRadius x:Key="FloatingInputCornerRadius">18</CornerRadius>
+            <CornerRadius x:Key="FloatingInputCornerRadius">10</CornerRadius>
             <Thickness x:Key="EasydictCardBorderThickness">1</Thickness>
             <Thickness x:Key="EasydictIconButtonBorderThickness">0</Thickness>
             <Thickness x:Key="FloatingWindowOuterPadding">0</Thickness>
-            <Thickness x:Key="FloatingWindowContentPadding">16</Thickness>
+            <Thickness x:Key="FloatingWindowContentPadding">10</Thickness>
             <Thickness x:Key="FloatingWindowBorderThickness">0</Thickness>
-            <Thickness x:Key="FloatingInputPadding">12,10</Thickness>
-            <Thickness x:Key="FloatingInputMargin">0,2,0,6</Thickness>
-            <Thickness x:Key="EasydictCardPadding">12</Thickness>
+            <Thickness x:Key="FloatingInputPadding">8,6</Thickness>
+            <Thickness x:Key="FloatingInputMargin">0,1,0,4</Thickness>
+            <Thickness x:Key="EasydictCardPadding">8</Thickness>
 
             <!-- Brushes -->
             <SolidColorBrush x:Key="MainViewBackgroundBrush" Color="{StaticResource MainViewBackgroundColor}" />
@@ -277,20 +277,20 @@
 
             <CornerRadius x:Key="ControlCornerRadius">10</CornerRadius>
             <CornerRadius x:Key="OverlayCornerRadius">10</CornerRadius>
-            <CornerRadius x:Key="EasydictCardCornerRadius">10</CornerRadius>
+            <CornerRadius x:Key="EasydictCardCornerRadius">6</CornerRadius>
             <CornerRadius x:Key="EasydictControlCornerRadius">10</CornerRadius>
             <CornerRadius x:Key="EasydictRoundButtonCornerRadius">20</CornerRadius>
             <CornerRadius x:Key="EasydictStatusCornerRadius">12</CornerRadius>
             <CornerRadius x:Key="FloatingWindowCornerRadius">0</CornerRadius>
-            <CornerRadius x:Key="FloatingInputCornerRadius">18</CornerRadius>
+            <CornerRadius x:Key="FloatingInputCornerRadius">10</CornerRadius>
             <Thickness x:Key="EasydictCardBorderThickness">1</Thickness>
             <Thickness x:Key="EasydictIconButtonBorderThickness">0</Thickness>
             <Thickness x:Key="FloatingWindowOuterPadding">0</Thickness>
-            <Thickness x:Key="FloatingWindowContentPadding">16</Thickness>
+            <Thickness x:Key="FloatingWindowContentPadding">10</Thickness>
             <Thickness x:Key="FloatingWindowBorderThickness">0</Thickness>
-            <Thickness x:Key="FloatingInputPadding">12,10</Thickness>
-            <Thickness x:Key="FloatingInputMargin">0,2,0,6</Thickness>
-            <Thickness x:Key="EasydictCardPadding">12</Thickness>
+            <Thickness x:Key="FloatingInputPadding">8,6</Thickness>
+            <Thickness x:Key="FloatingInputMargin">0,1,0,4</Thickness>
+            <Thickness x:Key="EasydictCardPadding">8</Thickness>
 
             <!-- Brushes -->
             <SolidColorBrush x:Key="MainViewBackgroundBrush" Color="#1F2229" />

--- a/dotnet/src/Easydict.WinUI/Themes/Colors.xaml
+++ b/dotnet/src/Easydict.WinUI/Themes/Colors.xaml
@@ -75,18 +75,18 @@
             <CornerRadius x:Key="OverlayCornerRadius">10</CornerRadius>
             <CornerRadius x:Key="EasydictCardCornerRadius">6</CornerRadius>
             <CornerRadius x:Key="EasydictControlCornerRadius">10</CornerRadius>
-            <CornerRadius x:Key="EasydictRoundButtonCornerRadius">20</CornerRadius>
+            <CornerRadius x:Key="EasydictRoundButtonCornerRadius">18</CornerRadius>
             <CornerRadius x:Key="EasydictStatusCornerRadius">12</CornerRadius>
             <CornerRadius x:Key="FloatingWindowCornerRadius">0</CornerRadius>
             <CornerRadius x:Key="FloatingInputCornerRadius">10</CornerRadius>
             <Thickness x:Key="EasydictCardBorderThickness">1</Thickness>
             <Thickness x:Key="EasydictIconButtonBorderThickness">0</Thickness>
             <Thickness x:Key="FloatingWindowOuterPadding">0</Thickness>
-            <Thickness x:Key="FloatingWindowContentPadding">10</Thickness>
+            <Thickness x:Key="FloatingWindowContentPadding">8</Thickness>
             <Thickness x:Key="FloatingWindowBorderThickness">0</Thickness>
-            <Thickness x:Key="FloatingInputPadding">8,6</Thickness>
-            <Thickness x:Key="FloatingInputMargin">0,1,0,4</Thickness>
-            <Thickness x:Key="EasydictCardPadding">8</Thickness>
+            <Thickness x:Key="FloatingInputPadding">6,4</Thickness>
+            <Thickness x:Key="FloatingInputMargin">0,0,0,3</Thickness>
+            <Thickness x:Key="EasydictCardPadding">6</Thickness>
 
             <!-- Brushes -->
             <SolidColorBrush x:Key="MainViewBackgroundBrush" Color="{StaticResource MainViewBackgroundColor}" />
@@ -279,18 +279,18 @@
             <CornerRadius x:Key="OverlayCornerRadius">10</CornerRadius>
             <CornerRadius x:Key="EasydictCardCornerRadius">6</CornerRadius>
             <CornerRadius x:Key="EasydictControlCornerRadius">10</CornerRadius>
-            <CornerRadius x:Key="EasydictRoundButtonCornerRadius">20</CornerRadius>
+            <CornerRadius x:Key="EasydictRoundButtonCornerRadius">18</CornerRadius>
             <CornerRadius x:Key="EasydictStatusCornerRadius">12</CornerRadius>
             <CornerRadius x:Key="FloatingWindowCornerRadius">0</CornerRadius>
             <CornerRadius x:Key="FloatingInputCornerRadius">10</CornerRadius>
             <Thickness x:Key="EasydictCardBorderThickness">1</Thickness>
             <Thickness x:Key="EasydictIconButtonBorderThickness">0</Thickness>
             <Thickness x:Key="FloatingWindowOuterPadding">0</Thickness>
-            <Thickness x:Key="FloatingWindowContentPadding">10</Thickness>
+            <Thickness x:Key="FloatingWindowContentPadding">8</Thickness>
             <Thickness x:Key="FloatingWindowBorderThickness">0</Thickness>
-            <Thickness x:Key="FloatingInputPadding">8,6</Thickness>
-            <Thickness x:Key="FloatingInputMargin">0,1,0,4</Thickness>
-            <Thickness x:Key="EasydictCardPadding">8</Thickness>
+            <Thickness x:Key="FloatingInputPadding">6,4</Thickness>
+            <Thickness x:Key="FloatingInputMargin">0,0,0,3</Thickness>
+            <Thickness x:Key="EasydictCardPadding">6</Thickness>
 
             <!-- Brushes -->
             <SolidColorBrush x:Key="MainViewBackgroundBrush" Color="#1F2229" />

--- a/dotnet/src/Easydict.WinUI/Views/Controls/CompactWindowControlsView.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/CompactWindowControlsView.cs
@@ -27,6 +27,7 @@ internal sealed class CompactWindowControlsView
             HorizontalAlignment = HorizontalAlignment.Right,
             VerticalAlignment = VerticalAlignment.Top,
             Margin = new Thickness(0),
+            Background = new SolidColorBrush(Colors.Transparent),
             Opacity = 0.52,
             Visibility = Visibility.Collapsed
         };

--- a/dotnet/src/Easydict.WinUI/Views/Controls/CompactWindowControlsView.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/CompactWindowControlsView.cs
@@ -1,0 +1,126 @@
+using Easydict.WinUI.Services;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Easydict.WinUI.Views.Controls;
+
+internal sealed class CompactWindowControlsView
+{
+    private readonly Border _surface;
+    private readonly Border _separator;
+    private readonly FontIcon _closeIcon;
+
+    public CompactWindowControlsView()
+    {
+        Root = new Grid
+        {
+            Width = 44,
+            Height = 44,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(0),
+            Opacity = 0.52,
+            Visibility = Visibility.Collapsed
+        };
+        Grid.SetRowSpan(Root, 6);
+        Canvas.SetZIndex(Root, 10);
+
+        _surface = new Border
+        {
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(22)
+        };
+        Root.Children.Add(_surface);
+
+        var layout = new Grid { Margin = new Thickness(1) };
+        layout.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        layout.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        Root.Children.Add(layout);
+
+        _closeIcon = new FontIcon { Glyph = "\uE8BB", FontSize = 9 };
+        CloseButton = CreateSegmentButton(_closeIcon);
+        Grid.SetRow(CloseButton, 0);
+        layout.Children.Add(CloseButton);
+
+        _separator = CreateSeparator();
+        Grid.SetRow(_separator, 0);
+        layout.Children.Add(_separator);
+
+        DragIsland = new Border
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            CornerRadius = new CornerRadius(0, 0, 21, 21)
+        };
+        Grid.SetRow(DragIsland, 1);
+
+        DragIsland.Child = new Image
+        {
+            Source = new BitmapImage(new Uri("ms-appx:///Assets/Square44x44Logo.targetsize-24_altform-unplated.png")),
+            Width = 18,
+            Height = 18,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsHitTestVisible = false,
+            Opacity = 0.52,
+            Stretch = Stretch.Uniform
+        };
+        layout.Children.Add(DragIsland);
+    }
+
+    public Grid Root { get; }
+
+    public Button CloseButton { get; }
+
+    public Border DragIsland { get; }
+
+    public void RefreshTheme(FrameworkElement? themeRoot)
+    {
+        var surfaceBrush = ThemeResourceService.GetBrush("ControlFillColorDefaultBrush", themeRoot)
+            ?? new SolidColorBrush(Colors.White);
+        var secondarySurfaceBrush = ThemeResourceService.GetBrush("ControlFillColorSecondaryBrush", themeRoot)
+            ?? surfaceBrush;
+        var strokeBrush = ThemeResourceService.GetBrush("ControlStrokeColorDefaultBrush", themeRoot)
+            ?? new SolidColorBrush(Colors.Gray);
+        var textBrush = ThemeResourceService.GetBrush("TextFillColorSecondaryBrush", themeRoot)
+            ?? new SolidColorBrush(Colors.DimGray);
+        var transparentBrush = new SolidColorBrush(Colors.Transparent);
+
+        _surface.Background = surfaceBrush;
+        _surface.BorderBrush = strokeBrush;
+        _separator.Background = strokeBrush;
+        DragIsland.Background = secondarySurfaceBrush;
+        CloseButton.Background = transparentBrush;
+        _closeIcon.Foreground = textBrush;
+    }
+
+    private static Button CreateSegmentButton(FontIcon icon)
+    {
+        return new Button
+        {
+            Content = icon,
+            Background = new SolidColorBrush(Colors.Transparent),
+            BorderThickness = new Thickness(0),
+            MinWidth = 0,
+            MinHeight = 0,
+            Padding = new Thickness(0),
+            IsTabStop = false,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch
+        };
+    }
+
+    private static Border CreateSeparator()
+    {
+        return new Border
+        {
+            Height = 1,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            IsHitTestVisible = false,
+            Opacity = 0.55
+        };
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Views/Controls/CompactWindowControlsView.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/CompactWindowControlsView.cs
@@ -107,7 +107,6 @@ internal sealed class CompactWindowControlsView
             MinWidth = 0,
             MinHeight = 0,
             Padding = new Thickness(0),
-            IsTabStop = false,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch
         };

--- a/dotnet/src/Easydict.WinUI/Views/Controls/CompactWindowControlsView.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/CompactWindowControlsView.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.IO;
 using Easydict.WinUI.Services;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
@@ -9,6 +11,9 @@ namespace Easydict.WinUI.Views.Controls;
 
 internal sealed class CompactWindowControlsView
 {
+    private const string DragIconAppxUri = "ms-appx:///Assets/Square44x44Logo.targetsize-24_altform-unplated.png";
+    private const string DragIconRelativePath = @"Assets\Square44x44Logo.targetsize-24_altform-unplated.png";
+
     private readonly Border _surface;
     private readonly Border _separator;
     private readonly FontIcon _closeIcon;
@@ -59,7 +64,7 @@ internal sealed class CompactWindowControlsView
 
         DragIsland.Child = new Image
         {
-            Source = new BitmapImage(new Uri("ms-appx:///Assets/Square44x44Logo.targetsize-24_altform-unplated.png")),
+            Source = CreateDragIconSource(),
             Width = 18,
             Height = 18,
             HorizontalAlignment = HorizontalAlignment.Center,
@@ -95,6 +100,35 @@ internal sealed class CompactWindowControlsView
         DragIsland.Background = secondarySurfaceBrush;
         CloseButton.Background = transparentBrush;
         _closeIcon.Foreground = textBrush;
+    }
+
+    private static ImageSource CreateDragIconSource()
+    {
+        if (!EasydictConditions.IsPackaged)
+        {
+            var iconPath = Path.Combine(AppContext.BaseDirectory, DragIconRelativePath);
+            if (File.Exists(iconPath))
+            {
+                try
+                {
+                    return new BitmapImage(new Uri(iconPath));
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[CompactWindowControls] Failed to load icon from file path: {ex.Message}");
+                }
+            }
+        }
+
+        try
+        {
+            return new BitmapImage(new Uri(DragIconAppxUri));
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[CompactWindowControls] Failed to load icon from ms-appx: {ex.Message}");
+            return new BitmapImage();
+        }
     }
 
     private static Button CreateSegmentButton(FontIcon icon)

--- a/dotnet/src/Easydict.WinUI/Views/Controls/IServiceResultView.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/IServiceResultView.cs
@@ -1,4 +1,5 @@
 using Easydict.TranslationService.Models;
+using Easydict.WinUI.Services;
 using Microsoft.UI.Xaml;
 
 namespace Easydict.WinUI.Views.Controls;
@@ -31,6 +32,14 @@ public interface IServiceResultView
     void RefreshDemotionState();
 
     void RefreshThemeChrome()
+    {
+    }
+
+    /// <summary>
+    /// Apply user-configurable appearance (result font size) to this item.
+    /// Default no-op keeps the interface non-breaking for any other implementers.
+    /// </summary>
+    void ApplyAppearance(AppearanceSettings settings)
     {
     }
 

--- a/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml
@@ -13,7 +13,7 @@
         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
         BorderThickness="{ThemeResource EasydictCardBorderThickness}"
         CornerRadius="{ThemeResource EasydictCardCornerRadius}"
-        Margin="0,0,0,4">
+        Margin="0,0,0,2">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -26,7 +26,7 @@
                 Background="{ThemeResource ServiceResultHeaderBackgroundBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                 BorderThickness="0,0,0,1"
-                Padding="8,5"
+                Padding="6,4"
                 PointerPressed="OnHeaderPointerPressed">
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml.cs
@@ -69,8 +69,6 @@ public sealed partial class MinimalServiceResultItem : UserControl, IServiceResu
         ServiceNameText.FontSize = settings.ServiceNameFontSize;
         StatusText.FontSize = settings.StatusFontSize;
         ResultText.FontSize = settings.ResultFontSize;
-        ErrorText.FontSize = settings.ResultFontSize;
-        PendingQueryText.FontSize = settings.ResultFontSize;
     }
 
     public IEnumerable<string> GetDisplayedPhoneticKeys() => Array.Empty<string>();

--- a/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/MinimalServiceResultItem.xaml.cs
@@ -64,6 +64,15 @@ public sealed partial class MinimalServiceResultItem : UserControl, IServiceResu
 
     public void RefreshDemotionState() => QueueUpdateUI();
 
+    public void ApplyAppearance(AppearanceSettings settings)
+    {
+        ServiceNameText.FontSize = settings.ServiceNameFontSize;
+        StatusText.FontSize = settings.StatusFontSize;
+        ResultText.FontSize = settings.ResultFontSize;
+        ErrorText.FontSize = settings.ResultFontSize;
+        PendingQueryText.FontSize = settings.ResultFontSize;
+    }
+
     public IEnumerable<string> GetDisplayedPhoneticKeys() => Array.Empty<string>();
 
     public void Cleanup()

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml
@@ -14,7 +14,7 @@
         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
         BorderThickness="{ThemeResource EasydictCardBorderThickness}"
         CornerRadius="{ThemeResource EasydictCardCornerRadius}"
-        Margin="0,0,0,8"
+        Margin="0,0,0,4"
         PointerEntered="OnControlPointerEntered"
         PointerExited="OnControlPointerExited">
         <Grid>

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -115,8 +115,6 @@ public sealed partial class ServiceResultItem : UserControl, IServiceResultView
         StatusText.FontSize = settings.StatusFontSize;
         ResultText.FontSize = settings.ResultFontSize;
         CorrectedText.FontSize = settings.ResultFontSize;
-        ErrorText.FontSize = settings.ResultFontSize;
-        PendingQueryText.FontSize = settings.ResultFontSize;
     }
 
     public void RefreshThemeChrome()

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultItem.xaml.cs
@@ -109,6 +109,16 @@ public sealed partial class ServiceResultItem : UserControl, IServiceResultView
     /// </summary>
     public void RefreshDemotionState() => QueueUpdateUI();
 
+    public void ApplyAppearance(AppearanceSettings settings)
+    {
+        ServiceNameText.FontSize = settings.ServiceNameFontSize;
+        StatusText.FontSize = settings.StatusFontSize;
+        ResultText.FontSize = settings.ResultFontSize;
+        CorrectedText.FontSize = settings.ResultFontSize;
+        ErrorText.FontSize = settings.ResultFontSize;
+        PendingQueryText.FontSize = settings.ResultFontSize;
+    }
+
     public void RefreshThemeChrome()
     {
         ApplyServiceChromeForCurrentTheme();

--- a/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultViewHost.cs
+++ b/dotnet/src/Easydict.WinUI/Views/Controls/ServiceResultViewHost.cs
@@ -30,6 +30,7 @@ internal static class ServiceResultViewHost
         control.ServiceResult = result;
         ApplyAutomationProperties(control, result);
         control.RefreshThemeChrome();
+        control.ApplyAppearance(AppearanceService.CurrentSnapshot());
         return control;
     }
 
@@ -252,6 +253,21 @@ internal static class ServiceResultViewHost
             }
 
             control.RefreshThemeChrome();
+        }
+    }
+
+    /// <summary>
+    /// Re-apply the current appearance snapshot (result font size) to existing items.
+    /// Mirrors <see cref="RefreshThemeChrome"/>; call after a font-size setting change.
+    /// </summary>
+    public static void RefreshAppearance(IEnumerable<IServiceResultView> controls)
+    {
+        using var hotspot = UiThreadHotspotDiagnostics.Measure("ServiceResultViewHost.RefreshAppearance");
+
+        var snapshot = AppearanceService.CurrentSnapshot();
+        foreach (var control in controls)
+        {
+            control.ApplyAppearance(snapshot);
         }
     }
 

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
@@ -87,6 +87,7 @@
 
             <Button
                 x:Name="CloseButton"
+                AutomationProperties.Name="Hide window"
                 Grid.Column="3"
                 Click="OnCloseClicked"
                 Style="{StaticResource EasydictIconButtonStyle}"
@@ -161,6 +162,7 @@
                 Padding="0"
                 Style="{StaticResource EasydictIconButtonStyle}"
                 ToolTipService.ToolTip="Swap languages"
+                AutomationProperties.Name="Swap languages"
                 Margin="4,0">
                 <FontIcon Glyph="&#xE8AB;"
                         FontSize="12"
@@ -185,6 +187,7 @@
                 Padding="0"
                 Style="{StaticResource EasydictPrimaryRoundButtonStyle}"
                 ToolTipService.ToolTip="Translate"
+                AutomationProperties.Name="Translate"
                 Margin="4,0,0,0">
                 <Grid>
                     <ProgressRing

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
@@ -47,6 +47,7 @@
                 Grid.Column="0"
                 Click="OnPinClicked"
                 ToolTipService.ToolTip="Pin window (stay on top)"
+                AutomationProperties.Name="Pin window (stay on top)"
                 Background="Transparent"
                 BorderThickness="0"
                 CornerRadius="{ThemeResource EasydictControlCornerRadius}"
@@ -74,6 +75,7 @@
                 Click="OnOcrClicked"
                 Style="{StaticResource EasydictIconButtonStyle}"
                 ToolTipService.ToolTip="OCR translate"
+                AutomationProperties.Name="OCR translate"
                 Width="28"
                 Height="28"
                 Padding="0">

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
@@ -30,28 +30,61 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <!-- Header with Close button (no Pin - always on top) - also serves as drag region -->
+                <!-- Header with Pin, OCR and Hide buttons - also serves as drag region -->
                 <Grid x:Name="TitleBarRegion"
                 Grid.Row="0"
                 Margin="0,0,0,4"
                 Background="Transparent">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock
+            <ToggleButton
+                x:Name="PinButton"
                 Grid.Column="0"
+                Click="OnPinClicked"
+                ToolTipService.ToolTip="Pin window (stay on top)"
+                Background="Transparent"
+                BorderThickness="0"
+                CornerRadius="{ThemeResource EasydictControlCornerRadius}"
+                Width="28"
+                Height="28"
+                Padding="0">
+                <FontIcon x:Name="PinIcon"
+                        Glyph="&#xE718;"
+                        FontSize="14"
+                        Foreground="{ThemeResource ButtonForeground}"/>
+            </ToggleButton>
+
+            <TextBlock
+                Grid.Column="1"
                 Text="Fixed Translate"
                 FontSize="12"
                 FontWeight="SemiBold"
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                 VerticalAlignment="Center"
-                Margin="4,0,0,0"/>
+                HorizontalAlignment="Center"/>
+
+            <Button
+                x:Name="OcrButton"
+                Grid.Column="2"
+                Click="OnOcrClicked"
+                Style="{StaticResource EasydictIconButtonStyle}"
+                ToolTipService.ToolTip="OCR translate"
+                Width="28"
+                Height="28"
+                Padding="0">
+                <FontIcon Glyph="&#xE722;"
+                        FontSize="14"
+                        Foreground="{ThemeResource ButtonForeground}"/>
+            </Button>
 
             <Button
                 x:Name="CloseButton"
-                Grid.Column="1"
+                Grid.Column="3"
                 Click="OnCloseClicked"
                 Style="{StaticResource EasydictIconButtonStyle}"
                 ToolTipService.ToolTip="Hide (Ctrl+Alt+F to show again)"

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml
@@ -19,7 +19,7 @@
             BorderBrush="{ThemeResource MainBorderBrush}"
             BorderThickness="0"
             CornerRadius="0"
-            Padding="16">
+            Padding="{ThemeResource FloatingWindowContentPadding}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -61,6 +61,7 @@
             </ToggleButton>
 
             <TextBlock
+                x:Name="TitleText"
                 Grid.Column="1"
                 Text="Fixed Translate"
                 FontSize="12"

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -163,6 +163,8 @@ public sealed partial class FixedWindow : Window
         ToolTipService.SetToolTip(PinButton, loc.GetString("PinWindowTooltip"));
         ToolTipService.SetToolTip(OcrButton, loc.GetString("OcrButtonTooltip"));
         ToolTipService.SetToolTip(CloseButton, loc.GetString("HideWindow"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(PinButton, loc.GetString("PinWindowTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(OcrButton, loc.GetString("OcrButtonTooltip"));
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
         ToolTipService.SetToolTip(TargetLangCombo, loc.GetString("TargetLanguageTooltip"));

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -49,6 +49,8 @@ public sealed partial class FixedWindow : Window
     private QuickQueryLanguageResolution? _lastQuickQueryResolution;
     private bool _showingGrammarFallbackNotice;
     private TitleBarDragRegionHelper? _titleBarHelper;
+    private CompactWindowControlsView? _compactWindowControls;
+    private WindowDragSession? _compactWindowDragSession;
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _resizeThrottleTimer;
     private bool _resizePending;      // resize requested but not yet executed
     private bool _resizeThrottling;   // inside cooldown window
@@ -59,6 +61,7 @@ public sealed partial class FixedWindow : Window
     private const int ResizeThrottleMs = 150;
     private const int InputFocusRetryDelayMs = 50;
     private const int InputFocusMaxAttempts = 10;
+    private const double CompactWindowControlsIdleOpacity = 0.52;
 
     /// <summary>
     /// Maximum time to wait for in-flight query to complete during cleanup.
@@ -69,6 +72,7 @@ public sealed partial class FixedWindow : Window
     {
         _targetLanguageSelector = new TargetLanguageSelector(_settings);
         this.InitializeComponent();
+        InitializeCompactWindowControls();
 
         // Frame-rate streaming text applicator — see StreamingTextCoalescer.
         _streamingCoalescer = new StreamingTextCoalescer(DispatcherQueue);
@@ -165,10 +169,39 @@ public sealed partial class FixedWindow : Window
         ToolTipService.SetToolTip(CloseButton, loc.GetString("HideWindow"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(PinButton, loc.GetString("PinWindowTooltip"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(OcrButton, loc.GetString("OcrButtonTooltip"));
+        if (_compactWindowControls is { } compactControls)
+        {
+            ToolTipService.SetToolTip(compactControls.CloseButton, loc.GetString("HideWindow"));
+            ToolTipService.SetToolTip(compactControls.DragIsland, loc.GetStringOrDefault("DragWindowTooltip", "Drag window"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(compactControls.CloseButton, loc.GetString("HideWindow"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+                compactControls.DragIsland,
+                loc.GetStringOrDefault("DragWindowTooltip", "Drag window"));
+        }
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
         ToolTipService.SetToolTip(TargetLangCombo, loc.GetString("TargetLanguageTooltip"));
         ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
+    }
+
+    private void InitializeCompactWindowControls()
+    {
+        if (WindowSurface.Child is not Grid surfaceGrid)
+        {
+            return;
+        }
+
+        _compactWindowControls = new CompactWindowControlsView();
+        surfaceGrid.Children.Add(_compactWindowControls.Root);
+        _compactWindowControls.Root.PointerEntered += OnCompactWindowControlsPointerEntered;
+        _compactWindowControls.Root.PointerExited += OnCompactWindowControlsPointerExited;
+        _compactWindowControls.DragIsland.PointerPressed += OnCompactDragIslandPointerPressed;
+        _compactWindowControls.DragIsland.PointerMoved += OnCompactDragIslandPointerMoved;
+        _compactWindowControls.DragIsland.PointerReleased += OnCompactDragIslandPointerReleased;
+        _compactWindowControls.DragIsland.PointerCanceled += OnCompactDragIslandPointerCanceled;
+        _compactWindowControls.DragIsland.PointerCaptureLost += OnCompactDragIslandPointerCaptureLost;
+        _compactWindowControls.CloseButton.Click += OnCompactCloseClicked;
+        _compactWindowControls.RefreshTheme(Content as FrameworkElement);
     }
 
     /// <summary>
@@ -229,6 +262,7 @@ public sealed partial class FixedWindow : Window
         // Apply pin state + quick-action button visibility from settings
         UpdatePinState();
         ApplyButtonVisibility();
+        ApplyCompactChromeLayout();
     }
 
     /// <summary>
@@ -442,7 +476,7 @@ public sealed partial class FixedWindow : Window
             DetectedLangText.Text = loc.GetStringOrDefault(
                 "GrammarCorrectionFallbackNotice",
                 "No grammar-capable AI service is enabled, so this query fell back to translation. Enable an AI service that supports grammar correction to show correction details when source and target are the same.");
-            DetectedLangText.Visibility = Visibility.Visible;
+            DetectedLangText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
             RequestResize();
             return;
         }
@@ -452,7 +486,7 @@ public sealed partial class FixedWindow : Window
             DetectedLangText.Text = loc.GetStringOrDefault(
                 "GrammarCorrectionActiveNotice",
                 "Grammar check mode: AI correction services will run. Choose a different target language to translate.");
-            DetectedLangText.Visibility = Visibility.Visible;
+            DetectedLangText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
             RequestResize();
             return;
         }
@@ -1523,7 +1557,7 @@ public sealed partial class FixedWindow : Window
             DetectedLangText.Text = string.Format(
                 LocalizationService.Instance.GetString("DetectedLanguage"),
                 displayName);
-            DetectedLangText.Visibility = Visibility.Visible;
+            DetectedLangText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
         }
         else
         {
@@ -1590,8 +1624,131 @@ public sealed partial class FixedWindow : Window
     public void ApplyAppearance()
     {
         ApplyButtonVisibility();
+        ApplyCompactChromeLayout();
         ServiceResultViewHost.RefreshAppearance(_resultControls);
         RequestResize();
+    }
+
+    private bool IsCompactChrome => MinimalThemeService.IsActive || SettingsService.Instance.CompactMode;
+
+    private bool ShouldShowCompactWindowControls => SettingsService.Instance.CompactMode;
+
+    private void ApplyCompactChromeLayout()
+    {
+        var compact = IsCompactChrome;
+        var showCompactControls = ShouldShowCompactWindowControls;
+        TitleBarRegion.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+        TitleBarRegion.Margin = compact ? new Thickness(0) : new Thickness(0, 0, 0, 4);
+        if (_compactWindowControls is { } compactControls)
+        {
+            compactControls.Root.Visibility = showCompactControls ? Visibility.Visible : Visibility.Collapsed;
+            compactControls.Root.Opacity = showCompactControls ? CompactWindowControlsIdleOpacity : 0;
+            compactControls.RefreshTheme(Content as FrameworkElement);
+        }
+        TitleText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+        DetectedLangText.Visibility = compact ? Visibility.Collapsed : DetectedLangText.Visibility;
+        StatusText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+        DispatcherQueue.TryEnqueue(() => _titleBarHelper?.UpdateDragRegions());
+    }
+
+    private void OnCompactWindowControlsPointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        if (ShouldShowCompactWindowControls)
+        {
+            if (_compactWindowControls is { } compactControls)
+            {
+                compactControls.Root.Opacity = 1;
+            }
+        }
+    }
+
+    private void OnCompactWindowControlsPointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        if (ShouldShowCompactWindowControls)
+        {
+            if (_compactWindowControls is { } compactControls)
+            {
+                compactControls.Root.Opacity = CompactWindowControlsIdleOpacity;
+            }
+        }
+    }
+
+    private void OnCompactDragIslandPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (!ShouldShowCompactWindowControls
+            || _compactWindowDragSession is not null
+            || sender is not UIElement dragElement
+            || !WindowDragHelper.TryBeginLeftButtonDrag(this, dragElement, e, out var session))
+        {
+            return;
+        }
+
+        _compactWindowDragSession = session;
+        e.Handled = true;
+    }
+
+    private void OnCompactDragIslandPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (_compactWindowDragSession is not { } session
+            || sender is not UIElement dragElement
+            || !WindowDragHelper.IsSessionPointer(session, e))
+        {
+            return;
+        }
+
+        if (WindowDragHelper.TryUpdateLeftButtonDrag(session, dragElement, e))
+        {
+            e.Handled = true;
+            return;
+        }
+
+        EndCompactWindowDrag(dragElement, e, releaseCapture: true);
+    }
+
+    private void OnCompactDragIslandPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement dragElement)
+        {
+            EndCompactWindowDrag(dragElement, e, releaseCapture: true);
+        }
+    }
+
+    private void OnCompactDragIslandPointerCanceled(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement dragElement)
+        {
+            EndCompactWindowDrag(dragElement, e, releaseCapture: true);
+        }
+    }
+
+    private void OnCompactDragIslandPointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement dragElement)
+        {
+            EndCompactWindowDrag(dragElement, e, releaseCapture: false);
+        }
+    }
+
+    private void EndCompactWindowDrag(UIElement dragElement, PointerRoutedEventArgs e, bool releaseCapture)
+    {
+        if (_compactWindowDragSession is not { } session
+            || !WindowDragHelper.IsSessionPointer(session, e))
+        {
+            return;
+        }
+
+        _compactWindowDragSession = null;
+        if (releaseCapture)
+        {
+            dragElement.ReleasePointerCapture(e.Pointer);
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnCompactCloseClicked(object sender, RoutedEventArgs e)
+    {
+        HideWindow();
     }
 
     /// <summary>
@@ -1600,8 +1757,9 @@ public sealed partial class FixedWindow : Window
     private void ApplyButtonVisibility()
     {
         var settings = SettingsService.Instance;
-        PinButton.Visibility = settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
-        OcrButton.Visibility = settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
+        var compact = IsCompactChrome;
+        PinButton.Visibility = !compact && settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
+        OcrButton.Visibility = !compact && settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
         SwapButton.Visibility = settings.ShowSwapButton ? Visibility.Visible : Visibility.Collapsed;
     }
 
@@ -1979,8 +2137,8 @@ public sealed partial class FixedWindow : Window
             SourceTextContainer,
             minimal,
             Content as FrameworkElement);
-        DetectedLangText.Visibility = minimal ? Visibility.Collapsed : DetectedLangText.Visibility;
-        StatusText.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
+        ApplyButtonVisibility();
+        ApplyCompactChromeLayout();
         var themeRoot = Content as FrameworkElement;
         MinimalThemeService.ApplyAccentIconForeground(TranslateIcon, LoadingRing, themeRoot);
 

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -1637,8 +1637,8 @@ public sealed partial class FixedWindow : Window
     {
         var compact = IsCompactChrome;
         var showCompactControls = ShouldShowCompactWindowControls;
-        TitleBarRegion.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
-        TitleBarRegion.Margin = compact ? new Thickness(0) : new Thickness(0, 0, 0, 4);
+        TitleBarRegion.Visibility = showCompactControls ? Visibility.Collapsed : Visibility.Visible;
+        TitleBarRegion.Margin = showCompactControls ? new Thickness(0) : new Thickness(0, 0, 0, 4);
         if (_compactWindowControls is { } compactControls)
         {
             compactControls.Root.Visibility = showCompactControls ? Visibility.Visible : Visibility.Collapsed;

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -19,8 +19,8 @@ using TranslationLanguage = Easydict.TranslationService.Models.Language;
 namespace Easydict.WinUI.Views;
 
 /// <summary>
-/// Fixed translation window that stays visible and on top.
-/// Unlike Mini Window, it does not auto-close on focus loss and is always on top.
+/// Fixed translation window that stays visible until hidden.
+/// Unlike Mini Window, it does not auto-close on focus loss; users can toggle always-on-top.
 /// </summary>
 public sealed partial class FixedWindow : Window
 {
@@ -225,7 +225,7 @@ public sealed partial class FixedWindow : Window
     }
 
     /// <summary>
-    /// Configure window to be compact with no title bar buttons, always on top.
+    /// Configure the compact fixed window chrome and apply the saved always-on-top state.
     /// </summary>
     private void ConfigureWindow()
     {

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -124,7 +124,7 @@ public sealed partial class FixedWindow : Window
                 this,
                 _appWindow,
                 TitleBarRegion,
-                new FrameworkElement[] { CloseButton },
+                new FrameworkElement[] { PinButton, OcrButton, CloseButton },
                 "FixedWindow");
             _titleBarHelper.Initialize();
         }
@@ -1646,9 +1646,27 @@ public sealed partial class FixedWindow : Window
             compactControls.RefreshTheme(Content as FrameworkElement);
         }
         TitleText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
-        DetectedLangText.Visibility = compact ? Visibility.Collapsed : DetectedLangText.Visibility;
+        if (compact)
+        {
+            DetectedLangText.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            RefreshDetectedLanguageChrome();
+        }
         StatusText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
         DispatcherQueue.TryEnqueue(() => _titleBarHelper?.UpdateDragRegions());
+    }
+
+    private void RefreshDetectedLanguageChrome()
+    {
+        if (_lastQuickQueryResolution is { } resolution)
+        {
+            UpdateQuickQueryModeStatus(resolution);
+            return;
+        }
+
+        UpdateDetectedLanguageDisplay(_lastDetectedLanguage);
     }
 
     private void OnCompactWindowControlsPointerEntered(object sender, PointerRoutedEventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -169,6 +169,7 @@ public sealed partial class FixedWindow : Window
         ToolTipService.SetToolTip(CloseButton, loc.GetString("HideWindow"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(PinButton, loc.GetString("PinWindowTooltip"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(OcrButton, loc.GetString("OcrButtonTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(CloseButton, loc.GetString("HideWindow"));
         if (_compactWindowControls is { } compactControls)
         {
             ToolTipService.SetToolTip(compactControls.CloseButton, loc.GetString("HideWindow"));
@@ -180,8 +181,10 @@ public sealed partial class FixedWindow : Window
         }
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SwapButton, loc.GetString("SwapLanguagesTooltip"));
         ToolTipService.SetToolTip(TargetLangCombo, loc.GetString("TargetLanguageTooltip"));
         ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButton, loc.GetString("TranslateTooltip"));
     }
 
     private void InitializeCompactWindowControls()
@@ -440,11 +443,11 @@ public sealed partial class FixedWindow : Window
         InputTextBox.PlaceholderText = _currentMode == QueryMode.GrammarCorrection
             ? loc.GetString("InputPlaceholder_Grammar")
             : loc.GetString("InputPlaceholder");
-        ToolTipService.SetToolTip(
-            TranslateButton,
-            _currentMode == QueryMode.GrammarCorrection
-                ? loc.GetString("TranslateButton_Grammar_Tooltip")
-                : loc.GetString("TranslateTooltip"));
+        var translateTooltip = _currentMode == QueryMode.GrammarCorrection
+            ? loc.GetString("TranslateButton_Grammar_Tooltip")
+            : loc.GetString("TranslateTooltip");
+        ToolTipService.SetToolTip(TranslateButton, translateTooltip);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButton, translateTooltip);
 
         if (reinitializeServiceResults && previousMode != _currentMode)
         {
@@ -889,8 +892,9 @@ public sealed partial class FixedWindow : Window
         _isQuerying = loading;
 
         var loc = LocalizationService.Instance;
-        ToolTipService.SetToolTip(TranslateButton,
-            loading ? loc.GetString("Cancel") : loc.GetString("TranslateTooltip"));
+        var translateTooltip = loading ? loc.GetString("Cancel") : loc.GetString("TranslateTooltip");
+        ToolTipService.SetToolTip(TranslateButton, translateTooltip);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButton, translateTooltip);
 
         // Swap icon: show cancel (X) glyph during query, translate glyph otherwise
         TranslateIcon.Glyph = loading ? "\uE711" : "\uE8C1";
@@ -1778,7 +1782,7 @@ public sealed partial class FixedWindow : Window
         var compact = IsCompactChrome;
         PinButton.Visibility = !compact && settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
         OcrButton.Visibility = !compact && settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
-        SwapButton.Visibility = settings.ShowSwapButton ? Visibility.Visible : Visibility.Collapsed;
+        SwapButton.Visibility = !compact && settings.ShowSwapButton ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private async void OnTranslateClicked(object sender, RoutedEventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/FixedWindow.xaml.cs
@@ -38,6 +38,7 @@ public sealed partial class FixedWindow : Window
     private TranslationLanguage _lastDetectedLanguage = TranslationLanguage.Auto;
     private AppWindow? _appWindow;
     private OverlappedPresenter? _presenter;
+    private bool _isPinned;
     private bool _isLoaded;
     private bool _isQuerying;
     private volatile bool _isClosing;
@@ -159,6 +160,8 @@ public sealed partial class FixedWindow : Window
         InputTextBox.PlaceholderText = loc.GetString("InputPlaceholder");
 
         // Tooltips
+        ToolTipService.SetToolTip(PinButton, loc.GetString("PinWindowTooltip"));
+        ToolTipService.SetToolTip(OcrButton, loc.GetString("OcrButtonTooltip"));
         ToolTipService.SetToolTip(CloseButton, loc.GetString("HideWindow"));
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
@@ -201,7 +204,7 @@ public sealed partial class FixedWindow : Window
             _presenter.IsMaximizable = false;
             _presenter.IsResizable = true;  // Allow resize for auto-height
             _presenter.SetBorderAndTitleBar(true, false); // Border yes, title bar no
-            _presenter.IsAlwaysOnTop = true;  // Fixed window is always on top
+            _presenter.IsAlwaysOnTop = _settings.FixedWindowIsPinned;  // Fixed window topmost (toggleable)
         }
 
         // Extend content into title bar for custom drag area
@@ -220,6 +223,10 @@ public sealed partial class FixedWindow : Window
 
         // Position window
         PositionWindow();
+
+        // Apply pin state + quick-action button visibility from settings
+        UpdatePinState();
+        ApplyButtonVisibility();
     }
 
     /// <summary>
@@ -712,8 +719,8 @@ public sealed partial class FixedWindow : Window
             content.Measure(new Windows.Foundation.Size(currentWidthDips, double.PositiveInfinity));
             var desiredHeight = content.DesiredSize.Height;
 
-            // Calculate new height with limits (200-800 DIPs)
-            var minHeight = DpiHelper.DipsToPhysicalPixels(200, scale);
+            // Calculate new height with limits (min from AppearanceService, max 800 DIPs)
+            var minHeight = DpiHelper.DipsToPhysicalPixels(AppearanceService.MinFloatingWindowHeightDips, scale);
             var maxHeight = DpiHelper.DipsToPhysicalPixels(800, scale);
             var newHeight = DpiHelper.DipsToPhysicalPixels(desiredHeight + 16, scale); // +16 for padding
             newHeight = Math.Clamp(newHeight, minHeight, maxHeight);
@@ -1547,6 +1554,53 @@ public sealed partial class FixedWindow : Window
     private void OnCloseClicked(object sender, RoutedEventArgs e)
     {
         HideWindow();
+    }
+
+    private void OnOcrClicked(object sender, RoutedEventArgs e)
+    {
+        _ = App.TriggerOcrTranslateAsync();
+    }
+
+    private void OnPinClicked(object sender, RoutedEventArgs e)
+    {
+        _isPinned = !_isPinned;
+        _settings.FixedWindowIsPinned = _isPinned;
+        _settings.Save();
+        UpdatePinState();
+    }
+
+    private void UpdatePinState()
+    {
+        _isPinned = _settings.FixedWindowIsPinned;
+        if (_presenter != null)
+        {
+            _presenter.IsAlwaysOnTop = _isPinned;
+        }
+
+        PinButton.IsChecked = _isPinned;
+        PinIcon.Glyph = _isPinned ? "\uE840" : "\uE718"; // Pinned vs Unpinned icon
+    }
+
+    /// <summary>
+    /// Re-apply appearance settings (result font size + quick-action button visibility)
+    /// to the fixed window. Called from the app-wide appearance broadcast (issue #172).
+    /// </summary>
+    public void ApplyAppearance()
+    {
+        ApplyButtonVisibility();
+        ServiceResultViewHost.RefreshAppearance(_resultControls);
+        RequestResize();
+    }
+
+    /// <summary>
+    /// Show/hide quick-action buttons per user settings.
+    /// </summary>
+    private void ApplyButtonVisibility()
+    {
+        var settings = SettingsService.Instance;
+        PinButton.Visibility = settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
+        OcrButton.Visibility = settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
+        SwapButton.Visibility = settings.ShowSwapButton ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private async void OnTranslateClicked(object sender, RoutedEventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
@@ -125,18 +125,52 @@
                 </StackPanel>
             </Border>
 
-            <!-- Settings Button -->
-            <Button
-                x:Name="SettingsButton"
+            <!-- Header action buttons -->
+            <StackPanel
                 Grid.Column="3"
-                Click="OnSettingsClicked"
-                Style="{StaticResource EasydictIconButtonStyle}"
-                ToolTipService.ToolTip="Settings"
+                Orientation="Horizontal"
+                Spacing="2"
                 VerticalAlignment="Center">
-                <FontIcon Glyph="&#xE713;"
-                          FontSize="18"
-                          Foreground="{ThemeResource ButtonForeground}"/>
-            </Button>
+                <ToggleButton
+                    x:Name="PinButton"
+                    Click="OnPinClicked"
+                    ToolTipService.ToolTip="Pin window (stay on top)"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    CornerRadius="{ThemeResource EasydictControlCornerRadius}"
+                    Padding="0"
+                    Width="36"
+                    Height="36"
+                    VerticalAlignment="Center">
+                    <FontIcon x:Name="PinIcon"
+                              Glyph="&#xE718;"
+                              FontSize="18"
+                              Foreground="{ThemeResource ButtonForeground}"/>
+                </ToggleButton>
+                <Button
+                    x:Name="OcrButton"
+                    Click="OnOcrClicked"
+                    Style="{StaticResource EasydictIconButtonStyle}"
+                    ToolTipService.ToolTip="OCR translate"
+                    Width="36"
+                    Height="36"
+                    VerticalAlignment="Center">
+                    <FontIcon Glyph="&#xE722;"
+                              FontSize="18"
+                              Foreground="{ThemeResource ButtonForeground}"/>
+                </Button>
+                <!-- Settings Button -->
+                <Button
+                    x:Name="SettingsButton"
+                    Click="OnSettingsClicked"
+                    Style="{StaticResource EasydictIconButtonStyle}"
+                    ToolTipService.ToolTip="Settings"
+                    VerticalAlignment="Center">
+                    <FontIcon Glyph="&#xE713;"
+                              FontSize="18"
+                              Foreground="{ThemeResource ButtonForeground}"/>
+                </Button>
+            </StackPanel>
         </Grid>
 
         <!-- Quick Translate Content -->

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
@@ -167,6 +167,7 @@
                     Click="OnSettingsClicked"
                     Style="{StaticResource EasydictIconButtonStyle}"
                     ToolTipService.ToolTip="Settings"
+                    AutomationProperties.Name="Settings"
                     VerticalAlignment="Center">
                     <FontIcon Glyph="&#xE713;"
                               FontSize="18"
@@ -253,6 +254,7 @@
                         Click="OnSwapLanguagesClicked"
                         Style="{StaticResource EasydictIconButtonStyle}"
                         ToolTipService.ToolTip="Swap source and target languages"
+                        AutomationProperties.Name="Swap source and target languages"
                         Margin="8,0"
                         VerticalAlignment="Center">
                         <FontIcon Glyph="&#xE8AB;"
@@ -288,7 +290,8 @@
                         Click="OnTranslateClicked"
                         Style="{StaticResource EasydictPrimaryRoundButtonStyle}"
                         VerticalAlignment="Center"
-                        ToolTipService.ToolTip="Translate">
+                        ToolTipService.ToolTip="Translate"
+                        AutomationProperties.Name="Translate">
                         <Grid>
                             <ProgressRing
                                 x:Name="LoadingRing"
@@ -335,6 +338,7 @@
                             Click="OnSwapLanguagesClicked"
                             Style="{StaticResource EasydictIconButtonStyle}"
                             ToolTipService.ToolTip="Swap source and target languages"
+                            AutomationProperties.Name="Swap source and target languages"
                             VerticalAlignment="Center"
                             Margin="4,0">
                             <FontIcon Glyph="&#xE8AB;"
@@ -365,7 +369,8 @@
                         Click="OnTranslateClicked"
                         Style="{StaticResource EasydictPrimaryRoundButtonStyle}"
                         HorizontalAlignment="Center"
-                        ToolTipService.ToolTip="Translate">
+                        ToolTipService.ToolTip="Translate"
+                        AutomationProperties.Name="Translate">
                         <Grid>
                             <ProgressRing
                                 x:Name="LoadingRingNarrow"
@@ -431,6 +436,7 @@
                                 Click="OnSourcePlayClicked"
                                 Style="{StaticResource EasydictIconButtonStyle}"
                                 ToolTipService.ToolTip="Play source text"
+                                AutomationProperties.Name="Play source text"
                                 Width="24"
                                 Height="24"
                                 HorizontalAlignment="Right"
@@ -786,7 +792,8 @@
                             Style="{StaticResource EasydictPrimaryRoundButtonStyle}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="Center"
-                            ToolTipService.ToolTip="Translate">
+                            ToolTipService.ToolTip="Translate"
+                            AutomationProperties.Name="Translate">
                         <FontIcon x:Name="LongDocTranslateIcon"
                                   Glyph="&#xE8C1;"
                                   FontSize="16"

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
@@ -135,6 +135,7 @@
                     x:Name="PinButton"
                     Click="OnPinClicked"
                     ToolTipService.ToolTip="Pin window (stay on top)"
+                    AutomationProperties.Name="Pin window (stay on top)"
                     Background="Transparent"
                     BorderThickness="0"
                     CornerRadius="{ThemeResource EasydictControlCornerRadius}"
@@ -152,6 +153,7 @@
                     Click="OnOcrClicked"
                     Style="{StaticResource EasydictIconButtonStyle}"
                     ToolTipService.ToolTip="OCR translate"
+                    AutomationProperties.Name="OCR translate"
                     Width="36"
                     Height="36"
                     VerticalAlignment="Center">

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml
@@ -140,8 +140,8 @@
                     BorderThickness="0"
                     CornerRadius="{ThemeResource EasydictControlCornerRadius}"
                     Padding="0"
-                    Width="36"
-                    Height="36"
+                    Width="32"
+                    Height="32"
                     VerticalAlignment="Center">
                     <FontIcon x:Name="PinIcon"
                               Glyph="&#xE718;"
@@ -154,8 +154,8 @@
                     Style="{StaticResource EasydictIconButtonStyle}"
                     ToolTipService.ToolTip="OCR translate"
                     AutomationProperties.Name="OCR translate"
-                    Width="36"
-                    Height="36"
+                    Width="32"
+                    Height="32"
                     VerticalAlignment="Center">
                     <FontIcon Glyph="&#xE722;"
                               FontSize="18"
@@ -400,7 +400,8 @@
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
 
-                        <Grid Grid.Row="0">
+                        <Grid x:Name="QuickInputHeaderGrid"
+                              Grid.Row="0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="Auto"/>
@@ -533,7 +534,8 @@
                 </Border>
 
                 <!-- Footer -->
-                <Grid Grid.Row="3"
+                <Grid x:Name="QuickFooterGrid"
+                      Grid.Row="3"
                       Margin="0,4,0,0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -404,6 +404,10 @@ namespace Easydict.WinUI.Views
             {
                 DetectedLanguageText.Visibility = Visibility.Collapsed;
             }
+            else
+            {
+                RefreshDetectedLanguageChrome();
+            }
             LangHelpIcon.Visibility = compact || _currentMode != QueryMode.Translation
                 ? Visibility.Collapsed
                 : Visibility.Visible;
@@ -2046,6 +2050,17 @@ namespace Easydict.WinUI.Views
 
             _showingGrammarFallbackNotice = false;
             UpdateDetectedLanguageDisplay(resolution.EffectiveSourceLanguage);
+        }
+
+        private void RefreshDetectedLanguageChrome()
+        {
+            if (_lastQuickQueryResolution is { } resolution)
+            {
+                UpdateQuickQueryModeStatus(resolution);
+                return;
+            }
+
+            UpdateDetectedLanguageDisplay(_lastDetectedLanguage);
         }
 
         private void RefreshQuickQueryModePreview()

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -1237,6 +1237,8 @@ namespace Easydict.WinUI.Views
             ToolTipService.SetToolTip(PinButton, loc.GetString("PinWindowTooltip"));
             ToolTipService.SetToolTip(OcrButton, loc.GetString("OcrButtonTooltip"));
             ToolTipService.SetToolTip(SettingsButton, loc.GetString("SettingsTooltip"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(PinButton, loc.GetString("PinWindowTooltip"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(OcrButton, loc.GetString("OcrButtonTooltip"));
             ToolTipService.SetToolTip(SwapLanguageButton, loc.GetString("SwapLanguagesTooltip"));
             ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
             ToolTipService.SetToolTip(TranslateButtonNarrow, loc.GetString("TranslateTooltip"));

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -280,8 +280,15 @@ namespace Easydict.WinUI.Views
             }
 #endif
 
+            // Apply quick-action button visibility + pin state from settings (issue #172)
+            ApplyButtonVisibility();
+            UpdatePinState();
+
             // Initialize service result controls based on enabled services
             InitializeServiceResults(skipRebuildWhenDebugFlagSet: true, reason: "OnPageLoaded");
+
+            // Re-apply result font size to any reused result controls (issue #172)
+            ServiceResultViewHost.RefreshAppearance(_resultControls);
 
             SettingsService.Instance.HideEmptyServiceResultsChanged += OnHideEmptyServiceResultsChanged;
             if (_deferLoadedThemeChrome)
@@ -1226,6 +1233,8 @@ namespace Easydict.WinUI.Views
             SyncLocalModelPreparationProgressFromCoordinator();
 
             // Tooltips
+            ToolTipService.SetToolTip(PinButton, loc.GetString("PinWindowTooltip"));
+            ToolTipService.SetToolTip(OcrButton, loc.GetString("OcrButtonTooltip"));
             ToolTipService.SetToolTip(SettingsButton, loc.GetString("SettingsTooltip"));
             ToolTipService.SetToolTip(SwapLanguageButton, loc.GetString("SwapLanguagesTooltip"));
             ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
@@ -4298,6 +4307,48 @@ namespace Easydict.WinUI.Views
             }
 
             await SwitchModeAsync(newMode);
+        }
+
+        private void OnOcrClicked(object sender, RoutedEventArgs e)
+        {
+            _ = App.TriggerOcrTranslateAsync();
+        }
+
+        private void OnPinClicked(object sender, RoutedEventArgs e)
+        {
+            var pinned = !SettingsService.Instance.AlwaysOnTop;
+            SettingsService.Instance.AlwaysOnTop = pinned;
+            SettingsService.Instance.Save();
+            App.ApplyAlwaysOnTop(pinned);
+            UpdatePinState();
+        }
+
+        private void UpdatePinState()
+        {
+            var pinned = SettingsService.Instance.AlwaysOnTop;
+            PinButton.IsChecked = pinned;
+            PinIcon.Glyph = pinned ? "\uE840" : "\uE718"; // Pinned vs Unpinned icon
+        }
+
+        /// <summary>
+        /// Re-apply appearance settings (result font size + quick-action button visibility)
+        /// to the main page. Called from the app-wide appearance broadcast (issue #172).
+        /// </summary>
+        public void ApplyAppearance()
+        {
+            ApplyButtonVisibility();
+            UpdatePinState();
+            ServiceResultViewHost.RefreshAppearance(_resultControls);
+        }
+
+        /// <summary>
+        /// Show/hide quick-action buttons per user settings.
+        /// </summary>
+        private void ApplyButtonVisibility()
+        {
+            var settings = SettingsService.Instance;
+            PinButton.Visibility = settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
+            OcrButton.Visibility = settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private async void OnSettingsClicked(object sender, RoutedEventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -1299,9 +1299,11 @@ namespace Easydict.WinUI.Views
             ToolTipService.SetToolTip(SwapLanguageButtonNarrow, loc.GetString("SwapLanguagesTooltip"));
             Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SwapLanguageButton, loc.GetString("SwapLanguagesTooltip"));
             Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SwapLanguageButtonNarrow, loc.GetString("SwapLanguagesTooltip"));
+            var sourcePlayTooltip = loc.GetString("PlaySourceTextTooltip");
+            ToolTipService.SetToolTip(SourcePlayButton, sourcePlayTooltip);
             Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
                 SourcePlayButton,
-                loc.GetStringOrDefault("PlaySourceTextTooltip", "Play source text"));
+                sourcePlayTooltip);
             ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
             ToolTipService.SetToolTip(TranslateButtonNarrow, loc.GetString("TranslateTooltip"));
             ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -390,21 +390,27 @@ namespace Easydict.WinUI.Views
             }
 
             var minimal = MinimalThemeService.IsActive;
-            ModeEmojiIcon.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
-            InputHelpIcon.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
-            SourcePlayButton.Visibility = (!minimal && SettingsService.Instance.ShowSourcePlayButton)
+            var compact = IsCompactChrome;
+            ModeEmojiIcon.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+            ModeSelectorButton.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+            ModeSubtitle.Visibility = compact || _currentMode != QueryMode.LongDocument
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+            InputHelpIcon.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+            SourcePlayButton.Visibility = (!compact && SettingsService.Instance.ShowSourcePlayButton)
                 ? Visibility.Visible : Visibility.Collapsed;
-            ResultsTitleText.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
-            if (minimal)
+            ResultsTitleText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+            if (compact)
             {
                 DetectedLanguageText.Visibility = Visibility.Collapsed;
             }
-            LangHelpIcon.Visibility = minimal || _currentMode != QueryMode.Translation
+            LangHelpIcon.Visibility = compact || _currentMode != QueryMode.Translation
                 ? Visibility.Collapsed
                 : Visibility.Visible;
-            LangHelpIconNarrow.Visibility = minimal || _currentMode != QueryMode.Translation
+            LangHelpIconNarrow.Visibility = compact || _currentMode != QueryMode.Translation
                 ? Visibility.Collapsed
                 : Visibility.Visible;
+            QuickInputHeaderGrid.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
 
             if (refreshServiceResults)
             {
@@ -419,10 +425,11 @@ namespace Easydict.WinUI.Views
             }
 
             ApplyMainWindowBorderChrome(minimal);
-            ApplyMainLayoutChrome(minimal);
+            ApplyMainLayoutChrome(minimal, compact);
             ApplyStatusChrome();
             ApplyStatusSummaryChrome();
             ApplyTranslateButtonsChrome();
+            ApplyButtonVisibility();
             RefreshMainControlChrome();
 
             if (!refreshServiceResults)
@@ -436,7 +443,9 @@ namespace Easydict.WinUI.Views
             }
         }
 
-        private void ApplyMainLayoutChrome(bool minimal)
+        private bool IsCompactChrome => MinimalThemeService.IsActive || SettingsService.Instance.CompactMode;
+
+        private void ApplyMainLayoutChrome(bool minimal, bool compact)
         {
             if (minimal)
             {
@@ -451,7 +460,7 @@ namespace Easydict.WinUI.Views
                 QuickOutputCard.Margin = new Thickness(0, 2, 0, 0);
                 QuickInputCardContent.Margin = new Thickness(4);
                 QuickOutputCardContent.Margin = new Thickness(4);
-                QuickInputHeaderRow.Height = new GridLength(15);
+                QuickInputHeaderRow.Height = compact ? new GridLength(0) : new GridLength(15);
 
                 LongDocInputCard.Margin = new Thickness(0, 0, 0, 2);
                 LongDocControlBar.Margin = new Thickness(0, 4, 0, 4);
@@ -461,12 +470,16 @@ namespace Easydict.WinUI.Views
                 LongDocOutputCardContent.Margin = new Thickness(4);
                 LongDocHistoryExpander.Margin = new Thickness(0, 8, 0, 0);
 
-                SettingsButton.Width = 36;
-                SettingsButton.Height = 36;
-                SwapLanguageButton.Width = 36;
-                SwapLanguageButton.Height = 36;
-                SwapLanguageButtonNarrow.Width = 36;
-                SwapLanguageButtonNarrow.Height = 36;
+                PinButton.Width = 32;
+                PinButton.Height = 32;
+                OcrButton.Width = 32;
+                OcrButton.Height = 32;
+                SettingsButton.Width = compact ? 28 : 32;
+                SettingsButton.Height = compact ? 28 : 32;
+                SwapLanguageButton.Width = 32;
+                SwapLanguageButton.Height = 32;
+                SwapLanguageButtonNarrow.Width = 32;
+                SwapLanguageButtonNarrow.Height = 32;
                 SourcePlayButton.Width = 24;
                 SourcePlayButton.Height = 24;
                 SourcePlayIcon.FontSize = 12;
@@ -476,39 +489,43 @@ namespace Easydict.WinUI.Views
                 return;
             }
 
-            MainHeader.Margin = new Thickness(0, 0, 0, 10);
+            MainHeader.Margin = compact ? new Thickness(0) : new Thickness(0, 0, 0, 6);
             QuickContentGrid.Padding = new Thickness(0);
             LongDocContentGrid.Padding = new Thickness(0);
-            ActionBarWide.Margin = new Thickness(0, 8, 0, 8);
-            ActionBarNarrow.Margin = new Thickness(0, 8, 0, 8);
-            ActionBarNarrow.Spacing = 8;
+            ActionBarWide.Margin = compact ? new Thickness(0) : new Thickness(0, 4, 0, 4);
+            ActionBarNarrow.Margin = compact ? new Thickness(0) : new Thickness(0, 4, 0, 4);
+            ActionBarNarrow.Spacing = 4;
 
-            QuickInputCard.Margin = new Thickness(0, 0, 0, 8);
+            QuickInputCard.Margin = compact ? new Thickness(0) : new Thickness(0, 0, 0, 4);
             QuickOutputCard.Margin = new Thickness(0);
             QuickInputCardContent.Margin = new Thickness(0);
             QuickOutputCardContent.Margin = new Thickness(0);
-            QuickInputHeaderRow.Height = GridLength.Auto;
+            QuickInputHeaderRow.Height = compact ? new GridLength(0) : GridLength.Auto;
 
-            LongDocInputCard.Margin = new Thickness(0, 0, 0, 8);
-            LongDocControlBar.Margin = new Thickness(0, 8, 0, 8);
-            LongDocControlBar.RowSpacing = 8;
+            LongDocInputCard.Margin = new Thickness(0, 0, 0, 4);
+            LongDocControlBar.Margin = new Thickness(0, 4, 0, 4);
+            LongDocControlBar.RowSpacing = 4;
             LongDocInputCardContent.Margin = new Thickness(0);
             LongDocOutputCard.Margin = new Thickness(0);
             LongDocOutputCardContent.Margin = new Thickness(0);
-            LongDocHistoryExpander.Margin = new Thickness(0, 10, 0, 0);
+            LongDocHistoryExpander.Margin = new Thickness(0, 8, 0, 0);
 
-            SettingsButton.Width = 36;
-            SettingsButton.Height = 36;
-            SwapLanguageButton.Width = 36;
-            SwapLanguageButton.Height = 36;
-            SwapLanguageButtonNarrow.Width = 36;
-            SwapLanguageButtonNarrow.Height = 36;
-            SourcePlayButton.Width = 28;
-            SourcePlayButton.Height = 28;
-            SourcePlayIcon.FontSize = 14;
-            TranslateButton.Margin = new Thickness(0, 0, 18, 0);
+            PinButton.Width = 32;
+            PinButton.Height = 32;
+            OcrButton.Width = 32;
+            OcrButton.Height = 32;
+            SettingsButton.Width = compact ? 28 : 32;
+            SettingsButton.Height = compact ? 28 : 32;
+            SwapLanguageButton.Width = 32;
+            SwapLanguageButton.Height = 32;
+            SwapLanguageButtonNarrow.Width = 32;
+            SwapLanguageButtonNarrow.Height = 32;
+            SourcePlayButton.Width = 24;
+            SourcePlayButton.Height = 24;
+            SourcePlayIcon.FontSize = 12;
+            TranslateButton.Margin = new Thickness(4, 0, 0, 0);
             TranslateButtonNarrow.Margin = new Thickness(0);
-            LongDocTranslateButton.Margin = new Thickness(0, 0, 18, 0);
+            LongDocTranslateButton.Margin = new Thickness(0);
         }
 
         private void ApplyMainWindowBorderChrome(bool minimal)
@@ -522,7 +539,7 @@ namespace Easydict.WinUI.Views
                 MainWindowBorder.BorderThickness = new Thickness(0);
                 MainWindowBorder.CornerRadius = new CornerRadius(0);
                 MainWindowBorder.Padding = new Thickness(0);
-                ApplyMainInputChrome(minimal);
+                ApplyMainInputChrome(minimal, IsCompactChrome);
                 return;
             }
 
@@ -532,11 +549,14 @@ namespace Easydict.WinUI.Views
             MainWindowBorder.BorderBrush = CreateThemeBrush("MainBorderColor");
             MainWindowBorder.BorderThickness = new Thickness(0);
             MainWindowBorder.CornerRadius = new CornerRadius(0);
-            MainWindowBorder.Padding = new Thickness(16);
-            ApplyMainInputChrome(minimal);
+            MainWindowBorder.Padding = ThemeResourceService.GetResourceOrDefault(
+                "FloatingWindowContentPadding",
+                this,
+                new Thickness(8));
+            ApplyMainInputChrome(minimal, IsCompactChrome);
         }
 
-        private void ApplyMainInputChrome(bool minimal)
+        private void ApplyMainInputChrome(bool minimal, bool compact)
         {
             if (minimal)
             {
@@ -546,7 +566,7 @@ namespace Easydict.WinUI.Views
                 InputTextContainer.BorderThickness = new Thickness(0);
                 InputTextContainer.CornerRadius = new CornerRadius(0);
                 InputTextContainer.Padding = new Thickness(0);
-                InputTextContainer.Margin = new Thickness(0, 4, 0, 0);
+                InputTextContainer.Margin = compact ? new Thickness(0) : new Thickness(0, 4, 0, 0);
                 InputTextBox.Background = transparent;
                 InputTextBox.BorderBrush = transparent;
                 InputTextBox.BorderThickness = new Thickness(0);
@@ -575,8 +595,8 @@ namespace Easydict.WinUI.Views
             InputTextContainer.Padding = ThemeResourceService.GetResourceOrDefault(
                 "FloatingInputPadding",
                 this,
-                new Thickness(10, 9, 10, 9));
-            InputTextContainer.Margin = new Thickness(0, 4, 0, 0);
+                new Thickness(6, 4, 6, 4));
+            InputTextContainer.Margin = compact ? new Thickness(0) : new Thickness(0, 3, 0, 0);
 
             InputTextBox.Background = textBackground;
             InputTextBox.BorderBrush = transparentBrush;
@@ -806,6 +826,17 @@ namespace Easydict.WinUI.Views
                 ? _lastStatusText.ToUpperInvariant()
                 : _lastStatusText;
 
+            if (SettingsService.Instance.CompactMode && !MinimalThemeService.IsActive)
+            {
+                StatusIndicator.Visibility = _lastStatusConnected == false
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+                if (_lastStatusConnected != false)
+                {
+                    return;
+                }
+            }
+
             if (MinimalThemeService.IsActive)
             {
                 StatusIndicator.Visibility = _lastStatusConnected == false
@@ -864,9 +895,25 @@ namespace Easydict.WinUI.Views
         {
             StatusSummaryText.Text = _lastStatusSummaryText;
             StatusSummaryText.Visibility =
-                !MinimalThemeService.IsActive || _lastStatusSummaryIsImportant
+                !IsCompactChrome || _lastStatusSummaryIsImportant
                     ? Visibility.Visible
                     : Visibility.Collapsed;
+            ApplyQuickFooterChrome(IsCompactChrome);
+        }
+
+        private void ApplyQuickFooterChrome(bool compact)
+        {
+            if (!compact)
+            {
+                QuickFooterGrid.Visibility = Visibility.Visible;
+                QuickFooterGrid.Margin = new Thickness(0, 4, 0, 0);
+                return;
+            }
+
+            var showFooter = _lastStatusSummaryIsImportant
+                || LocalModelPreparationProgressPanel.Visibility == Visibility.Visible;
+            QuickFooterGrid.Visibility = showFooter ? Visibility.Visible : Visibility.Collapsed;
+            QuickFooterGrid.Margin = showFooter ? new Thickness(0, 2, 0, 0) : new Thickness(0);
         }
 
         private void ShowLocalModelPreparationProgress(string resourceKey)
@@ -891,6 +938,7 @@ namespace Easydict.WinUI.Views
                 LocalModelPreparationProgressBar.IsIndeterminate = true;
             }
             LocalModelPreparationProgressPanel.Visibility = Visibility.Visible;
+            ApplyQuickFooterChrome(IsCompactChrome);
         }
 
         private void HideLocalModelPreparationProgress()
@@ -898,6 +946,7 @@ namespace Easydict.WinUI.Views
             LocalModelPreparationProgressPanel.Visibility = Visibility.Collapsed;
             LocalModelPreparationStatusText.Text = string.Empty;
             _localModelPreparationLastProgressPercent = null;
+            ApplyQuickFooterChrome(IsCompactChrome);
         }
 
         private void SyncLocalModelPreparationProgressFromCoordinator()
@@ -1296,11 +1345,12 @@ namespace Easydict.WinUI.Views
             };
 
             // Update subtitle
+            var compactChrome = IsCompactChrome;
             switch (_currentMode)
             {
                 case QueryMode.LongDocument:
                     ModeSubtitle.Text = loc.GetString("Mode_LongDocument") ?? "Long Document";
-                    ModeSubtitle.Visibility = Visibility.Visible;
+                    ModeSubtitle.Visibility = compactChrome ? Visibility.Collapsed : Visibility.Visible;
                     break;
                 default:
                     ModeSubtitle.Visibility = Visibility.Collapsed;
@@ -1323,12 +1373,13 @@ namespace Easydict.WinUI.Views
             if (_currentMode == QueryMode.Translation)
             {
                 var showSwap = SettingsService.Instance.ShowSwapButton;
+                var compact = IsCompactChrome;
                 TargetLangCombo.Visibility = Visibility.Visible;
                 SwapLanguageButton.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
-                LangHelpIcon.Visibility = Visibility.Visible;
+                LangHelpIcon.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
                 TargetLangComboNarrow.Visibility = Visibility.Visible;
                 SwapLanguageButtonNarrow.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
-                LangHelpIconNarrow.Visibility = Visibility.Visible;
+                LangHelpIconNarrow.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
 
                 InputTextBox.PlaceholderText = loc.GetString("InputPlaceholder");
                 ResultsTitleText.Text = loc.GetString("TranslationResults")
@@ -1980,7 +2031,7 @@ namespace Easydict.WinUI.Views
                 DetectedLanguageText.Text = loc.GetStringOrDefault(
                     "GrammarCorrectionFallbackNotice",
                     "No grammar-capable AI service is enabled, so this query fell back to translation. Enable an AI service that supports grammar correction to show correction details when source and target are the same.");
-                DetectedLanguageText.Visibility = Visibility.Visible;
+                DetectedLanguageText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
                 return;
             }
 
@@ -1989,7 +2040,7 @@ namespace Easydict.WinUI.Views
                 DetectedLanguageText.Text = loc.GetStringOrDefault(
                     "GrammarCorrectionActiveNotice",
                     "Grammar check mode: AI correction services will run. Choose a different target language to translate.");
-                DetectedLanguageText.Visibility = Visibility.Visible;
+                DetectedLanguageText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
                 return;
             }
 
@@ -3211,7 +3262,7 @@ namespace Easydict.WinUI.Views
                 DetectedLanguageText.Text = string.Format(
                     LocalizationService.Instance.GetString("DetectedLanguage"),
                     displayName);
-                DetectedLanguageText.Visibility = Visibility.Visible;
+                DetectedLanguageText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
             }
             else
             {
@@ -4340,7 +4391,7 @@ namespace Easydict.WinUI.Views
         /// </summary>
         public void ApplyAppearance()
         {
-            ApplyButtonVisibility();
+            ApplyThemeChrome(refreshServiceResults: false);
             UpdatePinState();
             ServiceResultViewHost.RefreshAppearance(_resultControls);
         }
@@ -4353,10 +4404,11 @@ namespace Easydict.WinUI.Views
         private void ApplyButtonVisibility()
         {
             var settings = SettingsService.Instance;
-            PinButton.Visibility = settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
-            OcrButton.Visibility = settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
+            var compact = IsCompactChrome;
+            PinButton.Visibility = !compact && settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
+            OcrButton.Visibility = !compact && settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
 
-            SourcePlayButton.Visibility = (!MinimalThemeService.IsActive && settings.ShowSourcePlayButton)
+            SourcePlayButton.Visibility = (!compact && settings.ShowSourcePlayButton)
                 ? Visibility.Visible : Visibility.Collapsed;
 
             var showSwap = settings.ShowSwapButton && _currentMode == QueryMode.Translation;

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -1034,6 +1034,7 @@ namespace Easydict.WinUI.Views
             double normalWidth,
             double normalHeight)
         {
+            AutomationProperties.SetName(button, text);
             if (minimal)
             {
                 button.Content = text;
@@ -1293,7 +1294,14 @@ namespace Easydict.WinUI.Views
             ToolTipService.SetToolTip(SettingsButton, loc.GetString("SettingsTooltip"));
             Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(PinButton, loc.GetString("PinWindowTooltip"));
             Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(OcrButton, loc.GetString("OcrButtonTooltip"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SettingsButton, loc.GetString("SettingsTooltip"));
             ToolTipService.SetToolTip(SwapLanguageButton, loc.GetString("SwapLanguagesTooltip"));
+            ToolTipService.SetToolTip(SwapLanguageButtonNarrow, loc.GetString("SwapLanguagesTooltip"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SwapLanguageButton, loc.GetString("SwapLanguagesTooltip"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SwapLanguageButtonNarrow, loc.GetString("SwapLanguagesTooltip"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+                SourcePlayButton,
+                loc.GetStringOrDefault("PlaySourceTextTooltip", "Play source text"));
             ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
             ToolTipService.SetToolTip(TranslateButtonNarrow, loc.GetString("TranslateTooltip"));
             ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
@@ -1377,8 +1385,8 @@ namespace Easydict.WinUI.Views
 
             if (_currentMode == QueryMode.Translation)
             {
-                var showSwap = SettingsService.Instance.ShowSwapButton;
                 var compact = IsCompactChrome;
+                var showSwap = !compact && SettingsService.Instance.ShowSwapButton;
                 TargetLangCombo.Visibility = Visibility.Visible;
                 SwapLanguageButton.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
                 LangHelpIcon.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
@@ -2006,6 +2014,8 @@ namespace Easydict.WinUI.Views
                 : loc.GetString("TranslateTooltip");
             ToolTipService.SetToolTip(TranslateButton, translateTooltip);
             ToolTipService.SetToolTip(TranslateButtonNarrow, translateTooltip);
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButton, translateTooltip);
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButtonNarrow, translateTooltip);
 
             if (reinitializeServiceResults && previousMode != _currentQuickQueryMode)
             {
@@ -4413,9 +4423,9 @@ namespace Easydict.WinUI.Views
         }
 
         /// <summary>
-        /// Show/hide quick-action buttons per user settings. The source-play button is also
-        /// hidden in Minimal mode, and the swap buttons only show in Translation mode — matching
-        /// the gating applied by ApplyThemeChrome and the mode-switch logic.
+        /// Show/hide quick-action buttons per user settings. Source-play and swap are hidden
+        /// in compact chrome, and swap only shows in Translation mode — matching the gating
+        /// applied by ApplyThemeChrome and the mode-switch logic.
         /// </summary>
         private void ApplyButtonVisibility()
         {
@@ -4427,7 +4437,7 @@ namespace Easydict.WinUI.Views
             SourcePlayButton.Visibility = (!compact && settings.ShowSourcePlayButton)
                 ? Visibility.Visible : Visibility.Collapsed;
 
-            var showSwap = settings.ShowSwapButton && _currentMode == QueryMode.Translation;
+            var showSwap = !compact && settings.ShowSwapButton && _currentMode == QueryMode.Translation;
             SwapLanguageButton.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
             SwapLanguageButtonNarrow.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
         }

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -321,6 +321,7 @@ namespace Easydict.WinUI.Views
             {
                 Frame.ForwardStack.Clear();
                 ApplySettings();
+                ApplyAppearance();
                 _deferLoadedThemeChrome = true;
                 QueueApplyThemeChrome(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
                 if (ShouldForceFullGcAfterSettingsReturn())

--- a/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MainPage.xaml.cs
@@ -392,7 +392,8 @@ namespace Easydict.WinUI.Views
             var minimal = MinimalThemeService.IsActive;
             ModeEmojiIcon.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
             InputHelpIcon.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
-            SourcePlayButton.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
+            SourcePlayButton.Visibility = (!minimal && SettingsService.Instance.ShowSourcePlayButton)
+                ? Visibility.Visible : Visibility.Collapsed;
             ResultsTitleText.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
             if (minimal)
             {
@@ -1319,11 +1320,12 @@ namespace Easydict.WinUI.Views
 
             if (_currentMode == QueryMode.Translation)
             {
+                var showSwap = SettingsService.Instance.ShowSwapButton;
                 TargetLangCombo.Visibility = Visibility.Visible;
-                SwapLanguageButton.Visibility = Visibility.Visible;
+                SwapLanguageButton.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
                 LangHelpIcon.Visibility = Visibility.Visible;
                 TargetLangComboNarrow.Visibility = Visibility.Visible;
-                SwapLanguageButtonNarrow.Visibility = Visibility.Visible;
+                SwapLanguageButtonNarrow.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
                 LangHelpIconNarrow.Visibility = Visibility.Visible;
 
                 InputTextBox.PlaceholderText = loc.GetString("InputPlaceholder");
@@ -4342,13 +4344,22 @@ namespace Easydict.WinUI.Views
         }
 
         /// <summary>
-        /// Show/hide quick-action buttons per user settings.
+        /// Show/hide quick-action buttons per user settings. The source-play button is also
+        /// hidden in Minimal mode, and the swap buttons only show in Translation mode — matching
+        /// the gating applied by ApplyThemeChrome and the mode-switch logic.
         /// </summary>
         private void ApplyButtonVisibility()
         {
             var settings = SettingsService.Instance;
             PinButton.Visibility = settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
             OcrButton.Visibility = settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
+
+            SourcePlayButton.Visibility = (!MinimalThemeService.IsActive && settings.ShowSourcePlayButton)
+                ? Visibility.Visible : Visibility.Collapsed;
+
+            var showSwap = settings.ShowSwapButton && _currentMode == QueryMode.Translation;
+            SwapLanguageButton.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
+            SwapLanguageButtonNarrow.Visibility = showSwap ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private async void OnSettingsClicked(object sender, RoutedEventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -47,6 +47,7 @@
                 Grid.Column="0"
                 Click="OnPinClicked"
                 ToolTipService.ToolTip="Pin window (stay on top)"
+                AutomationProperties.Name="Pin window (stay on top)"
                 Background="Transparent"
                 BorderThickness="0"
                 CornerRadius="{ThemeResource EasydictControlCornerRadius}"

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -39,6 +39,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <ToggleButton
@@ -68,9 +69,23 @@
                 VerticalAlignment="Center"/>
 
             <Button
+                x:Name="OcrButton"
+                Grid.Column="2"
+                Click="OnOcrClicked"
+                Style="{StaticResource EasydictIconButtonStyle}"
+                ToolTipService.ToolTip="OCR translate"
+                Width="28"
+                Height="28"
+                Padding="0">
+                <FontIcon Glyph="&#xE722;"
+                        FontSize="14"
+                        Foreground="{ThemeResource ButtonForeground}"/>
+            </Button>
+
+            <Button
                 x:Name="CloseButton"
                 AutomationProperties.AutomationId="MiniWindowCloseButton"
-                Grid.Column="2"
+                Grid.Column="3"
                 Click="OnCloseClicked"
                 Style="{StaticResource EasydictIconButtonStyle}"
                 ToolTipService.ToolTip="Close"

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -88,6 +88,7 @@
             <Button
                 x:Name="CloseButton"
                 AutomationProperties.AutomationId="MiniWindowCloseButton"
+                AutomationProperties.Name="Close"
                 Grid.Column="3"
                 Click="OnCloseClicked"
                 Style="{StaticResource EasydictIconButtonStyle}"
@@ -162,6 +163,7 @@
                         Click="OnSourcePlayClicked"
                         Style="{StaticResource EasydictIconButtonStyle}"
                         ToolTipService.ToolTip="Play source text"
+                        AutomationProperties.Name="Play source text"
                         Width="28"
                         Height="28"
                         Padding="0"
@@ -208,6 +210,7 @@
                 Padding="0"
                 Style="{StaticResource EasydictIconButtonStyle}"
                 ToolTipService.ToolTip="Swap languages"
+                AutomationProperties.Name="Swap languages"
                 Margin="4,0">
                 <FontIcon Glyph="&#xE8AB;"
                         FontSize="12"
@@ -232,6 +235,7 @@
                 Padding="0"
                 Style="{StaticResource EasydictPrimaryRoundButtonStyle}"
                 ToolTipService.ToolTip="Translate"
+                AutomationProperties.Name="Translate"
                 Margin="4,0,0,0">
                 <Grid>
                     <ProgressRing

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -19,7 +19,7 @@
             BorderBrush="{ThemeResource MainBorderBrush}"
             BorderThickness="0"
             CornerRadius="0"
-            Padding="16">
+            Padding="{ThemeResource FloatingWindowContentPadding}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -60,6 +60,7 @@
             </ToggleButton>
 
             <TextBlock
+                x:Name="TitleText"
                 Grid.Column="1"
                 Text="Quick Translate"
                 FontSize="12"

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml
@@ -74,6 +74,7 @@
                 Click="OnOcrClicked"
                 Style="{StaticResource EasydictIconButtonStyle}"
                 ToolTipService.ToolTip="OCR translate"
+                AutomationProperties.Name="OCR translate"
                 Width="28"
                 Height="28"
                 Padding="0">

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -2336,8 +2336,8 @@ public sealed partial class MiniWindow : Window
     {
         var compact = IsCompactChrome;
         var showCompactControls = ShouldShowCompactWindowControls;
-        TitleBarRegion.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
-        TitleBarRegion.Margin = compact ? new Thickness(0) : new Thickness(0, 0, 0, 4);
+        TitleBarRegion.Visibility = showCompactControls ? Visibility.Collapsed : Visibility.Visible;
+        TitleBarRegion.Margin = showCompactControls ? new Thickness(0) : new Thickness(0, 0, 0, 4);
         if (_compactWindowControls is { } compactControls)
         {
             compactControls.Root.Visibility = showCompactControls ? Visibility.Visible : Visibility.Collapsed;

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -185,6 +185,8 @@ public sealed partial class MiniWindow : Window
         ToolTipService.SetToolTip(PinButton, loc.GetString("PinWindowTooltip"));
         ToolTipService.SetToolTip(OcrButton, loc.GetString("OcrButtonTooltip"));
         ToolTipService.SetToolTip(CloseButton, loc.GetString("Close"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(PinButton, loc.GetString("PinWindowTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(OcrButton, loc.GetString("OcrButtonTooltip"));
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
         ToolTipService.SetToolTip(TargetLangCombo, loc.GetString("TargetLanguageTooltip"));

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -191,6 +191,7 @@ public sealed partial class MiniWindow : Window
         ToolTipService.SetToolTip(CloseButton, loc.GetString("Close"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(PinButton, loc.GetString("PinWindowTooltip"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(OcrButton, loc.GetString("OcrButtonTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(CloseButton, loc.GetString("Close"));
         if (_compactWindowControls is { } compactControls)
         {
             ToolTipService.SetToolTip(compactControls.CloseButton, loc.GetString("Close"));
@@ -202,8 +203,13 @@ public sealed partial class MiniWindow : Window
         }
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SwapButton, loc.GetString("SwapLanguagesTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+            SourcePlayButton,
+            loc.GetStringOrDefault("PlaySourceTextTooltip", "Play source text"));
         ToolTipService.SetToolTip(TargetLangCombo, loc.GetString("TargetLanguageTooltip"));
         ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButton, loc.GetString("TranslateTooltip"));
     }
 
     private void InitializeCompactWindowControls()
@@ -483,11 +489,11 @@ public sealed partial class MiniWindow : Window
         InputTextBox.PlaceholderText = _currentMode == QueryMode.GrammarCorrection
             ? loc.GetString("InputPlaceholder_Grammar")
             : loc.GetString("InputPlaceholder");
-        ToolTipService.SetToolTip(
-            TranslateButton,
-            _currentMode == QueryMode.GrammarCorrection
-                ? loc.GetString("TranslateButton_Grammar_Tooltip")
-                : loc.GetString("TranslateTooltip"));
+        var translateTooltip = _currentMode == QueryMode.GrammarCorrection
+            ? loc.GetString("TranslateButton_Grammar_Tooltip")
+            : loc.GetString("TranslateTooltip");
+        ToolTipService.SetToolTip(TranslateButton, translateTooltip);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButton, translateTooltip);
 
         if (reinitializeServiceResults && previousMode != _currentMode)
         {
@@ -1054,8 +1060,9 @@ public sealed partial class MiniWindow : Window
         _isQuerying = loading;
 
         var loc = LocalizationService.Instance;
-        ToolTipService.SetToolTip(TranslateButton,
-            loading ? loc.GetString("Cancel") : loc.GetString("TranslateTooltip"));
+        var translateTooltip = loading ? loc.GetString("Cancel") : loc.GetString("TranslateTooltip");
+        ToolTipService.SetToolTip(TranslateButton, translateTooltip);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButton, translateTooltip);
 
         // Swap icon: show cancel (X) glyph during query, translate glyph otherwise
         TranslateIcon.Glyph = loading ? "\uE711" : "\uE8C1";
@@ -2469,8 +2476,7 @@ public sealed partial class MiniWindow : Window
     }
 
     /// <summary>
-    /// Show/hide quick-action buttons per user settings. The source-play button is also
-    /// hidden in Minimal mode regardless of the setting.
+    /// Show/hide quick-action buttons per user settings. Helper actions are hidden in compact chrome.
     /// </summary>
     private void ApplyButtonVisibility()
     {
@@ -2479,7 +2485,7 @@ public sealed partial class MiniWindow : Window
 
         PinButton.Visibility = !compact && settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
         OcrButton.Visibility = !compact && settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
-        SwapButton.Visibility = settings.ShowSwapButton ? Visibility.Visible : Visibility.Collapsed;
+        SwapButton.Visibility = !compact && settings.ShowSwapButton ? Visibility.Visible : Visibility.Collapsed;
         SourcePlayButton.Visibility = (!compact && settings.ShowSourcePlayButton)
             ? Visibility.Visible
             : Visibility.Collapsed;

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -146,7 +146,7 @@ public sealed partial class MiniWindow : Window
                 this,
                 _appWindow,
                 TitleBarRegion,
-                new FrameworkElement[] { PinButton, CloseButton },
+                new FrameworkElement[] { PinButton, OcrButton, CloseButton },
                 "MiniWindow");
             _titleBarHelper.Initialize();
         }
@@ -2345,9 +2345,27 @@ public sealed partial class MiniWindow : Window
             compactControls.RefreshTheme(Content as FrameworkElement);
         }
         TitleText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
-        DetectedLangText.Visibility = compact ? Visibility.Collapsed : DetectedLangText.Visibility;
+        if (compact)
+        {
+            DetectedLangText.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            RefreshDetectedLanguageChrome();
+        }
         StatusText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
         DispatcherQueue.TryEnqueue(() => _titleBarHelper?.UpdateDragRegions());
+    }
+
+    private void RefreshDetectedLanguageChrome()
+    {
+        if (_lastQuickQueryResolution is { } resolution)
+        {
+            UpdateQuickQueryModeStatus(resolution);
+            return;
+        }
+
+        UpdateDetectedLanguageDisplay(_lastDetectedLanguage);
     }
 
     private void OnCompactWindowControlsPointerEntered(object sender, PointerRoutedEventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -183,6 +183,7 @@ public sealed partial class MiniWindow : Window
 
         // Tooltips
         ToolTipService.SetToolTip(PinButton, loc.GetString("PinWindowTooltip"));
+        ToolTipService.SetToolTip(OcrButton, loc.GetString("OcrButtonTooltip"));
         ToolTipService.SetToolTip(CloseButton, loc.GetString("Close"));
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
@@ -247,6 +248,9 @@ public sealed partial class MiniWindow : Window
         // Apply pinned state
         _isPinned = _settings.MiniWindowIsPinned;
         UpdatePinState();
+
+        // Apply quick-action button visibility from settings
+        ApplyButtonVisibility();
     }
 
     /// <summary>
@@ -859,7 +863,7 @@ public sealed partial class MiniWindow : Window
             var desiredHeightDips = content.DesiredSize.Height;
 
             // Calculate new height with limits
-            var minHeightPx = DpiHelper.DipsToPhysicalPixels(200, scale);
+            var minHeightPx = DpiHelper.DipsToPhysicalPixels(AppearanceService.MinFloatingWindowHeightDips, scale);
             var desiredHeightPx = DpiHelper.DipsToPhysicalPixels(desiredHeightDips + 16, scale); // +16 for padding
             
             var newHeightPx = Math.Clamp(desiredHeightPx, minHeightPx, maxHeightPx);
@@ -1777,6 +1781,11 @@ public sealed partial class MiniWindow : Window
         HideWindow();
     }
 
+    private void OnOcrClicked(object sender, RoutedEventArgs e)
+    {
+        _ = App.TriggerOcrTranslateAsync();
+    }
+
     private async void OnTranslateClicked(object sender, RoutedEventArgs e)
     {
         if (_isQuerying)
@@ -2247,7 +2256,7 @@ public sealed partial class MiniWindow : Window
             SourceTextContainer,
             minimal,
             Content as FrameworkElement);
-        SourcePlayButton.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
+        ApplyButtonVisibility();
         DetectedLangText.Visibility = minimal ? Visibility.Collapsed : DetectedLangText.Visibility;
         StatusText.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
         var themeRoot = Content as FrameworkElement;
@@ -2270,6 +2279,34 @@ public sealed partial class MiniWindow : Window
         {
             TryApplyMicaBackdrop();
         }
+    }
+
+    /// <summary>
+    /// Re-apply appearance settings (result font size + quick-action button visibility)
+    /// to the mini window. Called from the app-wide appearance broadcast (issue #172).
+    /// </summary>
+    public void ApplyAppearance()
+    {
+        ApplyButtonVisibility();
+        ServiceResultViewHost.RefreshAppearance(_resultControls);
+        RequestResize();
+    }
+
+    /// <summary>
+    /// Show/hide quick-action buttons per user settings. The source-play button is also
+    /// hidden in Minimal mode regardless of the setting.
+    /// </summary>
+    private void ApplyButtonVisibility()
+    {
+        var settings = SettingsService.Instance;
+        var minimal = MinimalThemeService.IsActive;
+
+        PinButton.Visibility = settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
+        OcrButton.Visibility = settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
+        SwapButton.Visibility = settings.ShowSwapButton ? Visibility.Visible : Visibility.Collapsed;
+        SourcePlayButton.Visibility = (!minimal && settings.ShowSourcePlayButton)
+            ? Visibility.Visible
+            : Visibility.Collapsed;
     }
 
     /// <summary>

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -204,9 +204,11 @@ public sealed partial class MiniWindow : Window
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SwapButton, loc.GetString("SwapLanguagesTooltip"));
+        var sourcePlayTooltip = loc.GetString("PlaySourceTextTooltip");
+        ToolTipService.SetToolTip(SourcePlayButton, sourcePlayTooltip);
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
             SourcePlayButton,
-            loc.GetStringOrDefault("PlaySourceTextTooltip", "Play source text"));
+            sourcePlayTooltip);
         ToolTipService.SetToolTip(TargetLangCombo, loc.GetString("TargetLanguageTooltip"));
         ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(TranslateButton, loc.GetString("TranslateTooltip"));

--- a/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/MiniWindow.xaml.cs
@@ -62,6 +62,8 @@ public sealed partial class MiniWindow : Window
     private QuickQueryLanguageResolution? _lastQuickQueryResolution;
     private bool _showingGrammarFallbackNotice;
     private TitleBarDragRegionHelper? _titleBarHelper;
+    private CompactWindowControlsView? _compactWindowControls;
+    private WindowDragSession? _compactWindowDragSession;
     private bool _hasAutoPlayedCurrentQuery = false;
     private DateTime _lastShowTime = DateTime.MinValue;
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _resizeThrottleTimer;
@@ -79,6 +81,7 @@ public sealed partial class MiniWindow : Window
     private const int ResizeThrottleMs = 150;
     private const int InputFocusRetryDelayMs = 50;
     private const int InputFocusMaxAttempts = 10;
+    private const double CompactWindowControlsIdleOpacity = 0.52;
 
     /// <summary>
     /// Maximum time to wait for in-flight query to complete during cleanup.
@@ -89,6 +92,7 @@ public sealed partial class MiniWindow : Window
     {
         _targetLanguageSelector = new TargetLanguageSelector(_settings);
         this.InitializeComponent();
+        InitializeCompactWindowControls();
 
         // Construct the streaming coalescer on the UI dispatcher — its timer is
         // thread-affine. Built here (not lazily in the streaming loop) so the
@@ -187,10 +191,39 @@ public sealed partial class MiniWindow : Window
         ToolTipService.SetToolTip(CloseButton, loc.GetString("Close"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(PinButton, loc.GetString("PinWindowTooltip"));
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(OcrButton, loc.GetString("OcrButtonTooltip"));
+        if (_compactWindowControls is { } compactControls)
+        {
+            ToolTipService.SetToolTip(compactControls.CloseButton, loc.GetString("Close"));
+            ToolTipService.SetToolTip(compactControls.DragIsland, loc.GetStringOrDefault("DragWindowTooltip", "Drag window"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(compactControls.CloseButton, loc.GetString("Close"));
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+                compactControls.DragIsland,
+                loc.GetStringOrDefault("DragWindowTooltip", "Drag window"));
+        }
         ToolTipService.SetToolTip(SourceLangCombo, loc.GetString("SourceLanguageTooltip"));
         ToolTipService.SetToolTip(SwapButton, loc.GetString("SwapLanguagesTooltip"));
         ToolTipService.SetToolTip(TargetLangCombo, loc.GetString("TargetLanguageTooltip"));
         ToolTipService.SetToolTip(TranslateButton, loc.GetString("TranslateTooltip"));
+    }
+
+    private void InitializeCompactWindowControls()
+    {
+        if (WindowSurface.Child is not Grid surfaceGrid)
+        {
+            return;
+        }
+
+        _compactWindowControls = new CompactWindowControlsView();
+        surfaceGrid.Children.Add(_compactWindowControls.Root);
+        _compactWindowControls.Root.PointerEntered += OnCompactWindowControlsPointerEntered;
+        _compactWindowControls.Root.PointerExited += OnCompactWindowControlsPointerExited;
+        _compactWindowControls.DragIsland.PointerPressed += OnCompactDragIslandPointerPressed;
+        _compactWindowControls.DragIsland.PointerMoved += OnCompactDragIslandPointerMoved;
+        _compactWindowControls.DragIsland.PointerReleased += OnCompactDragIslandPointerReleased;
+        _compactWindowControls.DragIsland.PointerCanceled += OnCompactDragIslandPointerCanceled;
+        _compactWindowControls.DragIsland.PointerCaptureLost += OnCompactDragIslandPointerCaptureLost;
+        _compactWindowControls.CloseButton.Click += OnCompactCloseClicked;
+        _compactWindowControls.RefreshTheme(Content as FrameworkElement);
     }
 
     /// <summary>
@@ -253,6 +286,7 @@ public sealed partial class MiniWindow : Window
 
         // Apply quick-action button visibility from settings
         ApplyButtonVisibility();
+        ApplyCompactChromeLayout();
     }
 
     /// <summary>
@@ -485,7 +519,7 @@ public sealed partial class MiniWindow : Window
             DetectedLangText.Text = loc.GetStringOrDefault(
                 "GrammarCorrectionFallbackNotice",
                 "No grammar-capable AI service is enabled, so this query fell back to translation. Enable an AI service that supports grammar correction to show correction details when source and target are the same.");
-            DetectedLangText.Visibility = Visibility.Visible;
+            DetectedLangText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
             RequestResize();
             return;
         }
@@ -495,7 +529,7 @@ public sealed partial class MiniWindow : Window
             DetectedLangText.Text = loc.GetStringOrDefault(
                 "GrammarCorrectionActiveNotice",
                 "Grammar check mode: AI correction services will run. Choose a different target language to translate.");
-            DetectedLangText.Visibility = Visibility.Visible;
+            DetectedLangText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
             RequestResize();
             return;
         }
@@ -1742,7 +1776,7 @@ public sealed partial class MiniWindow : Window
             DetectedLangText.Text = string.Format(
                 LocalizationService.Instance.GetString("DetectedLanguage"),
                 displayName);
-            DetectedLangText.Visibility = Visibility.Visible;
+            DetectedLangText.Visibility = IsCompactChrome ? Visibility.Collapsed : Visibility.Visible;
         }
         else
         {
@@ -2259,8 +2293,7 @@ public sealed partial class MiniWindow : Window
             minimal,
             Content as FrameworkElement);
         ApplyButtonVisibility();
-        DetectedLangText.Visibility = minimal ? Visibility.Collapsed : DetectedLangText.Visibility;
-        StatusText.Visibility = minimal ? Visibility.Collapsed : Visibility.Visible;
+        ApplyCompactChromeLayout();
         var themeRoot = Content as FrameworkElement;
         MinimalThemeService.ApplyAccentIconForeground(TranslateIcon, LoadingRing, themeRoot);
 
@@ -2290,8 +2323,131 @@ public sealed partial class MiniWindow : Window
     public void ApplyAppearance()
     {
         ApplyButtonVisibility();
+        ApplyCompactChromeLayout();
         ServiceResultViewHost.RefreshAppearance(_resultControls);
         RequestResize();
+    }
+
+    private bool IsCompactChrome => MinimalThemeService.IsActive || SettingsService.Instance.CompactMode;
+
+    private bool ShouldShowCompactWindowControls => SettingsService.Instance.CompactMode;
+
+    private void ApplyCompactChromeLayout()
+    {
+        var compact = IsCompactChrome;
+        var showCompactControls = ShouldShowCompactWindowControls;
+        TitleBarRegion.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+        TitleBarRegion.Margin = compact ? new Thickness(0) : new Thickness(0, 0, 0, 4);
+        if (_compactWindowControls is { } compactControls)
+        {
+            compactControls.Root.Visibility = showCompactControls ? Visibility.Visible : Visibility.Collapsed;
+            compactControls.Root.Opacity = showCompactControls ? CompactWindowControlsIdleOpacity : 0;
+            compactControls.RefreshTheme(Content as FrameworkElement);
+        }
+        TitleText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+        DetectedLangText.Visibility = compact ? Visibility.Collapsed : DetectedLangText.Visibility;
+        StatusText.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
+        DispatcherQueue.TryEnqueue(() => _titleBarHelper?.UpdateDragRegions());
+    }
+
+    private void OnCompactWindowControlsPointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        if (ShouldShowCompactWindowControls)
+        {
+            if (_compactWindowControls is { } compactControls)
+            {
+                compactControls.Root.Opacity = 1;
+            }
+        }
+    }
+
+    private void OnCompactWindowControlsPointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        if (ShouldShowCompactWindowControls)
+        {
+            if (_compactWindowControls is { } compactControls)
+            {
+                compactControls.Root.Opacity = CompactWindowControlsIdleOpacity;
+            }
+        }
+    }
+
+    private void OnCompactDragIslandPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (!ShouldShowCompactWindowControls
+            || _compactWindowDragSession is not null
+            || sender is not UIElement dragElement
+            || !WindowDragHelper.TryBeginLeftButtonDrag(this, dragElement, e, out var session))
+        {
+            return;
+        }
+
+        _compactWindowDragSession = session;
+        e.Handled = true;
+    }
+
+    private void OnCompactDragIslandPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (_compactWindowDragSession is not { } session
+            || sender is not UIElement dragElement
+            || !WindowDragHelper.IsSessionPointer(session, e))
+        {
+            return;
+        }
+
+        if (WindowDragHelper.TryUpdateLeftButtonDrag(session, dragElement, e))
+        {
+            e.Handled = true;
+            return;
+        }
+
+        EndCompactWindowDrag(dragElement, e, releaseCapture: true);
+    }
+
+    private void OnCompactDragIslandPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement dragElement)
+        {
+            EndCompactWindowDrag(dragElement, e, releaseCapture: true);
+        }
+    }
+
+    private void OnCompactDragIslandPointerCanceled(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement dragElement)
+        {
+            EndCompactWindowDrag(dragElement, e, releaseCapture: true);
+        }
+    }
+
+    private void OnCompactDragIslandPointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is UIElement dragElement)
+        {
+            EndCompactWindowDrag(dragElement, e, releaseCapture: false);
+        }
+    }
+
+    private void EndCompactWindowDrag(UIElement dragElement, PointerRoutedEventArgs e, bool releaseCapture)
+    {
+        if (_compactWindowDragSession is not { } session
+            || !WindowDragHelper.IsSessionPointer(session, e))
+        {
+            return;
+        }
+
+        _compactWindowDragSession = null;
+        if (releaseCapture)
+        {
+            dragElement.ReleasePointerCapture(e.Pointer);
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnCompactCloseClicked(object sender, RoutedEventArgs e)
+    {
+        HideWindow();
     }
 
     /// <summary>
@@ -2301,12 +2457,12 @@ public sealed partial class MiniWindow : Window
     private void ApplyButtonVisibility()
     {
         var settings = SettingsService.Instance;
-        var minimal = MinimalThemeService.IsActive;
+        var compact = IsCompactChrome;
 
-        PinButton.Visibility = settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
-        OcrButton.Visibility = settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
+        PinButton.Visibility = !compact && settings.ShowPinButton ? Visibility.Visible : Visibility.Collapsed;
+        OcrButton.Visibility = !compact && settings.ShowOcrButton ? Visibility.Visible : Visibility.Collapsed;
         SwapButton.Visibility = settings.ShowSwapButton ? Visibility.Visible : Visibility.Collapsed;
-        SourcePlayButton.Visibility = (!minimal && settings.ShowSourcePlayButton)
+        SourcePlayButton.Visibility = (!compact && settings.ShowSourcePlayButton)
             ? Visibility.Visible
             : Visibility.Collapsed;
     }

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -2162,6 +2162,16 @@
                                            TextWrapping="Wrap"
                                            Visibility="Collapsed"/>
 
+                                <!-- Compact mode (issue #172) -->
+                                <ToggleSwitch x:Name="CompactModeToggle"
+                                        Header="Compact mode"/>
+                                <TextBlock
+                                    x:Name="CompactModeDescriptionText"
+                                    Text="Hide secondary chrome and helper actions for a tighter translation surface."
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+
                                 <!-- Result font size (issue #172) -->
                                 <TextBlock
                                     x:Name="ResultFontSizeLabel"

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -2106,39 +2106,6 @@
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                         TextWrapping="Wrap"/>
 
-                                <!-- Result font size (issue #172) -->
-                                <TextBlock
-                                    x:Name="ResultFontSizeLabel"
-                                    Text="Result font size"
-                                    FontWeight="SemiBold"/>
-                                <Slider
-                                    x:Name="ResultFontScaleSlider"
-                                    Minimum="0.85"
-                                    Maximum="1.4"
-                                    StepFrequency="0.05"
-                                    Width="250"
-                                    HorizontalAlignment="Left"/>
-                                <TextBlock
-                                    x:Name="ResultFontSizeDescriptionText"
-                                    Text="Adjust the font size of translation results."
-                                    FontSize="12"
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    TextWrapping="Wrap"/>
-
-                                <!-- Quick-action buttons (issue #172) -->
-                                <TextBlock
-                                    x:Name="QuickActionsHeaderText"
-                                    Text="Quick action buttons"
-                                    FontWeight="SemiBold"/>
-                                <ToggleSwitch x:Name="ShowOcrButtonToggle"
-                                        Header="Show OCR button"/>
-                                <ToggleSwitch x:Name="ShowPinButtonToggle"
-                                        Header="Show pin button"/>
-                                <ToggleSwitch x:Name="ShowSourcePlayButtonToggle"
-                                        Header="Show play button"/>
-                                <ToggleSwitch x:Name="ShowSwapButtonToggle"
-                                        Header="Show swap button"/>
-
                                 <ToggleSwitch x:Name="MinimizeToTrayToggle"
                                         Header="Minimize to system tray"/>
                                 <ToggleSwitch x:Name="MinimizeToTrayOnStartupToggle"
@@ -2194,6 +2161,39 @@
                                            Margin="44,0,0,0"
                                            TextWrapping="Wrap"
                                            Visibility="Collapsed"/>
+
+                                <!-- Result font size (issue #172) -->
+                                <TextBlock
+                                    x:Name="ResultFontSizeLabel"
+                                    Text="Result font size"
+                                    FontWeight="SemiBold"/>
+                                <Slider
+                                    x:Name="ResultFontScaleSlider"
+                                    Minimum="0.85"
+                                    Maximum="1.4"
+                                    StepFrequency="0.05"
+                                    Width="250"
+                                    HorizontalAlignment="Left"/>
+                                <TextBlock
+                                    x:Name="ResultFontSizeDescriptionText"
+                                    Text="Adjust the font size of translation results."
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+
+                                <!-- Quick-action buttons (issue #172) -->
+                                <TextBlock
+                                    x:Name="QuickActionsHeaderText"
+                                    Text="Quick action buttons"
+                                    FontWeight="SemiBold"/>
+                                <ToggleSwitch x:Name="ShowOcrButtonToggle"
+                                        Header="Show OCR button"/>
+                                <ToggleSwitch x:Name="ShowPinButtonToggle"
+                                        Header="Show pin button"/>
+                                <ToggleSwitch x:Name="ShowSourcePlayButtonToggle"
+                                        Header="Show play button"/>
+                                <ToggleSwitch x:Name="ShowSwapButtonToggle"
+                                        Header="Show swap button"/>
                             </StackPanel>
                         </Border>
                     </StackPanel>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -2106,6 +2106,39 @@
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                         TextWrapping="Wrap"/>
 
+                                <!-- Result font size (issue #172) -->
+                                <TextBlock
+                                    x:Name="ResultFontSizeLabel"
+                                    Text="Result font size"
+                                    FontWeight="SemiBold"/>
+                                <Slider
+                                    x:Name="ResultFontScaleSlider"
+                                    Minimum="0.85"
+                                    Maximum="1.4"
+                                    StepFrequency="0.05"
+                                    Width="250"
+                                    HorizontalAlignment="Left"/>
+                                <TextBlock
+                                    x:Name="ResultFontSizeDescriptionText"
+                                    Text="Adjust the font size of translation results."
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    TextWrapping="Wrap"/>
+
+                                <!-- Quick-action buttons (issue #172) -->
+                                <TextBlock
+                                    x:Name="QuickActionsHeaderText"
+                                    Text="Quick action buttons"
+                                    FontWeight="SemiBold"/>
+                                <ToggleSwitch x:Name="ShowOcrButtonToggle"
+                                        Header="Show OCR button"/>
+                                <ToggleSwitch x:Name="ShowPinButtonToggle"
+                                        Header="Show pin button"/>
+                                <ToggleSwitch x:Name="ShowSourcePlayButtonToggle"
+                                        Header="Show play button"/>
+                                <ToggleSwitch x:Name="ShowSwapButtonToggle"
+                                        Header="Show swap button"/>
+
                                 <ToggleSwitch x:Name="MinimizeToTrayToggle"
                                         Header="Minimize to system tray"/>
                                 <ToggleSwitch x:Name="MinimizeToTrayOnStartupToggle"

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -1563,6 +1563,8 @@ public sealed partial class SettingsPage : Page
         MouseSelectionExcludedAppsBox.PlaceholderText = loc.GetString("ExcludedAppsPlaceholder");
         MouseSelectionExcludedAppsDescriptionText.Text = loc.GetString("ExcludedAppsDescription");
         AlwaysOnTopToggle.Header = loc.GetString("AlwaysOnTop");
+        CompactModeToggle.Header = loc.GetString("CompactMode");
+        CompactModeDescriptionText.Text = loc.GetString("CompactModeDescription");
         ResultFontSizeLabel.Text = loc.GetString("ResultFontSize");
         ResultFontSizeDescriptionText.Text = loc.GetString("ResultFontSizeDescription");
         QuickActionsHeaderText.Text = loc.GetString("QuickActionsHeader");
@@ -2181,6 +2183,7 @@ public sealed partial class SettingsPage : Page
         MouseSelectionTranslateToggle.Toggled += OnMouseSelectionTranslateToggled;
         MouseSelectionExcludedAppsBox.TextChanged += OnSettingChanged;
         AlwaysOnTopToggle.Toggled += OnSettingChanged;
+        CompactModeToggle.Toggled += OnSettingChanged;
         ShowOcrButtonToggle.Toggled += OnSettingChanged;
         ShowPinButtonToggle.Toggled += OnSettingChanged;
         ShowSourcePlayButtonToggle.Toggled += OnSettingChanged;
@@ -2289,6 +2292,7 @@ public sealed partial class SettingsPage : Page
         HideEmptyServiceResultsToggle.Toggled -= OnSettingChanged;
         EnableLocalDictionarySuggestionsToggle.Toggled -= OnSettingChanged;
         ShowOcrButtonToggle.Toggled -= OnSettingChanged;
+        CompactModeToggle.Toggled -= OnSettingChanged;
         ShowPinButtonToggle.Toggled -= OnSettingChanged;
         ShowSourcePlayButtonToggle.Toggled -= OnSettingChanged;
         ShowSwapButtonToggle.Toggled -= OnSettingChanged;
@@ -2699,6 +2703,7 @@ public sealed partial class SettingsPage : Page
             || HideEmptyServiceResultsToggle.IsOn != _settings.HideEmptyServiceResults
             || EnableLocalDictionarySuggestionsToggle.IsOn != _settings.EnableLocalDictionarySuggestions
             || !SameDouble(ResultFontScaleSlider.Value, _settings.ResultFontScale)
+            || CompactModeToggle.IsOn != _settings.CompactMode
             || ShowOcrButtonToggle.IsOn != _settings.ShowOcrButton
             || ShowPinButtonToggle.IsOn != _settings.ShowPinButton
             || ShowSourcePlayButtonToggle.IsOn != _settings.ShowSourcePlayButton
@@ -2958,6 +2963,7 @@ public sealed partial class SettingsPage : Page
                 ? Visibility.Visible : Visibility.Collapsed;
             AlwaysOnTopToggle.IsOn = _settings.AlwaysOnTop;
             ResultFontScaleSlider.Value = _settings.ResultFontScale;
+            CompactModeToggle.IsOn = _settings.CompactMode;
             ShowOcrButtonToggle.IsOn = _settings.ShowOcrButton;
             ShowPinButtonToggle.IsOn = _settings.ShowPinButton;
             ShowSourcePlayButtonToggle.IsOn = _settings.ShowSourcePlayButton;
@@ -4285,6 +4291,7 @@ public sealed partial class SettingsPage : Page
             .ToList();
         _settings.AlwaysOnTop = AlwaysOnTopToggle.IsOn;
         _settings.ResultFontScale = ResultFontScaleSlider.Value;
+        _settings.CompactMode = CompactModeToggle.IsOn;
         _settings.ShowOcrButton = ShowOcrButtonToggle.IsOn;
         _settings.ShowPinButton = ShowPinButtonToggle.IsOn;
         _settings.ShowSourcePlayButton = ShowSourcePlayButtonToggle.IsOn;

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -1563,6 +1563,13 @@ public sealed partial class SettingsPage : Page
         MouseSelectionExcludedAppsBox.PlaceholderText = loc.GetString("ExcludedAppsPlaceholder");
         MouseSelectionExcludedAppsDescriptionText.Text = loc.GetString("ExcludedAppsDescription");
         AlwaysOnTopToggle.Header = loc.GetString("AlwaysOnTop");
+        ResultFontSizeLabel.Text = loc.GetString("ResultFontSize");
+        ResultFontSizeDescriptionText.Text = loc.GetString("ResultFontSizeDescription");
+        QuickActionsHeaderText.Text = loc.GetString("QuickActionsHeader");
+        ShowOcrButtonToggle.Header = loc.GetString("ShowOcrButton");
+        ShowPinButtonToggle.Header = loc.GetString("ShowPinButton");
+        ShowSourcePlayButtonToggle.Header = loc.GetString("ShowSourcePlayButton");
+        ShowSwapButtonToggle.Header = loc.GetString("ShowSwapButton");
         LaunchAtStartupToggle.Header = loc.GetString("LaunchAtStartup");
         HideEmptyServiceResultsToggle.Header = loc.GetString("HideEmptyServiceResults");
         EnableLocalDictionarySuggestionsLabelText.Text = loc.GetString("EnableLocalDictionarySuggestions");
@@ -2174,12 +2181,17 @@ public sealed partial class SettingsPage : Page
         MouseSelectionTranslateToggle.Toggled += OnMouseSelectionTranslateToggled;
         MouseSelectionExcludedAppsBox.TextChanged += OnSettingChanged;
         AlwaysOnTopToggle.Toggled += OnSettingChanged;
+        ShowOcrButtonToggle.Toggled += OnSettingChanged;
+        ShowPinButtonToggle.Toggled += OnSettingChanged;
+        ShowSourcePlayButtonToggle.Toggled += OnSettingChanged;
+        ShowSwapButtonToggle.Toggled += OnSettingChanged;
         LaunchAtStartupToggle.Toggled += OnSettingChanged;
         HideEmptyServiceResultsToggle.Toggled += OnSettingChanged;
         EnableLocalDictionarySuggestionsToggle.Toggled += OnSettingChanged;
         ProxyEnabledToggle.Toggled += OnSettingChanged;
         ProxyBypassLocalToggle.Toggled += OnSettingChanged;
         TtsSpeedSlider.ValueChanged += OnSettingChanged;
+        ResultFontScaleSlider.ValueChanged += OnSettingChanged;
         AutoPlayTranslationToggle.Toggled += OnSettingChanged;
 
         // TextBox/PasswordBox changes - existing
@@ -2276,9 +2288,14 @@ public sealed partial class SettingsPage : Page
         LaunchAtStartupToggle.Toggled -= OnSettingChanged;
         HideEmptyServiceResultsToggle.Toggled -= OnSettingChanged;
         EnableLocalDictionarySuggestionsToggle.Toggled -= OnSettingChanged;
+        ShowOcrButtonToggle.Toggled -= OnSettingChanged;
+        ShowPinButtonToggle.Toggled -= OnSettingChanged;
+        ShowSourcePlayButtonToggle.Toggled -= OnSettingChanged;
+        ShowSwapButtonToggle.Toggled -= OnSettingChanged;
         ProxyEnabledToggle.Toggled -= OnSettingChanged;
         ProxyBypassLocalToggle.Toggled -= OnSettingChanged;
         TtsSpeedSlider.ValueChanged -= OnSettingChanged;
+        ResultFontScaleSlider.ValueChanged -= OnSettingChanged;
         AutoPlayTranslationToggle.Toggled -= OnSettingChanged;
 
         DeepLKeyBox.PasswordChanged -= OnSettingChanged;
@@ -2680,7 +2697,12 @@ public sealed partial class SettingsPage : Page
             || !SameDouble(TtsSpeedSlider.Value, _settings.TtsSpeed)
             || AutoPlayTranslationToggle.IsOn != _settings.AutoPlayTranslation
             || HideEmptyServiceResultsToggle.IsOn != _settings.HideEmptyServiceResults
-            || EnableLocalDictionarySuggestionsToggle.IsOn != _settings.EnableLocalDictionarySuggestions;
+            || EnableLocalDictionarySuggestionsToggle.IsOn != _settings.EnableLocalDictionarySuggestions
+            || !SameDouble(ResultFontScaleSlider.Value, _settings.ResultFontScale)
+            || ShowOcrButtonToggle.IsOn != _settings.ShowOcrButton
+            || ShowPinButtonToggle.IsOn != _settings.ShowPinButton
+            || ShowSourcePlayButtonToggle.IsOn != _settings.ShowSourcePlayButton
+            || ShowSwapButtonToggle.IsOn != _settings.ShowSwapButton;
     }
 
     private bool LanguageTabSettingsDifferFromSettings()
@@ -2935,6 +2957,11 @@ public sealed partial class SettingsPage : Page
             MouseSelectionExcludedAppsPanel.Visibility = _settings.MouseSelectionTranslate
                 ? Visibility.Visible : Visibility.Collapsed;
             AlwaysOnTopToggle.IsOn = _settings.AlwaysOnTop;
+            ResultFontScaleSlider.Value = _settings.ResultFontScale;
+            ShowOcrButtonToggle.IsOn = _settings.ShowOcrButton;
+            ShowPinButtonToggle.IsOn = _settings.ShowPinButton;
+            ShowSourcePlayButtonToggle.IsOn = _settings.ShowSourcePlayButton;
+            ShowSwapButtonToggle.IsOn = _settings.ShowSwapButton;
             LaunchAtStartupToggle.IsOn = _settings.LaunchAtStartup;
             HideEmptyServiceResultsToggle.IsOn = _settings.HideEmptyServiceResults;
             EnableLocalDictionarySuggestionsToggle.IsOn = _settings.EnableLocalDictionarySuggestions;
@@ -4257,6 +4284,11 @@ public sealed partial class SettingsPage : Page
             .Where(s => s.Length > 0)
             .ToList();
         _settings.AlwaysOnTop = AlwaysOnTopToggle.IsOn;
+        _settings.ResultFontScale = ResultFontScaleSlider.Value;
+        _settings.ShowOcrButton = ShowOcrButtonToggle.IsOn;
+        _settings.ShowPinButton = ShowPinButtonToggle.IsOn;
+        _settings.ShowSourcePlayButton = ShowSourcePlayButtonToggle.IsOn;
+        _settings.ShowSwapButton = ShowSwapButtonToggle.IsOn;
         _settings.LaunchAtStartup = LaunchAtStartupToggle.IsOn;
         _settings.TtsSpeed = TtsSpeedSlider.Value;
         _settings.AutoPlayTranslation = AutoPlayTranslationToggle.IsOn;
@@ -4341,6 +4373,9 @@ public sealed partial class SettingsPage : Page
 
         // Apply always-on-top setting immediately
         App.ApplyAlwaysOnTop(_settings.AlwaysOnTop);
+
+        // Apply appearance (result font size + button visibility) immediately (issue #172)
+        App.ApplyAppearance();
 
         // Apply clipboard monitoring immediately
         App.ApplyClipboardMonitoring(_settings.ClipboardMonitoring);

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/AppearanceServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/AppearanceServiceTests.cs
@@ -85,6 +85,7 @@ public class AppearanceServiceTests
     public void AppearanceSettings_SurviveSave()
     {
         var originalFontScale = _settings.ResultFontScale;
+        var originalCompactMode = _settings.CompactMode;
         var originalOcr = _settings.ShowOcrButton;
         var originalPin = _settings.ShowPinButton;
         var originalPlay = _settings.ShowSourcePlayButton;
@@ -94,6 +95,7 @@ public class AppearanceServiceTests
         try
         {
             _settings.ResultFontScale = 1.25;
+            _settings.CompactMode = true;
             _settings.ShowOcrButton = false;
             _settings.ShowPinButton = false;
             _settings.ShowSourcePlayButton = false;
@@ -102,6 +104,7 @@ public class AppearanceServiceTests
             _settings.Save();
 
             _settings.ResultFontScale.Should().Be(1.25);
+            _settings.CompactMode.Should().BeTrue();
             _settings.ShowOcrButton.Should().BeFalse();
             _settings.ShowPinButton.Should().BeFalse();
             _settings.ShowSourcePlayButton.Should().BeFalse();
@@ -111,6 +114,7 @@ public class AppearanceServiceTests
         finally
         {
             _settings.ResultFontScale = originalFontScale;
+            _settings.CompactMode = originalCompactMode;
             _settings.ShowOcrButton = originalOcr;
             _settings.ShowPinButton = originalPin;
             _settings.ShowSourcePlayButton = originalPlay;

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/AppearanceServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/AppearanceServiceTests.cs
@@ -1,35 +1,42 @@
 using Easydict.WinUI.Services;
 using FluentAssertions;
-using System.Reflection;
 using Xunit;
 
 namespace Easydict.WinUI.Tests.Services;
 
 /// <summary>
 /// Tests for the appearance personalization added in issue #172:
-/// the <see cref="AppearanceService"/> font-size math and round-trip
-/// persistence of the new <see cref="SettingsService"/> properties.
+/// the <see cref="AppearanceService"/> font-size math and persistence of the
+/// new <see cref="SettingsService"/> properties.
+///
+/// These tests use the <see cref="SettingsService"/> singleton and restore any
+/// mutated state in a finally block — mirroring the existing
+/// <c>TtsSettings_RoundTripThroughSave</c> pattern. They intentionally avoid the
+/// EASYDICT_SETTINGS_DIR + temporary-directory dance, which can poison the
+/// lazily-constructed singleton's settings path for other tests in the shared
+/// collection.
 /// </summary>
 [Trait("Category", "WinUI")]
 [Collection("SettingsService")]
 public class AppearanceServiceTests
 {
+    private readonly SettingsService _settings = SettingsService.Instance;
+
     [Theory]
     [InlineData(1.0, 13.0)]
     [InlineData(0.85, 11.05)]
     [InlineData(1.4, 18.2)]
     public void ResultFontSize_ScalesWithSetting(double scale, double expected)
     {
-        var settings = SettingsService.Instance;
-        var original = settings.ResultFontScale;
+        var original = _settings.ResultFontScale;
         try
         {
-            settings.ResultFontScale = scale;
+            _settings.ResultFontScale = scale;
             AppearanceService.ResultFontSize.Should().BeApproximately(expected, 0.001);
         }
         finally
         {
-            settings.ResultFontScale = original;
+            _settings.ResultFontScale = original;
         }
     }
 
@@ -38,27 +45,25 @@ public class AppearanceServiceTests
     [InlineData(2.0, 1.4)]    // above max clamps down
     public void FontScale_IsClamped(double raw, double clamped)
     {
-        var settings = SettingsService.Instance;
-        var original = settings.ResultFontScale;
+        var original = _settings.ResultFontScale;
         try
         {
-            settings.ResultFontScale = raw;
+            _settings.ResultFontScale = raw;
             AppearanceService.FontScale.Should().Be(clamped);
         }
         finally
         {
-            settings.ResultFontScale = original;
+            _settings.ResultFontScale = original;
         }
     }
 
     [Fact]
     public void CurrentSnapshot_DerivesHeaderAndStatusSizesFromScale()
     {
-        var settings = SettingsService.Instance;
-        var original = settings.ResultFontScale;
+        var original = _settings.ResultFontScale;
         try
         {
-            settings.ResultFontScale = 1.0;
+            _settings.ResultFontScale = 1.0;
             var snapshot = AppearanceService.CurrentSnapshot();
             snapshot.ResultFontSize.Should().BeApproximately(13.0, 0.001);
             snapshot.ServiceNameFontSize.Should().BeApproximately(12.0, 0.001);
@@ -66,7 +71,7 @@ public class AppearanceServiceTests
         }
         finally
         {
-            settings.ResultFontScale = original;
+            _settings.ResultFontScale = original;
         }
     }
 
@@ -77,98 +82,41 @@ public class AppearanceServiceTests
     }
 
     [Fact]
-    public void AppearanceSettings_RoundTripThroughSettingsFile()
+    public void AppearanceSettings_SurviveSave()
     {
-        using var testDirectory = new TemporaryDirectory();
-        var previous = Environment.GetEnvironmentVariable("EASYDICT_SETTINGS_DIR");
+        var originalFontScale = _settings.ResultFontScale;
+        var originalOcr = _settings.ShowOcrButton;
+        var originalPin = _settings.ShowPinButton;
+        var originalPlay = _settings.ShowSourcePlayButton;
+        var originalSwap = _settings.ShowSwapButton;
+        var originalFixedPinned = _settings.FixedWindowIsPinned;
+
         try
         {
-            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", testDirectory.Path);
+            _settings.ResultFontScale = 1.25;
+            _settings.ShowOcrButton = false;
+            _settings.ShowPinButton = false;
+            _settings.ShowSourcePlayButton = false;
+            _settings.ShowSwapButton = false;
+            _settings.FixedWindowIsPinned = false;
+            _settings.Save();
 
-            var writer = CreateIsolatedSettingsService();
-            writer.ResultFontScale = 1.25;
-            writer.ShowOcrButton = false;
-            writer.ShowPinButton = false;
-            writer.ShowSourcePlayButton = false;
-            writer.ShowSwapButton = false;
-            writer.FixedWindowIsPinned = false;
-            writer.Save();
-
-            var reader = CreateIsolatedSettingsService();
-            reader.ResultFontScale.Should().Be(1.25);
-            reader.ShowOcrButton.Should().BeFalse();
-            reader.ShowPinButton.Should().BeFalse();
-            reader.ShowSourcePlayButton.Should().BeFalse();
-            reader.ShowSwapButton.Should().BeFalse();
-            reader.FixedWindowIsPinned.Should().BeFalse();
+            _settings.ResultFontScale.Should().Be(1.25);
+            _settings.ShowOcrButton.Should().BeFalse();
+            _settings.ShowPinButton.Should().BeFalse();
+            _settings.ShowSourcePlayButton.Should().BeFalse();
+            _settings.ShowSwapButton.Should().BeFalse();
+            _settings.FixedWindowIsPinned.Should().BeFalse();
         }
         finally
         {
-            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", previous);
-        }
-    }
-
-    [Fact]
-    public void AppearanceDefaults_PreserveExistingLook()
-    {
-        using var testDirectory = new TemporaryDirectory();
-        var previous = Environment.GetEnvironmentVariable("EASYDICT_SETTINGS_DIR");
-        try
-        {
-            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", testDirectory.Path);
-
-            var settings = CreateIsolatedSettingsService();
-            settings.ResultFontScale.Should().Be(1.0);
-            settings.ShowOcrButton.Should().BeTrue();
-            settings.ShowPinButton.Should().BeTrue();
-            settings.ShowSourcePlayButton.Should().BeTrue();
-            settings.ShowSwapButton.Should().BeTrue();
-            settings.FixedWindowIsPinned.Should().BeTrue();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", previous);
-        }
-    }
-
-    private static SettingsService CreateIsolatedSettingsService()
-    {
-        var constructor = typeof(SettingsService).GetConstructor(
-            BindingFlags.Instance | BindingFlags.NonPublic,
-            binder: null,
-            Type.EmptyTypes,
-            modifiers: null);
-
-        constructor.Should().NotBeNull();
-        return (SettingsService)constructor!.Invoke(null);
-    }
-
-    private sealed class TemporaryDirectory : IDisposable
-    {
-        public TemporaryDirectory()
-        {
-            Path = System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(),
-                "Easydict.WinUI.Tests",
-                Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(Path);
-        }
-
-        public string Path { get; }
-
-        public void Dispose()
-        {
-            try
-            {
-                if (Directory.Exists(Path))
-                {
-                    Directory.Delete(Path, recursive: true);
-                }
-            }
-            catch
-            {
-                // Best-effort cleanup.
-            }
+            _settings.ResultFontScale = originalFontScale;
+            _settings.ShowOcrButton = originalOcr;
+            _settings.ShowPinButton = originalPin;
+            _settings.ShowSourcePlayButton = originalPlay;
+            _settings.ShowSwapButton = originalSwap;
+            _settings.FixedWindowIsPinned = originalFixedPinned;
+            _settings.Save();
         }
     }
 }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/AppearanceServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/AppearanceServiceTests.cs
@@ -1,0 +1,174 @@
+using Easydict.WinUI.Services;
+using FluentAssertions;
+using System.Reflection;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+/// <summary>
+/// Tests for the appearance personalization added in issue #172:
+/// the <see cref="AppearanceService"/> font-size math and round-trip
+/// persistence of the new <see cref="SettingsService"/> properties.
+/// </summary>
+[Trait("Category", "WinUI")]
+[Collection("SettingsService")]
+public class AppearanceServiceTests
+{
+    [Theory]
+    [InlineData(1.0, 13.0)]
+    [InlineData(0.85, 11.05)]
+    [InlineData(1.4, 18.2)]
+    public void ResultFontSize_ScalesWithSetting(double scale, double expected)
+    {
+        var settings = SettingsService.Instance;
+        var original = settings.ResultFontScale;
+        try
+        {
+            settings.ResultFontScale = scale;
+            AppearanceService.ResultFontSize.Should().BeApproximately(expected, 0.001);
+        }
+        finally
+        {
+            settings.ResultFontScale = original;
+        }
+    }
+
+    [Theory]
+    [InlineData(0.5, 0.85)]   // below min clamps up
+    [InlineData(2.0, 1.4)]    // above max clamps down
+    public void FontScale_IsClamped(double raw, double clamped)
+    {
+        var settings = SettingsService.Instance;
+        var original = settings.ResultFontScale;
+        try
+        {
+            settings.ResultFontScale = raw;
+            AppearanceService.FontScale.Should().Be(clamped);
+        }
+        finally
+        {
+            settings.ResultFontScale = original;
+        }
+    }
+
+    [Fact]
+    public void CurrentSnapshot_DerivesHeaderAndStatusSizesFromScale()
+    {
+        var settings = SettingsService.Instance;
+        var original = settings.ResultFontScale;
+        try
+        {
+            settings.ResultFontScale = 1.0;
+            var snapshot = AppearanceService.CurrentSnapshot();
+            snapshot.ResultFontSize.Should().BeApproximately(13.0, 0.001);
+            snapshot.ServiceNameFontSize.Should().BeApproximately(12.0, 0.001);
+            snapshot.StatusFontSize.Should().BeApproximately(10.0, 0.001);
+        }
+        finally
+        {
+            settings.ResultFontScale = original;
+        }
+    }
+
+    [Fact]
+    public void MinFloatingWindowHeight_IsCompact()
+    {
+        AppearanceService.MinFloatingWindowHeightDips.Should().BeLessThan(200.0);
+    }
+
+    [Fact]
+    public void AppearanceSettings_RoundTripThroughSettingsFile()
+    {
+        using var testDirectory = new TemporaryDirectory();
+        var previous = Environment.GetEnvironmentVariable("EASYDICT_SETTINGS_DIR");
+        try
+        {
+            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", testDirectory.Path);
+
+            var writer = CreateIsolatedSettingsService();
+            writer.ResultFontScale = 1.25;
+            writer.ShowOcrButton = false;
+            writer.ShowPinButton = false;
+            writer.ShowSourcePlayButton = false;
+            writer.ShowSwapButton = false;
+            writer.FixedWindowIsPinned = false;
+            writer.Save();
+
+            var reader = CreateIsolatedSettingsService();
+            reader.ResultFontScale.Should().Be(1.25);
+            reader.ShowOcrButton.Should().BeFalse();
+            reader.ShowPinButton.Should().BeFalse();
+            reader.ShowSourcePlayButton.Should().BeFalse();
+            reader.ShowSwapButton.Should().BeFalse();
+            reader.FixedWindowIsPinned.Should().BeFalse();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", previous);
+        }
+    }
+
+    [Fact]
+    public void AppearanceDefaults_PreserveExistingLook()
+    {
+        using var testDirectory = new TemporaryDirectory();
+        var previous = Environment.GetEnvironmentVariable("EASYDICT_SETTINGS_DIR");
+        try
+        {
+            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", testDirectory.Path);
+
+            var settings = CreateIsolatedSettingsService();
+            settings.ResultFontScale.Should().Be(1.0);
+            settings.ShowOcrButton.Should().BeTrue();
+            settings.ShowPinButton.Should().BeTrue();
+            settings.ShowSourcePlayButton.Should().BeTrue();
+            settings.ShowSwapButton.Should().BeTrue();
+            settings.FixedWindowIsPinned.Should().BeTrue();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EASYDICT_SETTINGS_DIR", previous);
+        }
+    }
+
+    private static SettingsService CreateIsolatedSettingsService()
+    {
+        var constructor = typeof(SettingsService).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            Type.EmptyTypes,
+            modifiers: null);
+
+        constructor.Should().NotBeNull();
+        return (SettingsService)constructor!.Invoke(null);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "Easydict.WinUI.Tests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/LocalCredentialProtectorTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/LocalCredentialProtectorTests.cs
@@ -41,7 +41,22 @@ public sealed class LocalCredentialProtectorTests
     public void TryUnprotect_WithTamperedProtectedValue_ShouldFail()
     {
         var protectedValue = LocalCredentialProtector.Protect("sk-test-local-api-key");
-        var tamperedValue = protectedValue[..^4] + "AAAA";
+
+        // Corrupt the DPAPI blob itself while keeping the "edcred1:user:" prefix intact,
+        // so the value is still recognized as protected and the real unprotect path runs.
+        // Flip the first half of the decoded blob: this hits the version, provider/master-key
+        // GUIDs, and salt, which CryptUnprotectData must reject regardless of the variable
+        // description length. Mutating only the trailing bytes is unreliable because DPAPI
+        // does not authenticate the final bytes of the blob on every Windows build.
+        var separatorIndex = protectedValue.LastIndexOf(':');
+        var prefix = protectedValue[..(separatorIndex + 1)];
+        var blob = Convert.FromBase64String(protectedValue[(separatorIndex + 1)..]);
+        for (var i = 0; i < blob.Length / 2; i++)
+        {
+            blob[i] ^= 0xFF;
+        }
+
+        var tamperedValue = prefix + Convert.ToBase64String(blob);
 
         LocalCredentialProtector.TryUnprotect(tamperedValue, out var unprotected)
             .Should().BeFalse();


### PR DESCRIPTION
Implements the personalization requests from issue #172:

- Compact layout as the new default: tighter floating-window padding,
  input padding/margins, result-card corner radius/padding, and a lower
  minimum window height (200 -> 110 DIPs) so short results take less space.
- User-adjustable result font size via a new AppearanceService + settings
  slider, applied to all three windows (Main, Mini, Fixed) through
  IServiceResultView.ApplyAppearance and ServiceResultViewHost.
- Quick-action buttons: OCR button added to Main/Mini/Fixed; always-on-top
  pin toggle on Fixed (and Main, reusing AlwaysOnTop); per-button
  show/hide toggles in Settings.

New settings (ResultFontScale, ShowOcr/Pin/SourcePlay/SwapButton,
FixedWindowIsPinned) persist via SettingsService. Localized en-US/zh-CN/zh-TW;
other locales fall back to en-US. Adds AppearanceService unit tests.