### PR TITLE
DeepL: separate API/web language codes and enforce regional EN target for API

### DIFF
--- a/dotnet/src/Easydict.TranslationService/Services/DeepLService.cs
+++ b/dotnet/src/Easydict.TranslationService/Services/DeepLService.cs
@@ -404,10 +404,10 @@ public sealed class DeepLService : BaseTranslationService
         var host = GetApiHost();
         var url = $"{host}/v2/translate";
 
-        var targetCode = GetDeepLLanguageCode(request.ToLanguage);
+        var targetCode = GetDeepLApiTargetLanguageCode(request.ToLanguage);
         var sourceCode = request.FromLanguage == Language.Auto
             ? null
-            : GetDeepLLanguageCode(request.FromLanguage);
+            : GetDeepLApiSourceLanguageCode(request.FromLanguage);
 
         var formData = new List<KeyValuePair<string, string>>
         {
@@ -690,8 +690,29 @@ public sealed class DeepLService : BaseTranslationService
     }
 
     /// <summary>
-    /// Get language code for DeepL API or web JSON-RPC.
-    /// The only difference is Portuguese: API uses "PT", web uses "PT-PT".
+    /// Get source language code for DeepL's official API.
+    /// DeepL accepts generic language codes for sources, e.g. EN for English.
+    /// </summary>
+    private static string GetDeepLApiSourceLanguageCode(Language language) =>
+        GetDeepLLanguageCode(language);
+
+    /// <summary>
+    /// Get target language code for DeepL's official API only.
+    /// DeepL requires regional variants for some target languages (notably English);
+    /// using generic EN as API target_lang causes HTTP 400 BadRequest.
+    /// Do not reuse this for the web JSON-RPC endpoint, which uses its own language codes.
+    /// </summary>
+    private static string GetDeepLApiTargetLanguageCode(Language language) => language switch
+    {
+        // DeepL API target languages are regionalized for English. Default to EN-US for the app's
+        // generic English option; EN is still valid as an API source language and for web JSON-RPC.
+        Language.English => "EN-US",
+        _ => GetDeepLLanguageCode(language)
+    };
+
+    /// <summary>
+    /// Get language code for DeepL web JSON-RPC or generic DeepL API source usage.
+    /// The only web-specific difference is Portuguese: API/source uses "PT", web uses "PT-PT".
     /// </summary>
     private static string GetDeepLLanguageCode(Language language, bool isWeb = false) => language switch
     {
@@ -743,4 +764,3 @@ public sealed class DeepLService : BaseTranslationService
         _ => language.ToIso639().ToUpperInvariant()
     };
 }
-

--- a/dotnet/tests/Easydict.TranslationService.Tests/Services/DeepLServiceMockTests.cs
+++ b/dotnet/tests/Easydict.TranslationService.Tests/Services/DeepLServiceMockTests.cs
@@ -116,6 +116,31 @@ public class DeepLServiceMockTests
     }
 
     [Fact]
