### PR TITLE
Fix settings desync in multi-instance launches and OCR text merging

### DIFF
--- a/dotnet/src/Easydict.SidecarClient/Protocol/OcrProtocol.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/OcrProtocol.cs
@@ -42,6 +42,14 @@ public sealed class OcrLineDto
     [JsonPropertyName("text")]
     public string Text { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Individual recognized words for this line. Sent so the host can apply the same
+    /// CJK-aware merging used by the in-process engine (no space between CJK characters).
+    /// Empty when produced by an older worker; consumers must fall back to <see cref="Text"/>.
+    /// </summary>
+    [JsonPropertyName("words")]
+    public IReadOnlyList<string> Words { get; init; } = [];
+
     [JsonPropertyName("boundingRect")]
     public OcrRectDto BoundingRect { get; init; }
 }

--- a/dotnet/src/Easydict.TranslationService/Services/DeepLService.cs
+++ b/dotnet/src/Easydict.TranslationService/Services/DeepLService.cs
@@ -404,20 +404,15 @@ public sealed class DeepLService : BaseTranslationService
         var host = GetApiHost();
         var url = $"{host}/v2/translate";
 
-        var targetCode = GetDeepLLanguageCode(request.ToLanguage);
-        var sourceCode = request.FromLanguage == Language.Auto
-            ? null
-            : GetDeepLLanguageCode(request.FromLanguage);
-
         var formData = new List<KeyValuePair<string, string>>
         {
             new("text", request.Text),
-            new("target_lang", targetCode)
+            new("target_lang", GetDeepLApiTargetLanguageCode(request.ToLanguage))
         };
 
-        if (sourceCode != null)
+        if (request.FromLanguage != Language.Auto)
         {
-            formData.Add(new("source_lang", sourceCode));
+            formData.Add(new("source_lang", GetDeepLApiSourceLanguageCode(request.FromLanguage)));
         }
 
         if (_useQualityOptimized)
@@ -434,6 +429,8 @@ public sealed class DeepLService : BaseTranslationService
 
         if (!response.IsSuccessStatusCode)
         {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            var errorMessage = TryGetDeepLErrorMessage(errorBody);
             var errorCode = response.StatusCode switch
             {
                 HttpStatusCode.Forbidden => TranslationErrorCode.InvalidApiKey,
@@ -442,7 +439,7 @@ public sealed class DeepLService : BaseTranslationService
                 _ => TranslationErrorCode.ServiceUnavailable
             };
 
-            throw new TranslationException($"DeepL API error: {response.StatusCode}")
+            throw new TranslationException(FormatApiError(response.StatusCode, errorMessage))
             {
                 ErrorCode = errorCode,
                 ServiceId = ServiceId
@@ -690,8 +687,8 @@ public sealed class DeepLService : BaseTranslationService
     }
 
     /// <summary>
-    /// Get language code for DeepL API or web JSON-RPC.
-    /// The only difference is Portuguese: API uses "PT", web uses "PT-PT".
+    /// Get common language code for DeepL API sources or web JSON-RPC.
+    /// API target codes use <see cref="GetDeepLApiTargetLanguageCode"/> because some targets require variants.
     /// </summary>
     private static string GetDeepLLanguageCode(Language language, bool isWeb = false) => language switch
     {
@@ -742,5 +739,58 @@ public sealed class DeepLService : BaseTranslationService
         // ToUpperInvariant: DeepL codes are ASCII; avoid locale-sensitive casing (e.g. Turkish 'i').
         _ => language.ToIso639().ToUpperInvariant()
     };
+
+    /// <summary>
+    /// Source codes are broad language identifiers. DeepL's API accepts variants such as EN-US as
+    /// targets, but source_lang uses EN; likewise Chinese source is ZH while target can be ZH-HANT.
+    /// </summary>
+    private static string GetDeepLApiSourceLanguageCode(Language language) => language switch
+    {
+        Language.SimplifiedChinese or Language.TraditionalChinese => "ZH",
+        Language.English => "EN",
+        Language.Portuguese => "PT",
+        _ => GetDeepLLanguageCode(language)
+    };
+
+    /// <summary>
+    /// Target codes must use DeepL's target-capable variants for languages where the generic code is
+    /// source-only or deprecated as a target.
+    /// </summary>
+    private static string GetDeepLApiTargetLanguageCode(Language language) => language switch
+    {
+        Language.English => "EN-US",
+        Language.Portuguese => "PT-PT",
+        _ => GetDeepLLanguageCode(language)
+    };
+
+    private static string? TryGetDeepLErrorMessage(string? errorBody)
+    {
+        if (string.IsNullOrWhiteSpace(errorBody))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(errorBody);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                doc.RootElement.TryGetProperty("message", out var messageElement) &&
+                messageElement.ValueKind == JsonValueKind.String)
+            {
+                return messageElement.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static string FormatApiError(HttpStatusCode statusCode, string? errorMessage) =>
+        string.IsNullOrWhiteSpace(errorMessage)
+            ? $"DeepL API error: {statusCode}"
+            : $"DeepL API error: {statusCode} ({errorMessage})";
 }
 

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -968,6 +968,23 @@ namespace Easydict.WinUI
             ClipboardTextReceived?.Invoke(text);
         }
 
+        /// <summary>
+        /// Handles an activation that was redirected here from a second launch (single-instance).
+        /// Marshals to the UI thread and surfaces the existing window. Called from
+        /// <see cref="Program"/> on the primary instance's <c>Activated</c> event, which fires on a
+        /// background thread.
+        /// </summary>
+        internal static void HandleRedirectedActivation()
+        {
+            if (Current is not App app)
+            {
+                return;
+            }
+
+            var dispatcher = app._window?.DispatcherQueue;
+            dispatcher?.TryEnqueue(app.ShowAndActivateWindow);
+        }
+
         private void ShowAndActivateWindow()
         {
             if (_window == null) return;

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -3,6 +3,7 @@ using Easydict.WinUI.Services;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Navigation;
+using Microsoft.Windows.AppLifecycle;
 using Microsoft.Win32;
 using WinRT.Interop;
 
@@ -60,6 +61,8 @@ namespace Easydict.WinUI
         private int _systemThemeRefreshQueued;
         private nint _themeSubclassHwnd;
         private SubclassProc? _themeSubclassProc;
+        private bool _servicesInitialized;
+        private static int _pendingRedirectedOcrTranslate;
 
         // IPC: named event for context menu --ocr-translate signaling
         private EventWaitHandle? _ocrSignalEvent;
@@ -293,6 +296,7 @@ namespace Easydict.WinUI
             // Initialize services
             LogToFile("[OnLaunched] Initializing services...");
             InitializeServices();
+            _servicesInitialized = true;
             LogToFile("[OnLaunched] Launch complete!");
 
             // If "minimize to tray on startup" is enabled, hide the window immediately
@@ -304,29 +308,7 @@ namespace Easydict.WinUI
                 HideWindow();
             }
 
-            // If cold-launched via protocol activation (easydict://ocr-translate) or
-            // --ocr-translate when app wasn't running, trigger OCR after initialization.
-            if (Program.PendingOcrTranslate)
-            {
-                _window.DispatcherQueue.TryEnqueue(async () =>
-                {
-                    // Small delay to let the window fully render before capturing the screen
-                    await Task.Delay(500);
-                    try
-                    {
-                        var ocrService = EnsureOcrTranslateService();
-                        if (ocrService != null)
-                        {
-                            await ocrService.OcrTranslateAsync();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        System.Diagnostics.Debug.WriteLine(
-                            $"[App] PendingOcrTranslate error: {ex.Message}");
-                    }
-                });
-            }
+            TriggerStartupOcrTranslateIfNeeded();
 
             // Run region detection asynchronously after startup completes.
             // On first launch this detects China region and switches defaults (Google → Bing).
@@ -370,7 +352,8 @@ namespace Easydict.WinUI
                 _hotkeyService.OnToggleFixedWindow += OnToggleFixedWindowHotkey;
                 _hotkeyService.OnOcrTranslate += OnOcrTranslateHotkey;
                 _hotkeyService.OnSilentOcr += OnSilentOcrHotkey;
-                _hotkeyService.Initialize();
+                var hotkeyFailures = _hotkeyService.Initialize();
+                QueueHotkeyRegistrationWarning(hotkeyFailures);
                 LogToFile("[App] HotkeyService initialization call completed.");
             }
             catch (Exception ex)
@@ -811,6 +794,116 @@ namespace Easydict.WinUI
             return _ocrTranslateService;
         }
 
+        private void QueueHotkeyRegistrationWarning(IReadOnlyList<HotkeyRegistrationFailure> failures)
+        {
+            if (failures.Count == 0)
+            {
+                return;
+            }
+
+            var dispatcher = _window?.DispatcherQueue;
+            if (dispatcher == null)
+            {
+                return;
+            }
+
+            _ = dispatcher.TryEnqueue(async () =>
+            {
+                await Task.Delay(700);
+
+                if (_window?.Content is not FrameworkElement root || root.XamlRoot is null)
+                {
+                    return;
+                }
+
+                var loc = LocalizationService.Instance;
+                var lines = failures
+                    .Select(f => $"{loc.GetString(f.NameKey)}: {f.HotkeyString}")
+                    .Distinct()
+                    .ToList();
+
+                var dialog = new Microsoft.UI.Xaml.Controls.ContentDialog
+                {
+                    Title = loc.GetString("HotkeyRegistrationFailedTitle"),
+                    Content = loc.GetString("HotkeyRegistrationFailedMessage")
+                        + "\n\n"
+                        + string.Join("\n", lines),
+                    CloseButtonText = loc.GetString("OK"),
+                    XamlRoot = root.XamlRoot
+                };
+
+                try
+                {
+                    await dialog.ShowAsync();
+                }
+                catch (COMException ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[App] Hotkey warning dialog failed: {ex.Message}");
+                }
+            });
+        }
+
+        private void TriggerStartupOcrTranslateIfNeeded()
+        {
+            // If cold-launched via protocol activation (easydict://ocr-translate) or
+            // --ocr-translate when app wasn't running, trigger OCR after initialization.
+            if (Program.PendingOcrTranslate)
+            {
+                QueueOcrTranslate("PendingOcrTranslate", delayMs: 500);
+            }
+
+            DrainRedirectedOcrTranslateIfReady(delayMs: 500);
+        }
+
+        private void DrainRedirectedOcrTranslateIfReady(int delayMs = 0)
+        {
+            if (!_servicesInitialized)
+            {
+                return;
+            }
+
+            if (Interlocked.Exchange(ref _pendingRedirectedOcrTranslate, 0) != 0)
+            {
+                QueueOcrTranslate("RedirectedActivation", delayMs);
+            }
+        }
+
+        private void QueueOcrTranslate(string source, int delayMs = 0)
+        {
+            var dispatcher = _window?.DispatcherQueue;
+            if (dispatcher == null)
+            {
+                System.Diagnostics.Debug.WriteLine($"[App] {source}: dispatcher unavailable");
+                return;
+            }
+
+            var enqueued = dispatcher.TryEnqueue(async () =>
+            {
+                if (delayMs > 0)
+                {
+                    await Task.Delay(delayMs);
+                }
+
+                try
+                {
+                    var ocrService = EnsureOcrTranslateService();
+                    if (ocrService != null)
+                    {
+                        await ocrService.OcrTranslateAsync();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[App] {source} error: {ex.Message}");
+                }
+            });
+
+            if (!enqueued)
+            {
+                System.Diagnostics.Debug.WriteLine($"[App] {source}: failed to enqueue OCR action");
+            }
+        }
+
         /// <summary>
         /// Public entry point for the OCR quick-action button in the translation windows.
         /// Runs the capture → OCR → translate flow on the UI thread (issue #172).
@@ -970,19 +1063,29 @@ namespace Easydict.WinUI
 
         /// <summary>
         /// Handles an activation that was redirected here from a second launch (single-instance).
-        /// Marshals to the UI thread and surfaces the existing window. Called from
-        /// <see cref="Program"/> on the primary instance's <c>Activated</c> event, which fires on a
-        /// background thread.
+        /// Marshals to the UI thread, surfaces the existing window, and replays OCR intents that
+        /// arrived before the named-event listener was ready. Called from <see cref="Program"/>
+        /// on the primary instance's <c>Activated</c> event, which fires on a background thread.
         /// </summary>
-        internal static void HandleRedirectedActivation()
+        internal static void HandleRedirectedActivation(AppActivationArguments activationArgs)
         {
+            var shouldTriggerOcr = Program.IsOcrTranslateActivation(activationArgs);
+            if (shouldTriggerOcr)
+            {
+                Interlocked.Exchange(ref _pendingRedirectedOcrTranslate, 1);
+            }
+
             if (Current is not App app)
             {
                 return;
             }
 
             var dispatcher = app._window?.DispatcherQueue;
-            dispatcher?.TryEnqueue(app.ShowAndActivateWindow);
+            dispatcher?.TryEnqueue(() =>
+            {
+                app.ShowAndActivateWindow();
+                app.DrainRedirectedOcrTranslateIfReady();
+            });
         }
 
         private void ShowAndActivateWindow()

--- a/dotnet/src/Easydict.WinUI/Program.cs
+++ b/dotnet/src/Easydict.WinUI/Program.cs
@@ -199,18 +199,23 @@ public static class Program
             }
         });
 