+    public async Task TranslateAsync_WebMode_ChineseToEnglish_KeepsGenericEnglishTarget()
+    {
+        // Arrange
+        var webResponse = """
+            {"jsonrpc":"2.0","id":123000,"result":{"texts":[{"text":"Hello"}],"lang":"ZH"}}
+            """;
+        _mockHandler.EnqueueJsonResponse(webResponse);
+
+        var request = new TranslationRequest
+        {
+            Text = "你好",
+            FromLanguage = Language.SimplifiedChinese,
+            ToLanguage = Language.English
+        };
+
+        // Act
+        await _service.TranslateAsync(request);
+
+        // Assert
+        var body = _mockHandler.LastRequestBody;
+        body.Should().Contain("\"source_lang_user_selected\":\"ZH\"");
+        body.Should().Contain("\"target_lang\":\"EN\"");
+    }
+
+    [Fact]
     public async Task TranslateAsync_WebMode_SetsAntiDetectionHeaders()
     {
         // Arrange
@@ -282,6 +307,78 @@ public class DeepLServiceMockTests
         sentRequest!.Headers.Authorization.Should().NotBeNull();
         sentRequest.Headers.Authorization!.Scheme.Should().Be("DeepL-Auth-Key");
         sentRequest.Headers.Authorization.Parameter.Should().Be("my-deepl-key:fx");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ApiMode_SimplifiedChineseToEnglish_UsesRegionalEnglishTarget()
+    {
+        // Arrange
+        _service.Configure("test-key:fx", useWebFirst: false);
+        var apiResponse = """{"translations":[{"text":"Hello"}]}""";
+        _mockHandler.EnqueueJsonResponse(apiResponse);
+
+        var request = new TranslationRequest
+        {
+            Text = "你好",
+            FromLanguage = Language.SimplifiedChinese,
+            ToLanguage = Language.English
+        };
+
+        // Act
+        await _service.TranslateAsync(request);
+
+        // Assert
+        var body = _mockHandler.LastRequestBody;
+        body.Should().Contain("source_lang=ZH");
+        body.Should().Contain("target_lang=EN-US");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ApiMode_TraditionalChineseToEnglish_UsesRegionalEnglishTarget()
+    {
+        // Arrange
+        _service.Configure("test-key:fx", useWebFirst: false);
+        var apiResponse = """{"translations":[{"text":"Hello"}]}""";
+        _mockHandler.EnqueueJsonResponse(apiResponse);
+
+        var request = new TranslationRequest
+        {
+            Text = "你好",
+            FromLanguage = Language.TraditionalChinese,
+            ToLanguage = Language.English
+        };
+
+        // Act
+        await _service.TranslateAsync(request);
+
+        // Assert
+        var body = _mockHandler.LastRequestBody;
+        body.Should().Contain("source_lang=ZH-HANT");
+        body.Should().Contain("target_lang=EN-US");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ApiMode_EnglishSource_KeepsGenericEnglishSourceCode()
+    {
+        // Arrange
+        _service.Configure("test-key:fx", useWebFirst: false);
+        var apiResponse = """{"translations":[{"text":"你好"}]}""";
+        _mockHandler.EnqueueJsonResponse(apiResponse);
+
+        var request = new TranslationRequest
+        {
+            Text = "Hello",
+            FromLanguage = Language.English,
+            ToLanguage = Language.TraditionalChinese
+        };
+
+        // Act
+        await _service.TranslateAsync(request);
+
+        // Assert
+        var body = _mockHandler.LastRequestBody;
+        body.Should().Contain("source_lang=EN");
+        body.Should().Contain("target_lang=ZH-HANT");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Prevent DeepL API `400 BadRequest` errors by using the correct regional target language codes for API requests while keeping web JSON-RPC codes unchanged.
- Make language-code selection explicit for API source vs API target vs web usage to avoid subtle differences (notably English and Portuguese).

### Description

- Introduce `GetDeepLApiSourceLanguageCode` and `GetDeepLApiTargetLanguageCode` helpers and map `Language.English` to `EN-US` for API target usage. 
- Update `TranslateApiAsync` to call the new API-specific source/target code functions instead of a single generic function. 
- Change `GetDeepLLanguageCode` to accept an `isWeb` flag and document the web vs API differences (Portuguese and other mappings) and retain generic codes for web/source use. 
- Add unit tests covering web vs API language-code behavior and regional `EN-US` usage for API targets.

### Testing

- Added and ran `TranslateAsync_WebMode_ChineseToEnglish_KeepsGenericEnglishTarget` and it succeeded. 
- Added and ran `TranslateAsync_ApiMode_SimplifiedChineseToEnglish_UsesRegionalEnglishTarget` and `TranslateAsync_ApiMode_TraditionalChineseToEnglish_UsesRegionalEnglishTarget` and both succeeded. 
- Added and ran `TranslateAsync_ApiMode_EnglishSource_KeepsGenericEnglishSourceCode` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a450b5f641c832296ceb694ee586c46)