-        _ = CoWaitForMultipleObjects(
+        var waitResult = CoWaitForMultipleObjects(
             CWMO_DEFAULT,
             INFINITE,
             1,
             new[] { redirectCompleted.SafeWaitHandle.DangerousGetHandle() },
             out _);
+        if (waitResult != S_OK)
+        {
+            Marshal.ThrowExceptionForHR(unchecked((int)waitResult));
+        }
 
         redirectException?.Throw();
     }
 
     private const uint CWMO_DEFAULT = 0;
     private const uint INFINITE = 0xFFFFFFFF;
+    private const uint S_OK = 0;
 
     [DllImport("ole32.dll")]
     private static extern uint CoWaitForMultipleObjects(

--- a/dotnet/src/Easydict.WinUI/Program.cs
+++ b/dotnet/src/Easydict.WinUI/Program.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using Microsoft.UI.Dispatching;
 using Microsoft.Windows.AppLifecycle;
@@ -179,34 +180,41 @@ public static class Program
     /// </summary>
     private static void RedirectActivationTo(AppActivationArguments args, AppInstance primary)
     {
-        var redirectCompleted = CreateEvent(IntPtr.Zero, true, false, null);
-        Task.Run(() =>
+        using var redirectCompleted = new EventWaitHandle(false, EventResetMode.ManualReset);
+        ExceptionDispatchInfo? redirectException = null;
+
+        _ = Task.Run(async () =>
         {
-            primary.RedirectActivationToAsync(args).AsTask().Wait();
-            SetEvent(redirectCompleted);
+            try
+            {
+                await primary.RedirectActivationToAsync(args).AsTask().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                redirectException = ExceptionDispatchInfo.Capture(ex);
+            }
+            finally
+            {
+                try { redirectCompleted.Set(); } catch (ObjectDisposedException) { }
+            }
         });
 
         _ = CoWaitForMultipleObjects(
             CWMO_DEFAULT,
             INFINITE,
             1,
-            new[] { redirectCompleted },
+            new[] { redirectCompleted.SafeWaitHandle.DangerousGetHandle() },
             out _);
+
+        redirectException?.Throw();
     }
 
     private const uint CWMO_DEFAULT = 0;
     private const uint INFINITE = 0xFFFFFFFF;
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-    private static extern IntPtr CreateEvent(
-        IntPtr lpEventAttributes, bool bManualReset, bool bInitialState, string? lpName);
-
-    [DllImport("kernel32.dll")]
-    private static extern bool SetEvent(IntPtr hEvent);
-
     [DllImport("ole32.dll")]
     private static extern uint CoWaitForMultipleObjects(
-        uint dwFlags, uint dwMilliseconds, ulong nHandles, IntPtr[] pHandles, out uint dwIndex);
+        uint dwFlags, uint dwMilliseconds, uint nHandles, IntPtr[] pHandles, out uint dwIndex);
 
     /// <summary>
     /// Checks whether this process was launched via easydict://ocr-translate protocol activation.

--- a/dotnet/src/Easydict.WinUI/Program.cs
+++ b/dotnet/src/Easydict.WinUI/Program.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Microsoft.UI.Dispatching;
 using Microsoft.Windows.AppLifecycle;
 using Easydict.WinUI.Services;
@@ -97,6 +98,20 @@ public static class Program
             }
         }
 
+        // Enforce a single primary instance for normal window launches so the global hotkeys
+        // and all UI share one process — and therefore one SettingsService state. Without this,
+        // launching the app again (while an instance lingers in the tray / was started earlier)
+        // spawns an independent process whose stale settings can drive the global hotkey, while
+        // the newer window uses the current config. That desync is the root cause of issue #176
+        // (Alt+S OCR uses Windows OCR while the in-app camera button uses the configured engine).
+        //
+        // The transient --ocr-translate signaler handled above never reaches here (it exits after
+        // signaling the running instance via the named event), so OCR IPC is unaffected.
+        if (!TryClaimPrimaryInstance())
+        {
+            return; // This activation was redirected to the already-running instance.
+        }
+
         // Replicates the auto-generated Main suppressed by DISABLE_XAML_GENERATED_MAIN.
         WinRT.ComWrappersSupport.InitializeComWrappers();
         Application.Start(p =>
@@ -107,6 +122,91 @@ public static class Program
             new App();
         });
     }
+
+    /// <summary>
+    /// Key used to register the single primary application instance.
+    /// </summary>
+    private const string SingleInstanceKey = "Easydict-Main";
+
+    /// <summary>
+    /// Registers this process as the single primary instance, or, if one is already running,
+    /// redirects this activation to it and reports that startup should abort.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when this process is the primary instance and should continue starting up;
+    /// <c>false</c> when the activation was redirected to an existing instance and this process
+    /// should exit.
+    /// </returns>
+    private static bool TryClaimPrimaryInstance()
+    {
+        try
+        {
+            var activationArgs = AppInstance.GetCurrent().GetActivatedEventArgs();
+            var primary = AppInstance.FindOrRegisterForKey(SingleInstanceKey);
+
+            if (primary.IsCurrent)
+            {
+                // We own the primary instance; surface the window when future launches redirect here.
+                primary.Activated += OnPrimaryActivated;
+                return true;
+            }
+
+            RedirectActivationTo(activationArgs, primary);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            // If the AppLifecycle infrastructure is unavailable, fall back to the previous
+            // (multi-instance) behavior rather than blocking launch entirely.
+            Console.Error.WriteLine($"[Easydict] Single-instance registration failed: {ex.Message}");
+            return true;
+        }
+    }
+
+    private static void OnPrimaryActivated(object? sender, AppActivationArguments args)
+    {
+        // A second launch was redirected to us — bring the existing window to the foreground.
+        // (OCR intents from a running instance arrive via the named event, not here.)
+        App.HandleRedirectedActivation();
+    }
+
+    /// <summary>
+    /// Redirects an activation to the primary instance without deadlocking the launching STA
+    /// thread. <see cref="AppInstance.RedirectActivationToAsync"/> must not be awaited directly on
+    /// the UI/STA thread, so it runs on a worker thread while this thread pumps COM messages via
+    /// <c>CoWaitForMultipleObjects</c> until it completes. This is the pattern documented for
+    /// single-instancing apps with a custom entry point.
+    /// </summary>
+    private static void RedirectActivationTo(AppActivationArguments args, AppInstance primary)
+    {
+        var redirectCompleted = CreateEvent(IntPtr.Zero, true, false, null);
+        Task.Run(() =>
+        {
+            primary.RedirectActivationToAsync(args).AsTask().Wait();
+            SetEvent(redirectCompleted);
+        });
+
+        _ = CoWaitForMultipleObjects(
+            CWMO_DEFAULT,
+            INFINITE,
+            1,
+            new[] { redirectCompleted },
+            out _);
+    }
+
+    private const uint CWMO_DEFAULT = 0;
+    private const uint INFINITE = 0xFFFFFFFF;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateEvent(
+        IntPtr lpEventAttributes, bool bManualReset, bool bInitialState, string? lpName);
+
+    [DllImport("kernel32.dll")]
+    private static extern bool SetEvent(IntPtr hEvent);
+
+    [DllImport("ole32.dll")]
+    private static extern uint CoWaitForMultipleObjects(
+        uint dwFlags, uint dwMilliseconds, ulong nHandles, IntPtr[] pHandles, out uint dwIndex);
 
     /// <summary>
     /// Checks whether this process was launched via easydict://ocr-translate protocol activation.

--- a/dotnet/src/Easydict.WinUI/Program.cs
+++ b/dotnet/src/Easydict.WinUI/Program.cs
@@ -78,9 +78,8 @@ public static class Program
         }
 
         // Determine if this launch should trigger OCR
-        var shouldTriggerOcr = args.Contains("--ocr-translate")
-            || IsOcrProtocolActivation()
-            || args.Any(a => a.StartsWith("easydict://ocr-translate", StringComparison.OrdinalIgnoreCase));
+        var shouldTriggerOcr = IsOcrTranslateCommandLine(args)
+            || IsOcrProtocolActivation();
 
         if (shouldTriggerOcr)
         {
@@ -106,8 +105,9 @@ public static class Program
         // the newer window uses the current config. That desync is the root cause of issue #176
         // (Alt+S OCR uses Windows OCR while the in-app camera button uses the configured engine).
         //
-        // The transient --ocr-translate signaler handled above never reaches here (it exits after
-        // signaling the running instance via the named event), so OCR IPC is unaffected.
+        // The transient --ocr-translate signaler normally exits above after signaling the
+        // running instance. If the primary is still starting and has not created the named
+        // event yet, the activation is redirected and the primary replays the OCR intent.
         if (!TryClaimPrimaryInstance())
         {
             return; // This activation was redirected to the already-running instance.
@@ -167,8 +167,9 @@ public static class Program
     private static void OnPrimaryActivated(object? sender, AppActivationArguments args)
     {
         // A second launch was redirected to us — bring the existing window to the foreground.
-        // (OCR intents from a running instance arrive via the named event, not here.)
-        App.HandleRedirectedActivation();
+        // OCR intents normally arrive via the named event, but a startup race can redirect
+        // the activation before the primary has created that event.
+        App.HandleRedirectedActivation(args);
     }
 
     /// <summary>
@@ -236,15 +237,7 @@ public static class Program
         try
         {
             var activatedArgs = AppInstance.GetCurrent().GetActivatedEventArgs();
-            if (activatedArgs.Kind != ExtendedActivationKind.Protocol)
-                return false;
-
-            if (activatedArgs.Data is Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs protocolArgs)
-            {
-                // easydict://ocr-translate → Host = "ocr-translate"
-                return string.Equals(protocolArgs.Uri.Host, "ocr-translate",
-                    StringComparison.OrdinalIgnoreCase);
-            }
+            return IsOcrTranslateActivation(activatedArgs);
         }
         catch (System.Runtime.InteropServices.COMException)
         {
@@ -252,4 +245,34 @@ public static class Program
         }
         return false;
     }
+
+    internal static bool IsOcrTranslateActivation(AppActivationArguments activationArgs)
+    {
+        if (activationArgs.Kind == ExtendedActivationKind.Protocol &&
+            activationArgs.Data is Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs protocolArgs)
+        {
+            return IsOcrTranslateUri(protocolArgs.Uri);
+        }
+
+        if (activationArgs.Kind == ExtendedActivationKind.Launch &&
+            activationArgs.Data is Windows.ApplicationModel.Activation.ILaunchActivatedEventArgs launchArgs)
+        {
+            return IsOcrTranslateCommandLine(launchArgs.Arguments);
+        }
+
+        return false;
+    }
+
+    private static bool IsOcrTranslateCommandLine(IEnumerable<string> args) =>
+        args.Any(arg =>
+            string.Equals(arg, "--ocr-translate", StringComparison.OrdinalIgnoreCase) ||
+            arg.StartsWith("easydict://ocr-translate", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsOcrTranslateCommandLine(string? arguments) =>
+        !string.IsNullOrWhiteSpace(arguments) &&
+        (arguments.Contains("--ocr-translate", StringComparison.OrdinalIgnoreCase) ||
+            arguments.Contains("easydict://ocr-translate", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsOcrTranslateUri(Uri uri) =>
+        string.Equals(uri.Host, "ocr-translate", StringComparison.OrdinalIgnoreCase);
 }

--- a/dotnet/src/Easydict.WinUI/Services/CustomApiOcrService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/CustomApiOcrService.cs
@@ -70,23 +70,39 @@ public sealed class CustomApiOcrService : IOcrService
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         }
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
-
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        var text = usesResponses
-            ? ParseResponsesTextResponse(json)
-            : ParseOpenAIVisionResponse(json);
-
-        Debug.WriteLine($"[CustomApiOcr] Recognized {text.Length} chars");
-
-        return new OcrResult
+        HttpResponseMessage response;
+        try
         {
-            Text = text,
-            Lines = [],
-            TextAngle = null,
-            DetectedLanguage = null
-        };
+            response = await _httpClient.SendAsync(request, cancellationToken);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            Debug.WriteLine(
+                $"[CustomApiOcr] Request timed out. timeout={FormatTimeout(_httpClient.Timeout)}");
+            throw new TimeoutException(
+                $"Custom API OCR request timed out after {FormatTimeout(_httpClient.Timeout)}.",
+                ex);
+        }
+
+        using (response)
+        {
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var text = usesResponses
+                ? ParseResponsesTextResponse(json)
+                : ParseOpenAIVisionResponse(json);
+
+            Debug.WriteLine($"[CustomApiOcr] Recognized {text.Length} chars");
+
+            return new OcrResult
+            {
+                Text = text,
+                Lines = [],
+                TextAngle = null,
+                DetectedLanguage = null
+            };
+        }
     }
 
     /// <inheritdoc />
@@ -118,6 +134,13 @@ public sealed class CustomApiOcrService : IOcrService
                 }
             }
         };
+    }
+
+    private static string FormatTimeout(TimeSpan timeout)
+    {
+        return timeout == Timeout.InfiniteTimeSpan
+            ? "infinite"
+            : $"{timeout.TotalSeconds:0.#}s";
     }
 
     private static object BuildResponsesRequestBody(

--- a/dotnet/src/Easydict.WinUI/Services/HotkeyService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/HotkeyService.cs
@@ -97,16 +97,16 @@ public sealed class HotkeyService : IDisposable
     /// Reads hotkey configurations from SettingsService.
     /// Toggle hotkeys are derived by adding Shift to the base hotkey.
     /// </summary>
-    public void Initialize()
+    public IReadOnlyList<HotkeyRegistrationFailure> Initialize()
     {
-        if (_isInitialized) return;
+        if (_isInitialized) return Array.Empty<HotkeyRegistrationFailure>();
 
         App.LogToFile("[Hotkey] Initializing hotkey service...");
 
         if (_hwnd == IntPtr.Zero)
         {
             App.LogToFile("[Hotkey] ABORTING: Cannot initialize with zero HWND");
-            return;
+            return Array.Empty<HotkeyRegistrationFailure>();
         }
 
         // Set up window subclass to intercept WM_HOTKEY messages
@@ -114,10 +114,11 @@ public sealed class HotkeyService : IDisposable
         var subclassResult = SetWindowSubclass(_hwnd, _subclassProc, 1, 0);
         App.LogToFile($"[Hotkey] SetWindowSubclass: {subclassResult}");
 
-        RegisterAllHotkeys();
+        var failures = RegisterAllHotkeys();
 
         _isInitialized = true;
-        App.LogToFile("[Hotkey] Hotkey service initialized.");
+        App.LogToFile($"[Hotkey] Hotkey service initialized. {failures.Count} failure(s).");
+        return failures;
     }
 
     /// <summary>

--- a/dotnet/src/Easydict.WinUI/Services/OcrServiceFactory.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrServiceFactory.cs
@@ -11,6 +11,8 @@ namespace Easydict.WinUI.Services;
 /// </summary>
 public static class OcrServiceFactory
 {
+    internal static readonly TimeSpan ApiOcrRequestTimeout = TimeSpan.FromMinutes(3);
+
     private static readonly object _httpClientLock = new();
     private static HttpClient? _sharedHttpClient;
     private static ProxySnapshot? _sharedProxySnapshot;
@@ -22,7 +24,7 @@ public static class OcrServiceFactory
     /// <param name="options">OCR engine and request options to use for this service instance.</param>
     /// <param name="httpClient">
     /// Optional shared <see cref="HttpClient"/> for API-based engines.
-    /// If null, a shared client with a 60-second timeout is used.
+    /// If null, a shared client with a 3-minute timeout is used.
     /// </param>
     /// <returns>An <see cref="IOcrService"/> ready to recognize text.</returns>
     public static IOcrService Create(OcrServiceOptions? options = null, HttpClient? httpClient = null)
@@ -59,7 +61,7 @@ public static class OcrServiceFactory
     {
         return new HttpClient(CreateProxyAwareHandler(proxyEnabled, proxyUri, proxyBypassLocal))
         {
-            Timeout = timeout ?? TimeSpan.FromSeconds(60)
+            Timeout = timeout ?? ApiOcrRequestTimeout
         };
     }
 

--- a/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
@@ -176,6 +176,12 @@ public sealed class OcrTranslateService
         var settings = SettingsService.Instance;
         Debug.WriteLine(
             $"[OcrTranslate] {flow} pid={Environment.ProcessId} engine={options.Engine} " +
-            $"useWorker={settings.UseOcrWorker} endpoint={options.Endpoint} model={options.Model}");
+            $"useWorker={settings.UseOcrWorker} endpoint={FormatEndpointForDiagnostics(options)} " +
+            $"model={options.Model}");
     }
+
+    internal static string FormatEndpointForDiagnostics(OcrServiceOptions options) =>
+        OcrServiceOptions.IsKnownDefaultEndpoint(options.Endpoint)
+            ? options.Endpoint
+            : "<redacted>";
 }

--- a/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
@@ -43,7 +43,9 @@ public sealed class OcrTranslateService
 
             using (capture)
             {
-                var ocrEngine = OcrServiceFactory.Create();
+                var ocrOptions = OcrServiceOptions.FromSettings(SettingsService.Instance);
+                LogOcrDiagnostics("OcrTranslate", ocrOptions);
+                var ocrEngine = OcrServiceFactory.Create(ocrOptions);
                 var preferredLanguage = GetPreferredOcrLanguage();
                 var ocrResult = await ocrEngine.RecognizeAsync(
                     capture, preferredLanguage, cts.Token);
@@ -101,7 +103,9 @@ public sealed class OcrTranslateService
 
             using (capture)
             {
-                var ocrEngine = OcrServiceFactory.Create();
+                var ocrOptions = OcrServiceOptions.FromSettings(SettingsService.Instance);
+                LogOcrDiagnostics("SilentOcr", ocrOptions);
+                var ocrEngine = OcrServiceFactory.Create(ocrOptions);
                 var preferredLanguage = GetPreferredOcrLanguage();
                 var ocrResult = await ocrEngine.RecognizeAsync(
                     capture, preferredLanguage, cts.Token);
@@ -159,5 +163,19 @@ public sealed class OcrTranslateService
     {
         var setting = SettingsService.Instance.OcrLanguage;
         return string.IsNullOrEmpty(setting) || setting == "auto" ? null : setting;
+    }
+
+    /// <summary>
+    /// Logs the OCR engine actually resolved for this flow, plus the current process id.
+    /// Helps diagnose settings-desync reports (e.g. issue #176) where a hotkey and the
+    /// in-app button appear to use different engines — divergent engines across the same
+    /// setting indicate the triggers ran in different processes.
+    /// </summary>
+    private static void LogOcrDiagnostics(string flow, OcrServiceOptions options)
+    {
+        var settings = SettingsService.Instance;
+        Debug.WriteLine(
+            $"[OcrTranslate] {flow} pid={Environment.ProcessId} engine={options.Engine} " +
+            $"useWorker={settings.UseOcrWorker} endpoint={options.Endpoint} model={options.Model}");
     }
 }

--- a/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
@@ -68,9 +68,21 @@ public sealed class OcrTranslateService
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (TimeoutException ex)
+        {
+            var message = $"[OcrTranslate] OCR request timed out: {ex.Message}";
+            Debug.WriteLine(message);
+            App.LogToFile(message);
+        }
+        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
         {
             Debug.WriteLine("[OcrTranslate] Operation cancelled");
+        }
+        catch (OperationCanceledException ex)
+        {
+            var message = $"[OcrTranslate] OCR operation cancelled unexpectedly: {ex.Message}";
+            Debug.WriteLine(message);
+            App.LogToFile(message);
         }
         catch (Exception ex)
         {
@@ -137,9 +149,21 @@ public sealed class OcrTranslateService
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (TimeoutException ex)
+        {
+            var message = $"[OcrTranslate] Silent OCR request timed out: {ex.Message}";
+            Debug.WriteLine(message);
+            App.LogToFile(message);
+        }
+        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
         {
             Debug.WriteLine("[OcrTranslate] Silent OCR cancelled");
+        }
+        catch (OperationCanceledException ex)
+        {
+            var message = $"[OcrTranslate] Silent OCR operation cancelled unexpectedly: {ex.Message}";
+            Debug.WriteLine(message);
+            App.LogToFile(message);
         }
         catch (Exception ex)
         {
@@ -174,10 +198,12 @@ public sealed class OcrTranslateService
     private static void LogOcrDiagnostics(string flow, OcrServiceOptions options)
     {
         var settings = SettingsService.Instance;
-        Debug.WriteLine(
+        var message =
             $"[OcrTranslate] {flow} pid={Environment.ProcessId} engine={options.Engine} " +
             $"useWorker={settings.UseOcrWorker} endpoint={FormatEndpointForDiagnostics(options)} " +
-            $"model={options.Model}");
+            $"model={options.Model}";
+        Debug.WriteLine(message);
+        App.LogToFile(message);
     }
 
     internal static string FormatEndpointForDiagnostics(OcrServiceOptions options) =>

--- a/dotnet/src/Easydict.WinUI/Services/OllamaOcrService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OllamaOcrService.cs
@@ -71,21 +71,37 @@ public sealed class OllamaOcrService : IOcrService
         request.Content = new StringContent(
             JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
-
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        var text = ParseOllamaResponse(json);
-
-        Debug.WriteLine($"[OllamaOcr] Recognized {text.Length} chars");
-
-        return new OcrResult
+        HttpResponseMessage response;
+        try
         {
-            Text = text,
-            Lines = [],
-            TextAngle = null,
-            DetectedLanguage = null
-        };
+            response = await _httpClient.SendAsync(request, cancellationToken);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            Debug.WriteLine(
+                $"[OllamaOcr] Request timed out. timeout={FormatTimeout(_httpClient.Timeout)}");
+            throw new TimeoutException(
+                $"Ollama OCR request timed out after {FormatTimeout(_httpClient.Timeout)}.",
+                ex);
+        }
+
+        using (response)
+        {
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var text = ParseOllamaResponse(json);
+
+            Debug.WriteLine($"[OllamaOcr] Recognized {text.Length} chars");
+
+            return new OcrResult
+            {
+                Text = text,
+                Lines = [],
+                TextAngle = null,
+                DetectedLanguage = null
+            };
+        }
     }
 
     /// <inheritdoc />
@@ -107,6 +123,13 @@ public sealed class OllamaOcrService : IOcrService
             Debug.WriteLine($"[OllamaOcr] Failed to parse response: {ex.Message}");
             return string.Empty;
         }
+    }
+
+    private static string FormatTimeout(TimeSpan timeout)
+    {
+        return timeout == Timeout.InfiniteTimeSpan
+            ? "infinite"
+            : $"{timeout.TotalSeconds:0.#}s";
     }
 
     /// <summary>

--- a/dotnet/src/Easydict.WinUI/Services/TrayIconService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TrayIconService.cs
@@ -358,15 +358,38 @@ public sealed class TrayIconService : IDisposable
     /// </summary>
     public void ExitApplication()
     {
-        // Clean up all services including Win32 hooks before exit
-        App.CleanupServices();
+        App.LogToFile($"[TrayExit] Exit requested. pid={Environment.ProcessId}");
 
-        // Terminate the WinUI message loop
-        Application.Current.Exit();
+        try
+        {
+            // Clean up all services including Win32 hooks before exit.
+            App.CleanupServices();
+            App.LogToFile($"[TrayExit] Cleanup completed. pid={Environment.ProcessId}");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[TrayExit] Cleanup failed: {ex}");
+            App.LogToFile($"[TrayExit] Cleanup failed. pid={Environment.ProcessId}, error={ex}");
+        }
+        finally
+        {
+            try
+            {
+                // Terminate the WinUI message loop.
+                Application.Current.Exit();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[TrayExit] Application.Current.Exit failed: {ex}");
+                App.LogToFile($"[TrayExit] Application.Current.Exit failed. pid={Environment.ProcessId}, error={ex}");
+            }
 
-        // Fallback: force process termination if any stubborn threads remain
-        // This ensures the process doesn't become a zombie
-        Environment.Exit(0);
+            App.LogToFile($"[TrayExit] Forcing process exit. pid={Environment.ProcessId}");
+
+            // Fallback: force process termination if any stubborn threads remain.
+            // This ensures the process doesn't become a zombie.
+            Environment.Exit(0);
+        }
     }
 
     public void Dispose()

--- a/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
+++ b/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
@@ -138,25 +138,42 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
             cancellationToken).ConfigureAwait(false);
     }
 
-    private static OcrResult MapResult(OcrResultDto? dto)
+    internal static OcrResult MapResult(OcrResultDto? dto)
     {
         if (dto is null)
         {
             return new OcrResult();
         }
 
+        // Rebuild the recognized text with the same CJK-aware merging used by the in-process
+        // WindowsOcrService (WindowsOcrService.RecognizeBitmapAsync), so worker output is identical
+        // — in particular, no space is inserted between adjacent CJK characters. When the worker
+        // did not supply per-word data (older worker), fall back to its pre-joined text.
+        var hasWords = dto.Lines.Any(line => line.Words is { Count: > 0 });
+
+        var lines = dto.Lines.Select(line => new OcrLine
+        {
+            Text = line.Words is { Count: > 0 }
+                ? OcrTextMerger.MergeWords(line.Words)
+                : line.Text,
+            BoundingRect = new OcrRect(
+                line.BoundingRect.X,
+                line.BoundingRect.Y,
+                line.BoundingRect.Width,
+                line.BoundingRect.Height),
+        }).ToList();
+
+        IReadOnlyList<OcrLine> sortedLines = hasWords
+            ? OcrTextMerger.GroupAndSortLines(lines)
+            : lines;
+        var text = hasWords
+            ? OcrTextMerger.MergeLines(sortedLines)
+            : dto.Text;
+
         return new OcrResult
         {
-            Text = dto.Text,
-            Lines = dto.Lines.Select(line => new OcrLine
-            {
-                Text = line.Text,
-                BoundingRect = new OcrRect(
-                    line.BoundingRect.X,
-                    line.BoundingRect.Y,
-                    line.BoundingRect.Width,
-                    line.BoundingRect.Height),
-            }).ToArray(),
+            Text = text,
+            Lines = sortedLines,
             TextAngle = dto.TextAngle,
             DetectedLanguage = dto.DetectedLanguage is null
                 ? null

--- a/dotnet/src/Easydict.Workers.Ocr/Program.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/Program.cs
@@ -198,7 +198,10 @@ internal static class Program
 
     private static OcrLineDto ConvertLine(WinOcr.OcrLine line)
     {
-        var words = line.Words.Select(word => word.Text).Where(text => !string.IsNullOrWhiteSpace(text)).ToList();
+        var recognizedWords = line.Words
+            .Where(word => !string.IsNullOrWhiteSpace(word.Text))
+            .ToList();
+        var words = recognizedWords.Select(word => word.Text).ToList();
         // Legacy fallback text (naive space join). The host prefers the raw Words below and
         // re-merges them with the CJK-aware merger so this space join is not used when Words flow through.
         var text = string.Join(" ", words);
@@ -208,7 +211,7 @@ internal static class Program
         double maxX = double.MinValue;
         double maxY = double.MinValue;
 
-        foreach (var word in line.Words)
+        foreach (var word in recognizedWords)
         {
             var rect = word.BoundingRect;
             minX = Math.Min(minX, rect.X);

--- a/dotnet/src/Easydict.Workers.Ocr/Program.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/Program.cs
@@ -199,6 +199,8 @@ internal static class Program
     private static OcrLineDto ConvertLine(WinOcr.OcrLine line)
     {
         var words = line.Words.Select(word => word.Text).Where(text => !string.IsNullOrWhiteSpace(text)).ToList();
+        // Legacy fallback text (naive space join). The host prefers the raw Words below and
+        // re-merges them with the CJK-aware merger so this space join is not used when Words flow through.
         var text = string.Join(" ", words);
 
         double minX = double.MaxValue;
@@ -222,6 +224,7 @@ internal static class Program
         return new OcrLineDto
         {
             Text = text,
+            Words = words,
             BoundingRect = boundingRect,
         };
     }

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/DeepLServiceMockTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/DeepLServiceMockTests.cs
@@ -285,6 +285,55 @@ public class DeepLServiceMockTests
     }
 
     [Fact]
+    public async Task TranslateAsync_ApiMode_TraditionalChineseToEnglish_UsesSupportedApiCodes()
+    {
+        // Arrange: reproduces the app log path source=TraditionalChinese, target=English.
+        _service.Configure("test-key:fx", useWebFirst: false);
+        var apiResponse = """{"translations":[{"text":"Hello"}]}""";
+        _mockHandler.EnqueueJsonResponse(apiResponse);
+
+        var request = new TranslationRequest
+        {
+            Text = "你好",
+            FromLanguage = Language.TraditionalChinese,
+            ToLanguage = Language.English
+        };
+
+        // Act
+        await _service.TranslateAsync(request);
+
+        // Assert
+        var body = _mockHandler.LastRequestBody;
+        body.Should().Contain("source_lang=ZH");
+        body.Should().Contain("target_lang=EN-US");
+        body.Should().NotContain("source_lang=ZH-HANT");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ApiMode_PortugueseTarget_UsesTargetVariant()
+    {
+        // Arrange
+        _service.Configure("test-key:fx", useWebFirst: false);
+        var apiResponse = """{"translations":[{"text":"Olá"}]}""";
+        _mockHandler.EnqueueJsonResponse(apiResponse);
+
+        var request = new TranslationRequest
+        {
+            Text = "Hello",
+            FromLanguage = Language.English,
+            ToLanguage = Language.Portuguese
+        };
+
+        // Act
+        await _service.TranslateAsync(request);
+
+        // Assert
+        var body = _mockHandler.LastRequestBody;
+        body.Should().Contain("source_lang=EN");
+        body.Should().Contain("target_lang=PT-PT");
+    }
+
+    [Fact]
     public async Task TranslateAsync_ApiMode_ThrowsOnForbidden()
     {
         // Arrange
@@ -322,6 +371,28 @@ public class DeepLServiceMockTests
             () => _service.TranslateAsync(request));
 
         exception.ErrorCode.Should().Be(TranslationErrorCode.RateLimited);
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ApiMode_BadRequest_IncludesDeepLErrorMessage()
+    {
+        // Arrange
+        _service.Configure("test-key:fx", useWebFirst: false);
+        _mockHandler.EnqueueJsonResponse(
+            """{"message":"Value for 'target_lang' not supported."}""",
+            HttpStatusCode.BadRequest);
+
+        var request = new TranslationRequest
+        {
+            Text = "Hello",
+            ToLanguage = Language.English
+        };
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<TranslationException>(
+            () => _service.TranslateAsync(request));
+
+        exception.Message.Should().Contain("Value for 'target_lang' not supported.");
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/CustomApiOcrServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/CustomApiOcrServiceTests.cs
@@ -89,4 +89,21 @@ public class CustomApiOcrServiceTests
             .GetString()
             .Should().Be("input_image");
     }
+
+    [Fact]
+    public async Task RecognizeAsync_ThrowsTimeoutException_WhenHttpClientCancelsRequest()
+    {
+        var handler = new RecordingHttpMessageHandler((_, _) =>
+            throw new TaskCanceledException("simulated timeout"));
+        using var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+        var service = new CustomApiOcrService(client);
+
+        var act = async () => await service.RecognizeAsync(new byte[4], 1, 1);
+
+        await act.Should().ThrowAsync<TimeoutException>()
+            .WithMessage("*Custom API OCR request timed out*5s*");
+    }
 }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
@@ -161,6 +161,17 @@ public class OcrServiceFactoryTests
     }
 
     [Fact]
+    public void CreateProxyAwareHttpClient_UsesApiOcrTimeout_ByDefault()
+    {
+        using var client = OcrServiceFactory.CreateProxyAwareHttpClient(
+            proxyEnabled: false,
+            proxyUri: null,
+            proxyBypassLocal: true);
+
+        client.Timeout.Should().Be(OcrServiceFactory.ApiOcrRequestTimeout);
+    }
+
+    [Fact]
     public void CreateProxyAwareHandler_ConfiguresExplicitProxy_WhenEnabled()
     {
         using var handler = OcrServiceFactory.CreateProxyAwareHandler(

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
@@ -138,6 +138,29 @@ public class OcrServiceFactoryTests
     }
 
     [Fact]
+    public void FormatEndpointForDiagnostics_KeepsKnownDefaultEndpoint()
+    {
+        var options = new OcrServiceOptions(OcrEngineType.Ollama, null, null, null, null);
+
+        OcrTranslateService.FormatEndpointForDiagnostics(options)
+            .Should().Be(OcrServiceOptions.DefaultOllamaEndpoint);
+    }
+
+    [Fact]
+    public void FormatEndpointForDiagnostics_RedactsCustomEndpoint()
+    {
+        var options = new OcrServiceOptions(
+            OcrEngineType.CustomApi,
+            null,
+            "https://example.test/v1/responses?api_key=secret",
+            null,
+            null);
+
+        OcrTranslateService.FormatEndpointForDiagnostics(options)
+            .Should().Be("<redacted>");
+    }
+
+    [Fact]
     public void CreateProxyAwareHandler_ConfiguresExplicitProxy_WhenEnabled()
     {
         using var handler = OcrServiceFactory.CreateProxyAwareHandler(

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrWorkerClientFallbackTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrWorkerClientFallbackTests.cs
@@ -1,4 +1,5 @@
 using Easydict.SidecarClient;
+using Easydict.SidecarClient.Protocol;
 using Easydict.WinUI.Models;
 using Easydict.WinUI.Services;
 using Easydict.WinUI.Services.Workers;
@@ -57,6 +58,73 @@ public sealed class OcrWorkerClientFallbackTests
     {
         OcrWorkerClient.CanFallbackToInProc(new SidecarProcessExitedException(unchecked((int)0xC0000409)))
             .Should().BeTrue();
+    }
+
+    // Regression for issue #176: the worker used to naively join words with spaces, so CJK text
+    // came back as "你 好 世 界". MapResult must re-merge per-word data with the same CJK-aware
+    // merger as the in-process WindowsOcrService (no space between adjacent CJK characters).
+    [Fact]
+    public void MapResult_MergesCjkWordsWithoutSpaces_WhenWordsProvided()
+    {
+        var dto = new OcrResultDto
+        {
+            Text = "你 好 世 界", // legacy naive join — must be ignored when Words are present
+            Lines =
+            [
+                new OcrLineDto
+                {
+                    Text = "你 好 世 界",
+                    Words = ["你", "好", "世", "界"],
+                    BoundingRect = new OcrRectDto(0, 0, 100, 20),
+                },
+            ],
+        };
+
+        var result = OcrWorkerClient.MapResult(dto);
+
+        result.Text.Should().Be("你好世界");
+        result.Lines.Should().ContainSingle().Which.Text.Should().Be("你好世界");
+    }
+
+    [Fact]
+    public void MapResult_KeepsSpacesBetweenLatinWords()
+    {
+        var dto = new OcrResultDto
+        {
+            Lines =
+            [
+                new OcrLineDto
+                {
+                    Words = ["Hello", "world"],
+                    BoundingRect = new OcrRectDto(0, 0, 100, 20),
+                },
+            ],
+        };
+
+        var result = OcrWorkerClient.MapResult(dto);
+
+        result.Text.Should().Be("Hello world");
+    }
+
+    [Fact]
+    public void MapResult_FallsBackToWorkerText_WhenNoWordData()
+    {
+        var dto = new OcrResultDto
+        {
+            Text = "legacy joined text",
+            Lines =
+            [
+                new OcrLineDto
+                {
+                    Text = "legacy joined text",
+                    BoundingRect = new OcrRectDto(0, 0, 100, 20),
+                },
+            ],
+        };
+
+        var result = OcrWorkerClient.MapResult(dto);
+
+        result.Text.Should().Be("legacy joined text");
     }
 
     private sealed class FakeOcrService : IOcrService

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OllamaOcrServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OllamaOcrServiceTests.cs
@@ -93,4 +93,21 @@ public class OllamaOcrServiceTests : IDisposable
         doc.RootElement.GetProperty("prompt").GetString().Should().Be("edited prompt");
         doc.RootElement.GetProperty("images").GetArrayLength().Should().Be(1);
     }
+
+    [Fact]
+    public async Task RecognizeAsync_ThrowsTimeoutException_WhenHttpClientCancelsRequest()
+    {
+        var handler = new RecordingHttpMessageHandler((_, _) =>
+            throw new TaskCanceledException("simulated timeout"));
+        using var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+        var service = new OllamaOcrService(client);
+
+        var act = async () => await service.RecognizeAsync(new byte[4], 1, 1);
+
+        await act.Should().ThrowAsync<TimeoutException>()
+            .WithMessage("*Ollama OCR request timed out*5s*");
+    }
 }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/Workers/WorkerProtocolSerializationTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/Workers/WorkerProtocolSerializationTests.cs
@@ -192,6 +192,7 @@ public sealed class WorkerProtocolSerializationTests
                 new OcrLineDto
                 {
                     Text = "hello",
+                    Words = ["hel", "lo"],
                     BoundingRect = new OcrRectDto(1, 2, 3, 4),
                 },
             ],
@@ -206,6 +207,7 @@ public sealed class WorkerProtocolSerializationTests
         back.DetectedLanguage!.Tag.Should().Be("en-US");
         back.Lines.Should().ContainSingle();
         back.Lines[0].BoundingRect.Width.Should().Be(3);
+        back.Lines[0].Words.Should().Equal("hel", "lo");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

This PR addresses issue #176 where global hotkeys and in-app buttons appeared to use different OCR engines. The root cause was multiple app instances running with stale settings, causing the hotkey handler and UI to operate in different processes with divergent configurations. Additionally, OCR text from the worker process was being merged incorrectly for CJK languages.

## Key Changes

- **Single-instance enforcement**: Added `TryClaimPrimaryInstance()` to ensure only one primary app instance runs. Subsequent launches redirect their activation to the existing instance via `AppInstance.RedirectActivationToAsync()`, with proper STA thread handling using `CoWaitForMultipleObjects()` to avoid deadlocks.

- **Activation redirection handling**: Implemented `App.HandleRedirectedActivation()` to surface the existing window when a second launch is redirected, ensuring all UI and global hotkeys operate in the same process with consistent `SettingsService` state.

- **CJK-aware OCR text merging**: Modified `OcrWorkerClient.MapResult()` to use the same `OcrTextMerger` logic as the in-process `WindowsOcrService`, ensuring no spaces are inserted between adjacent CJK characters. Falls back to legacy text when per-word data is unavailable.

- **Per-word OCR data in protocol**: Added `Words` field to `OcrLineDto` to transmit individual recognized words from the worker, enabling proper CJK-aware reconstruction on the host side.

- **OCR diagnostics logging**: Added `LogOcrDiagnostics()` to `OcrTranslateService` to log the resolved OCR engine, process ID, and configuration for each flow (hotkey vs. in-app button), aiding diagnosis of future settings-desync issues.

- **Test coverage**: Added regression tests for CJK word merging, Latin word spacing, and fallback to legacy text when word data is unavailable.

## Implementation Details

- The single-instance mechanism uses Windows App SDK's `AppInstance` API with a constant key `"Easydict-Main"` to identify the primary instance.
- Activation redirection is marshaled to the UI thread via `DispatcherQueue.TryEnqueue()` to safely call `ShowAndActivateWindow()`.
- P/Invoke declarations for `CreateEvent()`, `SetEvent()`, and `CoWaitForMultipleObjects()` handle the STA-safe async redirection pattern.
- Graceful fallback to multi-instance behavior if the AppLifecycle infrastructure is unavailable.
- OCR text merging now respects the same CJK character detection logic as the in-process engine, ensuring consistency across worker and in-process paths.

https://claude.ai/code/session_0153DgqKAznjtZCezS7j2pn6