### PR TITLE
feat(ocr): integrate PP-OCRv6 local OCR with model management

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -111,7 +111,11 @@ jobs:
         working-directory: dotnet
         run: dotnet restore src/Easydict.WinUI/Easydict.WinUI.csproj --runtime win-${{ matrix.platform }} -p:Configuration=Release -p:BuildWorkerOutputs=false -p:EnableInProcLongDocFallback=false
 
-      # Build and publish the application (portable: ZIP and EXE)
+      # Portable build: host auto-publishes workers via PublishWorkerOutputs (AfterTargets=Publish).
+      # This step intentionally does NOT set PublishWorkerOutputs=false so the worker EXEs
+      # land in ./publish/{arch}/workers/{kind}/ without needing separate worker steps.
+      # MSIX below still opts out (PublishWorkerOutputs=false) and publishes workers explicitly
+      # as framework-dependent with a shared dotnet runtime.
       - name: Publish WinUI App (portable)
         working-directory: dotnet
         run: |
@@ -127,6 +131,17 @@ jobs:
             -p:EnableInProcLongDocFallback=false `
             -p:EnableGitHubUpdateCheck=true `
             -p:PublishTrimmed=false
+
+      - name: Verify portable workers present
+        shell: pwsh
+        working-directory: dotnet
+        run: |
+          $missing = @()
+          foreach ($w in @("workers/ocr/Easydict.Workers.Ocr.exe","workers/longdoc/Easydict.Workers.LongDoc.exe","workers/localai/Easydict.Workers.LocalAi.exe")) {
+            if (-not (Test-Path "./publish/${{ matrix.platform }}/$w")) { $missing += $w }
+          }
+          if ($missing.Count -gt 0) { throw "Portable worker(s) missing: $($missing -join ', ')" }
+          Write-Host "Portable workers OK: workers/ocr, workers/longdoc, workers/localai"
 
       # Publish NativeBridge (for portable/Inno installer)
       - name: Publish NativeBridge
@@ -150,48 +165,10 @@ jobs:
             --output ./publish/${{ matrix.platform }} `
             -p:PublishTrimmed=true
 
-      # Publish LongDoc worker (out-of-process PDF + ONNX layout detection).
-      # Resolved by host via AppContext.BaseDirectory + "workers/longdoc/Easydict.Workers.LongDoc.exe".
-      # No trimming — MuPDF.NET and ONNX Runtime use reflection that breaks under IL trim.
-      # Portable artifacts ship outside the MSIX framework-dependency umbrella, so
-      # workers self-contain both .NET and WindowsAppSDK. The MSIX path below strips
-      # this back to a shared .NET 8 runtime via Extract-DotnetRuntime.ps1.
-      - name: Publish LongDoc Worker
-        working-directory: dotnet
-        run: |
-          dotnet publish src/Easydict.Workers.LongDoc/Easydict.Workers.LongDoc.csproj `
-            --configuration Release `
-            --runtime win-${{ matrix.platform }} `
-            --self-contained true `
-            --output ./publish/${{ matrix.platform }}/workers/longdoc `
-            -p:Platform=${{ matrix.platform }} `
-            -p:PublishTrimmed=false
-
-      - name: Publish LocalAi Worker
-        working-directory: dotnet
-        run: |
-          dotnet publish src/Easydict.Workers.LocalAi/Easydict.Workers.LocalAi.csproj `
-            --configuration Release `
-            --runtime win-${{ matrix.platform }} `
-            --self-contained true `
-            --output ./publish/${{ matrix.platform }}/workers/localai `
-            -p:Platform=${{ matrix.platform }} `
-            -p:PublishTrimmed=false
-
-      - name: Publish OCR Worker
-        working-directory: dotnet
-        run: |
-          dotnet publish src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj `
-            --configuration Release `
-            --runtime win-${{ matrix.platform }} `
-            --self-contained true `
-            --output ./publish/${{ matrix.platform }}/workers/ocr `
-            -p:Platform=${{ matrix.platform }} `
-            -p:PublishTrimmed=false
-
       # Publish again for MSIX without bundled Windows App SDK DLLs.
       # MSIX declares a framework package dependency (Microsoft.WindowsAppRuntime)
-      # so bundled DLLs are redundant and cause launch failures.
+      # so bundled DLLs are redundant and cause launch failures. Workers are handled
+      # explicitly below as framework-dependent, so suppress the portable auto-publish.
       - name: Publish WinUI App (MSIX)
         working-directory: dotnet
         run: |
@@ -204,6 +181,7 @@ jobs:
             -p:Version=${{ needs.prepare.outputs.BASE_VERSION }} `
             -p:Platform=${{ matrix.platform }} `
             -p:BuildWorkerOutputs=false `
+            -p:PublishWorkerOutputs=false `
             -p:EnableInProcLongDocFallback=false `
             -p:EnableGitHubUpdateCheck=false `
             -p:PublishTrimmed=false `

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -119,7 +119,9 @@ clean:
 	rm -rf tests/Easydict.UIAutomation.Tests/bin tests/Easydict.UIAutomation.Tests/obj
 	rm -rf publish publish-msix msix
 
-# Publish for distribution (portable)
+# Publish for distribution (portable) — workers are auto-published by
+# Easydict.WinUI.csproj PublishWorkerOutputs (AfterTargets=Publish) so a plain
+# `dotnet publish Easydict.WinUI.csproj` always yields a runnable layout.
 publish: restore
 	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --output ./publish --self-contained true
 
@@ -128,7 +130,8 @@ publish: restore
 # framework package installed, so the workers self-contain everything they need
 # (the size penalty here is ~30 MB per worker, accepted as the cost of a portable
 # distribution). MSIX strips this back to a single shared .NET 8 runtime — see
-# the publish-msix-* targets below.
+# the publish-msix-* targets below. Workers are auto-published by the host
+# PublishWorkerOutputs target; no explicit worker publish is needed for portable.
 #
 # x86 omits the workers because MuPDF.NET 3.2.12 doesn't ship a stable x86 runtime
 # and the worker csproj RuntimeIdentifiers exclude win-x86. Worker settings default
@@ -137,9 +140,6 @@ publish-x64: restore
 	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish/x64
 	dotnet publish src/Easydict.NativeBridge/Easydict.NativeBridge.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish/x64 -p:PublishTrimmed=true
 	dotnet publish src/Easydict.BrowserRegistrar/Easydict.BrowserRegistrar.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish/x64 -p:PublishTrimmed=true
-	dotnet publish src/Easydict.Workers.LongDoc/Easydict.Workers.LongDoc.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish/x64/workers/longdoc -p:Platform=x64
-	dotnet publish src/Easydict.Workers.LocalAi/Easydict.Workers.LocalAi.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish/x64/workers/localai -p:Platform=x64
-	dotnet publish src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish/x64/workers/ocr -p:Platform=x64
 
 publish-x86: restore
 	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-x86 --self-contained true --output ./publish/x86
@@ -150,35 +150,32 @@ publish-arm64: restore
 	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish/arm64
 	dotnet publish src/Easydict.NativeBridge/Easydict.NativeBridge.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish/arm64 -p:PublishTrimmed=true
 	dotnet publish src/Easydict.BrowserRegistrar/Easydict.BrowserRegistrar.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish/arm64 -p:PublishTrimmed=true
-	dotnet publish src/Easydict.Workers.LongDoc/Easydict.Workers.LongDoc.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish/arm64/workers/longdoc -p:Platform=arm64
-	dotnet publish src/Easydict.Workers.LocalAi/Easydict.Workers.LocalAi.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish/arm64/workers/localai -p:Platform=arm64
-	dotnet publish src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish/arm64/workers/ocr -p:Platform=arm64
 
 # Publish for MSIX (without bundled Windows App SDK DLLs)
 # MSIX declares a framework package dependency so bundled DLLs are redundant and cause launch failures.
 # Includes NativeBridge + BrowserRegistrar + workers published into the same output directory.
 publish-msix-x64: restore
-	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish-msix/x64 -p:BuildWorkerOutputs=false -p:EnableInProcLongDocFallback=false -p:PublishReadyToRun=false -p:WindowsAppSDKSelfContained=false
+	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish-msix/x64 -p:BuildWorkerOutputs=false -p:PublishWorkerOutputs=false -p:EnableInProcLongDocFallback=false -p:PublishReadyToRun=false -p:WindowsAppSDKSelfContained=false
 	dotnet publish src/Easydict.NativeBridge/Easydict.NativeBridge.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish-msix/x64 -p:PublishTrimmed=true
 	dotnet publish src/Easydict.BrowserRegistrar/Easydict.BrowserRegistrar.csproj --configuration Release --runtime win-x64 --self-contained true --output ./publish-msix/x64 -p:PublishTrimmed=true
 	dotnet publish src/Easydict.Workers.LongDoc/Easydict.Workers.LongDoc.csproj --configuration Release --runtime win-x64 --no-self-contained --output ./publish-msix/x64/workers/longdoc -p:Platform=x64 -p:WindowsAppSDKSelfContained=false
 	dotnet publish src/Easydict.Workers.LocalAi/Easydict.Workers.LocalAi.csproj --configuration Release --runtime win-x64 --no-self-contained --output ./publish-msix/x64/workers/localai -p:Platform=x64 -p:WindowsAppSDKSelfContained=false
-	dotnet publish src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj --configuration Release --runtime win-x64 --no-self-contained --output ./publish-msix/x64/workers/ocr -p:Platform=x64
+	dotnet publish src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj --configuration Release --runtime win-x64 --no-self-contained --output ./publish-msix/x64/workers/ocr -p:Platform=x64 -p:WindowsAppSDKSelfContained=false
 	pwsh -NoProfile -File scripts/Dedupe-WorkerSharedFiles.ps1 -PublishDir ./publish-msix/x64
 	pwsh -NoProfile -File scripts/Extract-DotnetRuntime.ps1 -Rid win-x64 -OutputDir ./publish-msix/x64/dotnet
 
 publish-msix-x86: restore
-	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-x86 --self-contained true --output ./publish-msix/x86 -p:BuildWorkerOutputs=false -p:EnableInProcLongDocFallback=false -p:PublishReadyToRun=false -p:WindowsAppSDKSelfContained=false
+	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-x86 --self-contained true --output ./publish-msix/x86 -p:BuildWorkerOutputs=false -p:PublishWorkerOutputs=false -p:EnableInProcLongDocFallback=false -p:PublishReadyToRun=false -p:WindowsAppSDKSelfContained=false
 	dotnet publish src/Easydict.NativeBridge/Easydict.NativeBridge.csproj --configuration Release --runtime win-x86 --self-contained true --output ./publish-msix/x86 -p:PublishTrimmed=true
 	dotnet publish src/Easydict.BrowserRegistrar/Easydict.BrowserRegistrar.csproj --configuration Release --runtime win-x86 --self-contained true --output ./publish-msix/x86 -p:PublishTrimmed=true
 
 publish-msix-arm64: restore
-	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish-msix/arm64 -p:BuildWorkerOutputs=false -p:EnableInProcLongDocFallback=false -p:PublishReadyToRun=false -p:WindowsAppSDKSelfContained=false
+	dotnet publish src/Easydict.WinUI/Easydict.WinUI.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish-msix/arm64 -p:BuildWorkerOutputs=false -p:PublishWorkerOutputs=false -p:EnableInProcLongDocFallback=false -p:PublishReadyToRun=false -p:WindowsAppSDKSelfContained=false
 	dotnet publish src/Easydict.NativeBridge/Easydict.NativeBridge.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish-msix/arm64 -p:PublishTrimmed=true
 	dotnet publish src/Easydict.BrowserRegistrar/Easydict.BrowserRegistrar.csproj --configuration Release --runtime win-arm64 --self-contained true --output ./publish-msix/arm64 -p:PublishTrimmed=true
 	dotnet publish src/Easydict.Workers.LongDoc/Easydict.Workers.LongDoc.csproj --configuration Release --runtime win-arm64 --no-self-contained --output ./publish-msix/arm64/workers/longdoc -p:Platform=arm64 -p:WindowsAppSDKSelfContained=false
 	dotnet publish src/Easydict.Workers.LocalAi/Easydict.Workers.LocalAi.csproj --configuration Release --runtime win-arm64 --no-self-contained --output ./publish-msix/arm64/workers/localai -p:Platform=arm64 -p:WindowsAppSDKSelfContained=false
-	dotnet publish src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj --configuration Release --runtime win-arm64 --no-self-contained --output ./publish-msix/arm64/workers/ocr -p:Platform=arm64
+	dotnet publish src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj --configuration Release --runtime win-arm64 --no-self-contained --output ./publish-msix/arm64/workers/ocr -p:Platform=arm64 -p:WindowsAppSDKSelfContained=false
 	pwsh -NoProfile -File scripts/Dedupe-WorkerSharedFiles.ps1 -PublishDir ./publish-msix/arm64
 	pwsh -NoProfile -File scripts/Extract-DotnetRuntime.ps1 -Rid win-arm64 -OutputDir ./publish-msix/arm64/dotnet
 

--- a/dotnet/e2e/Program.cs
+++ b/dotnet/e2e/Program.cs
@@ -173,6 +173,37 @@ allPassed &= await RunTest("Stderr log collection", async () =>
     Assert(logs.Any(l => l.Contains("\"level\"")), "logs should be structured JSON");
 });
 
+// Test 9: Synchronous disposal force-stops an active request without awaiting the worker.
+allPassed &= await RunTest("Synchronous disposal stops active request", async () =>
+{
+    var client = CreateClient(mockServicePath);
+    client.Start();
+
+    var request = client.SendRequestAsync("translate", new
+    {
+        text = "active-request",
+        toLang = "en",
+        delayMs = 30_000
+    }, timeoutMs: 0);
+    await Task.Delay(250);
+
+    var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+    client.Dispose();
+    stopwatch.Stop();
+
+    Assert(stopwatch.Elapsed < TimeSpan.FromSeconds(2),
+        $"synchronous disposal should return promptly, took {stopwatch.Elapsed}");
+    try
+    {
+        await request.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert(false, "active request should not complete successfully after disposal");
+    }
+    catch (SidecarProcessExitedException)
+    {
+        // Expected: Dispose() force-kills the sidecar process.
+    }
+});
+
 // Summary
 Console.WriteLine();
 Console.WriteLine(allPassed ? "[E2E] ✅ All tests passed!" : "[E2E] ❌ Some tests failed!");

--- a/dotnet/scripts/Build-Installer.ps1
+++ b/dotnet/scripts/Build-Installer.ps1
@@ -96,6 +96,17 @@ if (-not (Test-Path $mainExe)) {
     exit 1
 }
 
+if ($Platform -ne "x86") {
+    $missing = @()
+    foreach ($w in @("workers\ocr\Easydict.Workers.Ocr.exe", "workers\longdoc\Easydict.Workers.LongDoc.exe", "workers\localai\Easydict.Workers.LocalAi.exe")) {
+        if (-not (Test-Path (Join-Path $PublishDir $w))) { $missing += $w }
+    }
+    if ($missing.Count -gt 0) {
+        Write-Error "Worker(s) missing in PublishDir: $($missing -join ', '). Run dotnet publish Easydict.WinUI (which auto-publishes workers) or make publish-$Platform."
+        exit 1
+    }
+}
+
 # Create output directory
 $outputDir = Join-Path $SolutionDir "installer-output"
 New-Item -ItemType Directory -Force -Path $outputDir | Out-Null

--- a/dotnet/scripts/publish.ps1
+++ b/dotnet/scripts/publish.ps1
@@ -1,13 +1,13 @@
 # Easydict WinUI Publish Script
-# Creates a self-contained deployment that includes .NET runtime
+# Creates a self-contained deployment that includes .NET runtime + workers.
 
 param(
     [ValidateSet("x64", "x86", "arm64")]
     [string]$Platform = "x64",
-    
+
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = "Release",
-    
+
     [switch]$CreateZip
 )
 
@@ -26,14 +26,12 @@ Write-Host "Configuration: $Configuration"
 Write-Host "Output:        $PublishDir"
 Write-Host ""
 
-# Clean previous publish
 if (Test-Path $PublishDir) {
     Write-Host "Cleaning previous publish..." -ForegroundColor Yellow
     Remove-Item -Path $PublishDir -Recurse -Force
 }
 
-# Publish
-Write-Host "Publishing self-contained app..." -ForegroundColor Green
+Write-Host "Publishing self-contained app (workers auto-published by PublishWorkerOutputs)..." -ForegroundColor Green
 dotnet publish $ProjectPath `
     -c $Configuration `
     -p:Platform=$Platform `
@@ -45,7 +43,18 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# Publish NativeBridge and copy to WinUI publish output
+$ocrExe = Join-Path $PublishDir "workers\ocr\Easydict.Workers.Ocr.exe"
+$longDocExe = Join-Path $PublishDir "workers\longdoc\Easydict.Workers.LongDoc.exe"
+$localAiExe = Join-Path $PublishDir "workers\localai\Easydict.Workers.LocalAi.exe"
+if (-not (Test-Path $ocrExe) -and $Platform -ne "x86") {
+    Write-Host "ERROR: OCR worker not found at $ocrExe - PublishWorkerOutputs did not run." -ForegroundColor Red
+    Write-Host "Hint: ensure -p:PublishWorkerOutputs is not set to false and dotnet SDK is available in PATH." -ForegroundColor Yellow
+    exit 1
+}
+if (Test-Path $ocrExe) { Write-Host "Worker OK: workers/ocr/Easydict.Workers.Ocr.exe" -ForegroundColor Green }
+if (Test-Path $longDocExe) { Write-Host "Worker OK: workers/longdoc/Easydict.Workers.LongDoc.exe" -ForegroundColor Green }
+if (Test-Path $localAiExe) { Write-Host "Worker OK: workers/localai/Easydict.Workers.LocalAi.exe" -ForegroundColor Green }
+
 $BridgeProject = Join-Path $SolutionDir "src\Easydict.NativeBridge\Easydict.NativeBridge.csproj"
 $BridgePublishDir = Join-Path $SolutionDir "src\Easydict.NativeBridge\bin\publish\win-$Platform"
 
@@ -69,7 +78,6 @@ if (Test-Path $BridgeExe) {
     Write-Host "WARNING: easydict-native-bridge.exe not found at $BridgeExe" -ForegroundColor Yellow
 }
 
-# Publish BrowserRegistrar and copy to WinUI publish output
 $RegistrarProject = Join-Path $SolutionDir "src\Easydict.BrowserRegistrar\Easydict.BrowserRegistrar.csproj"
 $RegistrarPublishDir = Join-Path $SolutionDir "src\Easydict.BrowserRegistrar\bin\publish\win-$Platform"
 
@@ -94,7 +102,6 @@ if (Test-Path $RegistrarExe) {
     Write-Host "WARNING: BrowserHostRegistrar.exe not found at $RegistrarExe" -ForegroundColor Yellow
 }
 
-# Calculate size
 $files = Get-ChildItem -Path $PublishDir -Recurse -File
 $totalSize = ($files | Measure-Object -Property Length -Sum).Sum
 $sizeMB = [math]::Round($totalSize / 1MB, 2)
@@ -107,18 +114,17 @@ Write-Host "Files:  $($files.Count)"
 Write-Host "Size:   $sizeMB MB"
 Write-Host "Output: $PublishDir"
 
-# Create ZIP if requested
 if ($CreateZip) {
     $zipPath = Join-Path $SolutionDir "Easydict-win-$Platform-$Configuration.zip"
     Write-Host ""
     Write-Host "Creating ZIP archive..." -ForegroundColor Yellow
-    
+
     if (Test-Path $zipPath) {
         Remove-Item $zipPath -Force
     }
-    
+
     Compress-Archive -Path "$PublishDir\*" -DestinationPath $zipPath -CompressionLevel Optimal
-    
+
     $zipSize = [math]::Round((Get-Item $zipPath).Length / 1MB, 2)
     Write-Host "ZIP created: $zipPath ($zipSize MB)" -ForegroundColor Green
 }
@@ -126,4 +132,3 @@ if ($CreateZip) {
 Write-Host ""
 Write-Host "To run the app:" -ForegroundColor Cyan
 Write-Host "  $PublishDir\Easydict.WinUI.exe"
-

--- a/dotnet/src/Easydict.SidecarClient/Protocol/OcrProtocol.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/OcrProtocol.cs
@@ -7,6 +7,12 @@ public static class OcrMethods
     public const string Recognize = "recognize";
 }
 
+public static class OcrEngines
+{
+    public const string WindowsNative = "windowsNative";
+    public const string PpOcrV6 = "ppOcrV6";
+}
+
 public sealed class OcrRecognizeParams
 {
     [JsonPropertyName("pixelDataPath")]
@@ -20,6 +26,18 @@ public sealed class OcrRecognizeParams
 
     [JsonPropertyName("preferredLanguageTag")]
     public string? PreferredLanguageTag { get; init; }
+
+    [JsonPropertyName("engine")]
+    public string? Engine { get; init; }
+
+    [JsonPropertyName("modelId")]
+    public string? ModelId { get; init; }
+
+    [JsonPropertyName("threadCount")]
+    public int? ThreadCount { get; init; }
+
+    [JsonPropertyName("useGpu")]
+    public bool UseGpu { get; init; }
 }
 
 public sealed class OcrResultDto
@@ -35,12 +53,21 @@ public sealed class OcrResultDto
 
     [JsonPropertyName("textAngle")]
     public double? TextAngle { get; init; }
+
+    [JsonPropertyName("engine")]
+    public string? Engine { get; init; }
+
+    [JsonPropertyName("modelId")]
+    public string? ModelId { get; init; }
 }
 
 public sealed class OcrLineDto
 {
     [JsonPropertyName("text")]
     public string Text { get; init; } = string.Empty;
+
+    [JsonPropertyName("confidence")]
+    public float? Confidence { get; init; }
 
     /// <summary>
     /// Individual recognized words for this line. Sent so the host can apply the same

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelCatalog.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelCatalog.cs
@@ -1,0 +1,163 @@
+using System.Collections.ObjectModel;
+
+namespace Easydict.SidecarClient.Protocol;
+
+public sealed record PpOcrV6Artifact(
+    string FileName,
+    string Url,
+    long SizeBytes,
+    string Sha256);
+
+public sealed record PpOcrV6ModelInfo(
+    string Id,
+    string DisplayName,
+    long DownloadSizeBytes,
+    string DetectorModelName,
+    string RecognizerModelName,
+    IReadOnlyList<PpOcrV6Artifact> Artifacts,
+    IReadOnlyList<string> Languages);
+
+public static class PpOcrV6ModelCatalog
+{
+    public const string TinyId = "PP-OCRv6_tiny";
+    public const string SmallId = "PP-OCRv6_small";
+    public const string MediumId = "PP-OCRv6_medium";
+
+    private static readonly IReadOnlyList<string> SupportedLanguages = new ReadOnlyCollection<string>(
+    [
+        "zh-Hans", "zh-Hant", "en", "ja", "af", "az", "bs", "ca", "cs", "cy",
+        "da", "de", "es", "et", "eu", "fi", "fr", "ga", "gl", "hr", "hu",
+        "id", "is", "it", "ku", "la", "lb", "lt", "lv", "mi", "ms", "mt",
+        "nl", "no", "oc", "pl", "pt", "qu", "rm", "ro", "sr-Latn", "sk",
+        "sl", "sq", "sv", "sw", "tl", "tr", "uz", "vi"
+    ]);
+
+    private static readonly IReadOnlyList<string> TinyLanguages = new ReadOnlyCollection<string>(
+        SupportedLanguages.Where(language => !string.Equals(language, "ja", StringComparison.Ordinal)).ToArray());
+
+    private static readonly IReadOnlyList<PpOcrV6ModelInfo> _models =
+    [
+        CreateModel(
+            TinyId,
+            "PP-OCRv6 Tiny",
+            "2ba1506c0380b8f0b03dd142459aac66d4421f6c",
+            "2612ab37152ae0a677521bae4e1e3d4fb4cf7c30",
+            "PP-OCRv6_tiny_det",
+            "PP-OCRv6_tiny_rec",
+            6_299_683,
+            1_780_590,
+            4_462_639,
+            883,
+            55_571,
+            "193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8",
+            "9ef676d6ed3c88256d2a92c640c44f25b0c40947e111b14b8be8f594091563e6",
+            "3ac018be6f97499a08faa3bbdeb33640968d9307f6736d152902747a9f259593",
+            "66170210bad538e83fff3c4a3867e547d6bf20b50d64b20347c4b913f3034ea1"),
+        CreateModel(
+            SmallId,
+            "PP-OCRv6 Small",
+            "28fe5895c24fd108c19eb3e8479f4ab385fbfc62",
+            "b8f84f0b80c529de40b4fbb3544b84fa7233a513",
+            "PP-OCRv6_small_det",
+            "PP-OCRv6_small_rec",
+            31_191_354,
+            9_880_512,
+            21_159_378,
+            885,
+            150_579,
+            "d73e0058b7a8086bbd57f3d10b8bcd4ff95363f67e06e2762b5e814fe9c9410e",
+            "5435fd747c9e0efe15a96d0b378d5bd157e9492ed8fd80edf08f30d02fa24634",
+            "193f435274bf9f0b5f71a929bbfbcf148282df7e633b34e7c373e8f44741b516",
+            "ab078671bb49f06228eadccd34f1bb501e157f7a047095ffb943ba81512c77d1"),
+        CreateModel(
+            MediumId,
+            "PP-OCRv6 Medium",
+            "61323801669c338b7891481ec7bac61ce31b576a",
+            "50c7eacafc52fa7bcf4194e8cd08e46f8558504b",
+            "PP-OCRv6_medium_det",
+            "PP-OCRv6_medium_rec",
+            138_739_282,
+            62_032_837,
+            76_554_979,
+            886,
+            150_580,
+            "eb13b44b25bb36f89528b68720af8a61d9cf381176107f465db1757b65d086e1",
+            "9c09abf0957f7968c7586464b7397b84ad2387a0497a351af40e9acc71b673ba",
+            "7298d5ead546584af2504d03355f881ac7a7bc0eb1e282d3e159277c1d0af871",
+            "991b700facf5b50a7de193468207d5f4255b538dde0d312ae3b7c7a9b6873129")
+    ];
+
+    public static IReadOnlyList<PpOcrV6ModelInfo> Models => _models;
+
+    public static PpOcrV6ModelInfo Get(string id)
+    {
+        return _models.FirstOrDefault(model =>
+                   string.Equals(model.Id, id, StringComparison.OrdinalIgnoreCase))
+               ?? throw new ArgumentException($"Unknown PP-OCRv6 model: {id}", nameof(id));
+    }
+
+    public static bool TryGet(string? id, out PpOcrV6ModelInfo? model)
+    {
+        model = _models.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, id, StringComparison.OrdinalIgnoreCase));
+        return model is not null;
+    }
+
+    public static bool SupportsLanguage(string modelId, string? languageTag)
+    {
+        if (string.IsNullOrWhiteSpace(languageTag) || string.Equals(languageTag, "auto", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var normalized = languageTag.Trim().ToLowerInvariant();
+        var model = Get(modelId);
+        return model.Languages.Any(language =>
+        {
+            var candidate = language.ToLowerInvariant();
+            return normalized == candidate
+                || normalized.StartsWith(candidate + "-", StringComparison.Ordinal)
+                || (candidate == "zh-hans" && normalized.StartsWith("zh-cn", StringComparison.Ordinal))
+                || (candidate == "zh-hant" && normalized.StartsWith("zh-tw", StringComparison.Ordinal));
+        });
+    }
+
+    private static PpOcrV6ModelInfo CreateModel(
+        string id,
+        string displayName,
+        string detectorRevision,
+        string recognizerRevision,
+        string detectorModelName,
+        string recognizerModelName,
+        long downloadSizeBytes,
+        long detectorSizeBytes,
+        long recognizerSizeBytes,
+        long detectorConfigSizeBytes,
+        long recognizerConfigSizeBytes,
+        string detectorSha256,
+        string recognizerSha256,
+        string detectorConfigSha256,
+        string recognizerConfigSha256)
+    {
+        var detectorRepository = $"PaddlePaddle/{detectorModelName}_onnx";
+        var recognizerRepository = $"PaddlePaddle/{recognizerModelName}_onnx";
+        var detectorBaseUrl = $"https://huggingface.co/{detectorRepository}/resolve/{detectorRevision}";
+        var recognizerBaseUrl = $"https://huggingface.co/{recognizerRepository}/resolve/{recognizerRevision}";
+
+        return new PpOcrV6ModelInfo(
+            id,
+            displayName,
+            downloadSizeBytes,
+            detectorModelName,
+            recognizerModelName,
+            [
+                new("det.onnx", $"{detectorBaseUrl}/inference.onnx", detectorSizeBytes, detectorSha256),
+                new("det.yml", $"{detectorBaseUrl}/inference.yml", detectorConfigSizeBytes, detectorConfigSha256),
+                new("rec.onnx", $"{recognizerBaseUrl}/inference.onnx", recognizerSizeBytes, recognizerSha256),
+                new("rec.yml", $"{recognizerBaseUrl}/inference.yml", recognizerConfigSizeBytes, recognizerConfigSha256),
+            ],
+            string.Equals(id, TinyId, StringComparison.OrdinalIgnoreCase)
+                ? TinyLanguages
+                : SupportedLanguages);
+    }
+}

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelCatalog.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelCatalog.cs
@@ -50,7 +50,7 @@ public static class PpOcrV6ModelCatalog
             883,
             55_571,
             "193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8",
-            "9ef676d6ed3c88256d2a92c640c44f25b0c40947e111b14b8be8f594091563e6",
+            "9ef676d6ed3c88256a2d92c640c44f25b0c40947e111b14b8be8f594091563e6",
             "3ac018be6f97499a08faa3bbdeb33640968d9307f6736d152902747a9f259593",
             "66170210bad538e83fff3c4a3867e547d6bf20b50d64b20347c4b913f3034ea1"),
         CreateModel(

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelCatalog.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelCatalog.cs
@@ -5,8 +5,7 @@ namespace Easydict.SidecarClient.Protocol;
 public sealed record PpOcrV6Artifact(
     string FileName,
     string Url,
-    long SizeBytes,
-    string Sha256);
+    long SizeBytes);
 
 public sealed record PpOcrV6ModelInfo(
     string Id,
@@ -47,15 +46,12 @@ public static class PpOcrV6ModelCatalog
             "2612ab37152ae0a677521bae4e1e3d4fb4cf7c30",
             "PP-OCRv6_tiny_det",
             "PP-OCRv6_tiny_rec",
-            6_299_683,
-            1_780_590,
-            4_462_639,
-            883,
-            55_571,
-            "193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8",
-            "9ef676d6ed3c88256a2d92c640c44f25b0c40947e111b14b8be8f594091563e6",
-            "3ac018be6f97499a08faa3bbdeb33640968d9307f6736d152902747a9f259593",
-            "66170210bad538e83fff3c4a3867e547d6bf20b50d64b20347c4b913f3034ea1"),
+            [
+                new(PpOcrV6ModelStore.DetectorModelFileName, "inference.onnx", 1_780_590),
+                new(PpOcrV6ModelStore.DetectorConfigFileName, "inference.yml", 883),
+                new(PpOcrV6ModelStore.RecognizerModelFileName, "inference.onnx", 4_462_639),
+                new(PpOcrV6ModelStore.RecognizerConfigFileName, "inference.yml", 55_571),
+            ]),
         CreateModel(
             SmallId,
             "PP-OCRv6 Small",
@@ -63,15 +59,12 @@ public static class PpOcrV6ModelCatalog
             "b8f84f0b80c529de40b4fbb3544b84fa7233a513",
             "PP-OCRv6_small_det",
             "PP-OCRv6_small_rec",
-            31_191_354,
-            9_880_512,
-            21_159_378,
-            885,
-            150_579,
-            "d73e0058b7a8086bbd57f3d10b8bcd4ff95363f67e06e2762b5e814fe9c9410e",
-            "5435fd747c9e0efe15a96d0b378d5bd157e9492ed8fd80edf08f30d02fa24634",
-            "193f435274bf9f0b5f71a929bbfbcf148282df7e633b34e7c373e8f44741b516",
-            "ab078671bb49f06228eadccd34f1bb501e157f7a047095ffb943ba81512c77d1"),
+            [
+                new(PpOcrV6ModelStore.DetectorModelFileName, "inference.onnx", 9_880_512),
+                new(PpOcrV6ModelStore.DetectorConfigFileName, "inference.yml", 885),
+                new(PpOcrV6ModelStore.RecognizerModelFileName, "inference.onnx", 21_159_378),
+                new(PpOcrV6ModelStore.RecognizerConfigFileName, "inference.yml", 150_579),
+            ]),
         CreateModel(
             MediumId,
             "PP-OCRv6 Medium",
@@ -79,15 +72,12 @@ public static class PpOcrV6ModelCatalog
             "50c7eacafc52fa7bcf4194e8cd08e46f8558504b",
             "PP-OCRv6_medium_det",
             "PP-OCRv6_medium_rec",
-            138_739_282,
-            62_032_837,
-            76_554_979,
-            886,
-            150_580,
-            "eb13b44b25bb36f89528b68720af8a61d9cf381176107f465db1757b65d086e1",
-            "9c09abf0957f7968c7586464b7397b84ad2387a0497a351af40e9acc71b673ba",
-            "7298d5ead546584af2504d03355f881ac7a7bc0eb1e282d3e159277c1d0af871",
-            "991b700facf5b50a7de193468207d5f4255b538dde0d312ae3b7c7a9b6873129")
+            [
+                new(PpOcrV6ModelStore.DetectorModelFileName, "inference.onnx", 62_032_837),
+                new(PpOcrV6ModelStore.DetectorConfigFileName, "inference.yml", 886),
+                new(PpOcrV6ModelStore.RecognizerModelFileName, "inference.onnx", 76_554_979),
+                new(PpOcrV6ModelStore.RecognizerConfigFileName, "inference.yml", 150_580),
+            ])
     ];
 
     public static IReadOnlyList<PpOcrV6ModelInfo> Models => _models;
@@ -133,35 +123,38 @@ public static class PpOcrV6ModelCatalog
         string recognizerRevision,
         string detectorModelName,
         string recognizerModelName,
-        long downloadSizeBytes,
-        long detectorSizeBytes,
-        long recognizerSizeBytes,
-        long detectorConfigSizeBytes,
-        long recognizerConfigSizeBytes,
-        string detectorSha256,
-        string recognizerSha256,
-        string detectorConfigSha256,
-        string recognizerConfigSha256)
+        IReadOnlyList<ArtifactSpec> artifactSpecs)
     {
         var detectorRepository = $"PaddlePaddle/{detectorModelName}_onnx";
         var recognizerRepository = $"PaddlePaddle/{recognizerModelName}_onnx";
         var detectorBaseUrl = $"https://huggingface.co/{detectorRepository}/resolve/{detectorRevision}";
         var recognizerBaseUrl = $"https://huggingface.co/{recognizerRepository}/resolve/{recognizerRevision}";
+        var artifacts = artifactSpecs.Select(spec => new PpOcrV6Artifact(
+            spec.FileName,
+            $"{(spec.IsDetector ? detectorBaseUrl : recognizerBaseUrl)}/{spec.RemoteFileName}",
+            spec.SizeBytes)).ToArray();
 
         return new PpOcrV6ModelInfo(
             id,
             displayName,
-            downloadSizeBytes,
+            artifacts.Sum(artifact => artifact.SizeBytes),
             detectorModelName,
             recognizerModelName,
-            [
-                new(PpOcrV6ModelStore.DetectorModelFileName, $"{detectorBaseUrl}/inference.onnx", detectorSizeBytes, detectorSha256),
-                new(PpOcrV6ModelStore.DetectorConfigFileName, $"{detectorBaseUrl}/inference.yml", detectorConfigSizeBytes, detectorConfigSha256),
-                new(PpOcrV6ModelStore.RecognizerModelFileName, $"{recognizerBaseUrl}/inference.onnx", recognizerSizeBytes, recognizerSha256),
-                new(PpOcrV6ModelStore.RecognizerConfigFileName, $"{recognizerBaseUrl}/inference.yml", recognizerConfigSizeBytes, recognizerSha256),
-            ],
+            artifacts,
             string.Equals(id, TinyId, StringComparison.OrdinalIgnoreCase)
                 ? TinyLanguages
                 : SupportedLanguages);
+    }
+
+    private sealed record ArtifactSpec(
+        string FileName,
+        string RemoteFileName,
+        long SizeBytes,
+        bool IsDetector)
+    {
+        public ArtifactSpec(string fileName, string remoteFileName, long sizeBytes)
+            : this(fileName, remoteFileName, sizeBytes, fileName.StartsWith("det.", StringComparison.Ordinal))
+        {
+        }
     }
 }

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelCatalog.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelCatalog.cs
@@ -22,6 +22,9 @@ public static class PpOcrV6ModelCatalog
     public const string TinyId = "PP-OCRv6_tiny";
     public const string SmallId = "PP-OCRv6_small";
     public const string MediumId = "PP-OCRv6_medium";
+    public const int MinThreadCount = 1;
+    public const int MaxThreadCount = 16;
+    public const int DefaultThreadCount = 4;
 
     private static readonly IReadOnlyList<string> SupportedLanguages = new ReadOnlyCollection<string>(
     [
@@ -117,6 +120,7 @@ public static class PpOcrV6ModelCatalog
             var candidate = language.ToLowerInvariant();
             return normalized == candidate
                 || normalized.StartsWith(candidate + "-", StringComparison.Ordinal)
+                || candidate.StartsWith(normalized + "-", StringComparison.Ordinal)
                 || (candidate == "zh-hans" && normalized.StartsWith("zh-cn", StringComparison.Ordinal))
                 || (candidate == "zh-hant" && normalized.StartsWith("zh-tw", StringComparison.Ordinal));
         });
@@ -151,10 +155,10 @@ public static class PpOcrV6ModelCatalog
             detectorModelName,
             recognizerModelName,
             [
-                new("det.onnx", $"{detectorBaseUrl}/inference.onnx", detectorSizeBytes, detectorSha256),
-                new("det.yml", $"{detectorBaseUrl}/inference.yml", detectorConfigSizeBytes, detectorConfigSha256),
-                new("rec.onnx", $"{recognizerBaseUrl}/inference.onnx", recognizerSizeBytes, recognizerSha256),
-                new("rec.yml", $"{recognizerBaseUrl}/inference.yml", recognizerConfigSizeBytes, recognizerConfigSha256),
+                new(PpOcrV6ModelStore.DetectorModelFileName, $"{detectorBaseUrl}/inference.onnx", detectorSizeBytes, detectorSha256),
+                new(PpOcrV6ModelStore.DetectorConfigFileName, $"{detectorBaseUrl}/inference.yml", detectorConfigSizeBytes, detectorConfigSha256),
+                new(PpOcrV6ModelStore.RecognizerModelFileName, $"{recognizerBaseUrl}/inference.onnx", recognizerSizeBytes, recognizerSha256),
+                new(PpOcrV6ModelStore.RecognizerConfigFileName, $"{recognizerBaseUrl}/inference.yml", recognizerConfigSizeBytes, recognizerSha256),
             ],
             string.Equals(id, TinyId, StringComparison.OrdinalIgnoreCase)
                 ? TinyLanguages

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-
 namespace Easydict.SidecarClient.Protocol;
 
 public enum PpOcrV6ModelState
@@ -88,41 +86,6 @@ public sealed class PpOcrV6ModelStore
         return PpOcrV6ModelState.Installed;
     }
 
-    public async Task<PpOcrV6ModelState> ValidateAsync(
-        string modelId,
-        CancellationToken cancellationToken = default)
-    {
-        var presence = GetStateByPresence(modelId);
-        if (presence != PpOcrV6ModelState.Installed)
-        {
-            return presence;
-        }
-
-        var model = PpOcrV6ModelCatalog.Get(modelId);
-        var paths = GetPaths(modelId);
-        foreach (var artifact in model.Artifacts)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            var path = Path.Combine(paths.Directory, artifact.FileName);
-            var info = new FileInfo(path);
-            if (info.Length != artifact.SizeBytes)
-            {
-                return PpOcrV6ModelState.Invalid;
-            }
-
-            await using var stream = File.OpenRead(path);
-            using var sha = SHA256.Create();
-            var hash = Convert.ToHexString(
-                await sha.ComputeHashAsync(stream, cancellationToken)).ToLowerInvariant();
-            if (!string.Equals(hash, artifact.Sha256, StringComparison.OrdinalIgnoreCase))
-            {
-                return PpOcrV6ModelState.Invalid;
-            }
-        }
-
-        return PpOcrV6ModelState.Installed;
-    }
-
     public void PrepareRoot()
     {
         Directory.CreateDirectory(RootDirectory);
@@ -135,10 +98,13 @@ public sealed class PpOcrV6ModelStore
         {
             File.Delete(paths.CompletionSentinel);
         }
-        catch (FileNotFoundException)
+        catch (DirectoryNotFoundException)
         {
         }
-        catch (DirectoryNotFoundException)
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
         {
         }
     }

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
@@ -138,6 +138,9 @@ public sealed class PpOcrV6ModelStore
         catch (FileNotFoundException)
         {
         }
+        catch (DirectoryNotFoundException)
+        {
+        }
     }
 
 }

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
@@ -1,0 +1,158 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Easydict.SidecarClient.Protocol;
+
+public enum PpOcrV6ModelState
+{
+    Missing,
+    Installed,
+    Invalid,
+}
+
+public sealed record PpOcrV6ModelPaths(
+    string Directory,
+    string DetectorModel,
+    string DetectorConfig,
+    string RecognizerModel,
+    string RecognizerConfig,
+    string CompletionSentinel);
+
+public sealed class PpOcrV6ModelStore
+{
+    public const string ModelsDirectoryName = "PpOcrV6";
+    public const string CompletionSentinelName = ".complete";
+
+    public PpOcrV6ModelStore(string? rootDirectory = null)
+    {
+        RootDirectory = rootDirectory ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Easydict",
+            "Models",
+            ModelsDirectoryName);
+    }
+
+    public string RootDirectory { get; }
+
+    public PpOcrV6ModelPaths GetPaths(string modelId)
+    {
+        var model = PpOcrV6ModelCatalog.Get(modelId);
+        var directory = Path.Combine(RootDirectory, model.Id);
+        return new PpOcrV6ModelPaths(
+            directory,
+            Path.Combine(directory, "det.onnx"),
+            Path.Combine(directory, "det.yml"),
+            Path.Combine(directory, "rec.onnx"),
+            Path.Combine(directory, "rec.yml"),
+            Path.Combine(directory, CompletionSentinelName));
+    }
+
+    public PpOcrV6ModelState GetStateByPresence(string modelId)
+    {
+        var paths = GetPaths(modelId);
+        if (!File.Exists(paths.CompletionSentinel))
+        {
+            return PpOcrV6ModelState.Missing;
+        }
+
+        var artifacts = PpOcrV6ModelCatalog.Get(modelId).Artifacts;
+        if (artifacts.Any(artifact => !File.Exists(Path.Combine(paths.Directory, artifact.FileName))))
+        {
+            return PpOcrV6ModelState.Invalid;
+        }
+
+        return PpOcrV6ModelState.Installed;
+    }
+
+    public PpOcrV6ModelState Validate(string modelId)
+    {
+        var presence = GetStateByPresence(modelId);
+        if (presence != PpOcrV6ModelState.Installed)
+        {
+            return presence;
+        }
+
+        var paths = GetPaths(modelId);
+        foreach (var artifact in PpOcrV6ModelCatalog.Get(modelId).Artifacts)
+        {
+            var path = Path.Combine(paths.Directory, artifact.FileName);
+            var info = new FileInfo(path);
+            if (info.Length != artifact.SizeBytes)
+            {
+                return PpOcrV6ModelState.Invalid;
+            }
+
+            using var stream = File.OpenRead(path);
+            using var sha = SHA256.Create();
+            var hash = Convert.ToHexString(sha.ComputeHash(stream)).ToLowerInvariant();
+            if (!string.Equals(hash, artifact.Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                return PpOcrV6ModelState.Invalid;
+            }
+        }
+
+        return PpOcrV6ModelState.Installed;
+    }
+
+    public async Task<PpOcrV6ModelState> ValidateAsync(
+        string modelId,
+        CancellationToken cancellationToken = default)
+    {
+        var presence = GetStateByPresence(modelId);
+        if (presence != PpOcrV6ModelState.Installed)
+        {
+            return presence;
+        }
+
+        var model = PpOcrV6ModelCatalog.Get(modelId);
+        var paths = GetPaths(modelId);
+        foreach (var artifact in model.Artifacts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var path = Path.Combine(paths.Directory, artifact.FileName);
+            var info = new FileInfo(path);
+            if (info.Length != artifact.SizeBytes)
+            {
+                return PpOcrV6ModelState.Invalid;
+            }
+
+            await using var stream = File.OpenRead(path);
+            using var sha = SHA256.Create();
+            var hash = Convert.ToHexString(
+                await sha.ComputeHashAsync(stream, cancellationToken)).ToLowerInvariant();
+            if (!string.Equals(hash, artifact.Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                return PpOcrV6ModelState.Invalid;
+            }
+        }
+
+        return PpOcrV6ModelState.Installed;
+    }
+
+    public void PrepareRoot()
+    {
+        Directory.CreateDirectory(RootDirectory);
+    }
+
+    public void InvalidateCompletion(string modelId)
+    {
+        var paths = GetPaths(modelId);
+        try
+        {
+            File.Delete(paths.CompletionSentinel);
+        }
+        catch (FileNotFoundException)
+        {
+        }
+    }
+
+    public void Complete(string modelId)
+    {
+        var paths = GetPaths(modelId);
+        Directory.CreateDirectory(paths.Directory);
+        File.WriteAllText(
+            paths.CompletionSentinel,
+            $"{modelId}{Environment.NewLine}{DateTimeOffset.UtcNow:O}",
+            new UTF8Encoding(false));
+    }
+}

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
@@ -21,6 +21,10 @@ public sealed class PpOcrV6ModelStore
 {
     public const string ModelsDirectoryName = "PpOcrV6";
     public const string CompletionSentinelName = ".complete";
+    public const string DetectorModelFileName = "det.onnx";
+    public const string DetectorConfigFileName = "det.yml";
+    public const string RecognizerModelFileName = "rec.onnx";
+    public const string RecognizerConfigFileName = "rec.yml";
 
     public PpOcrV6ModelStore(string? rootDirectory = null)
     {
@@ -39,10 +43,10 @@ public sealed class PpOcrV6ModelStore
         var directory = Path.Combine(RootDirectory, model.Id);
         return new PpOcrV6ModelPaths(
             directory,
-            Path.Combine(directory, "det.onnx"),
-            Path.Combine(directory, "det.yml"),
-            Path.Combine(directory, "rec.onnx"),
-            Path.Combine(directory, "rec.yml"),
+            Path.Combine(directory, DetectorModelFileName),
+            Path.Combine(directory, DetectorConfigFileName),
+            Path.Combine(directory, RecognizerModelFileName),
+            Path.Combine(directory, RecognizerConfigFileName),
             Path.Combine(directory, CompletionSentinelName));
     }
 
@@ -58,6 +62,27 @@ public sealed class PpOcrV6ModelStore
         if (artifacts.Any(artifact => !File.Exists(Path.Combine(paths.Directory, artifact.FileName))))
         {
             return PpOcrV6ModelState.Invalid;
+        }
+
+        return PpOcrV6ModelState.Installed;
+    }
+
+    public PpOcrV6ModelState GetStateBySize(string modelId)
+    {
+        var presence = GetStateByPresence(modelId);
+        if (presence != PpOcrV6ModelState.Installed)
+        {
+            return presence;
+        }
+
+        var paths = GetPaths(modelId);
+        foreach (var artifact in PpOcrV6ModelCatalog.Get(modelId).Artifacts)
+        {
+            var path = Path.Combine(paths.Directory, artifact.FileName);
+            if (!File.Exists(path) || new FileInfo(path).Length != artifact.SizeBytes)
+            {
+                return PpOcrV6ModelState.Invalid;
+            }
         }
 
         return PpOcrV6ModelState.Installed;

--- a/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/PpOcrV6ModelStore.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Easydict.SidecarClient.Protocol;
 
@@ -64,36 +63,6 @@ public sealed class PpOcrV6ModelStore
         return PpOcrV6ModelState.Installed;
     }
 
-    public PpOcrV6ModelState Validate(string modelId)
-    {
-        var presence = GetStateByPresence(modelId);
-        if (presence != PpOcrV6ModelState.Installed)
-        {
-            return presence;
-        }
-
-        var paths = GetPaths(modelId);
-        foreach (var artifact in PpOcrV6ModelCatalog.Get(modelId).Artifacts)
-        {
-            var path = Path.Combine(paths.Directory, artifact.FileName);
-            var info = new FileInfo(path);
-            if (info.Length != artifact.SizeBytes)
-            {
-                return PpOcrV6ModelState.Invalid;
-            }
-
-            using var stream = File.OpenRead(path);
-            using var sha = SHA256.Create();
-            var hash = Convert.ToHexString(sha.ComputeHash(stream)).ToLowerInvariant();
-            if (!string.Equals(hash, artifact.Sha256, StringComparison.OrdinalIgnoreCase))
-            {
-                return PpOcrV6ModelState.Invalid;
-            }
-        }
-
-        return PpOcrV6ModelState.Installed;
-    }
-
     public async Task<PpOcrV6ModelState> ValidateAsync(
         string modelId,
         CancellationToken cancellationToken = default)
@@ -146,13 +115,4 @@ public sealed class PpOcrV6ModelStore
         }
     }
 
-    public void Complete(string modelId)
-    {
-        var paths = GetPaths(modelId);
-        Directory.CreateDirectory(paths.Directory);
-        File.WriteAllText(
-            paths.CompletionSentinel,
-            $"{modelId}{Environment.NewLine}{DateTimeOffset.UtcNow:O}",
-            new UTF8Encoding(false));
-    }
 }

--- a/dotnet/src/Easydict.SidecarClient/Protocol/WorkerProtocol.cs
+++ b/dotnet/src/Easydict.SidecarClient/Protocol/WorkerProtocol.cs
@@ -48,6 +48,11 @@ public static class WorkerErrorCodes
     public const string ServiceError = "service_error";
     public const string Internal = "internal_error";
     public const string VersionMismatch = "version_mismatch";
+    public const string ModelInvalid = "model_invalid";
+    public const string RuntimeMissing = "runtime_missing";
+    public const string GpuUnavailable = "gpu_unavailable";
+    public const string InferenceError = "inference_error";
+    public const string UnsupportedLanguage = "unsupported_language";
 }
 
 /// <summary>

--- a/dotnet/src/Easydict.SidecarClient/SidecarClient.cs
+++ b/dotnet/src/Easydict.SidecarClient/SidecarClient.cs
@@ -349,7 +349,11 @@ public sealed class SidecarClient : IDisposable, IAsyncDisposable
 
         _cts?.Cancel();
 
-        try { _process?.Kill(); } catch { }
+        try { _process?.Kill(entireProcessTree: true); } catch { }
+
+        // Process.Exited can race with Process.Dispose(), so unblock active callers
+        // directly before releasing the process handle.
+        FailPendingRequests(exitCode: null);
         _process?.Dispose();
         _stdin?.Dispose();
 

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -1264,6 +1264,8 @@ namespace Easydict.WinUI
             app._clipboardService?.Dispose();
             app._hotkeyService?.Dispose();
             app._trayIconService?.Dispose();
+            app._ocrTranslateService?.Dispose();
+            app._ocrTranslateService = null;
             FixedWindowService.Instance.Dispose();
             MiniWindowService.Instance.Dispose();
             TextToSpeechService.StopIfInitialized();

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -664,6 +664,15 @@ namespace Easydict.WinUI
         // OcrTranslateService captures DispatcherQueue. Called from all OCR entry points
         // (hotkeys, tray menu, shell context menu signal, browser extension signal,
         // protocol activation).
+        internal static async Task ReleasePpOcrV6ModelAsync(string modelId)
+        {
+            var service = Instance._ocrTranslateService;
+            if (service is not null)
+            {
+                await service.ReleasePpOcrV6ModelAsync(modelId).ConfigureAwait(false);
+            }
+        }
+
         private OcrTranslateService? EnsureOcrTranslateService()
         {
             if (_ocrTranslateService != null) return _ocrTranslateService;

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -67,6 +67,8 @@ namespace Easydict.WinUI
         private SubclassProc? _appWindowSubclassProc;
         private volatile bool _isSystemShutdownRequested;
         private bool _servicesInitialized;
+        private Task? _shutdownCleanupTask;
+        private bool _shutdownCleanupCompleted;
         private static int _pendingRedirectedOcrTranslate;
 
         // IPC: named event for context menu --ocr-translate signaling
@@ -1141,8 +1143,14 @@ namespace Easydict.WinUI
             CrashDiagnostics.Log("[MemoryGate] Root frame released after hiding main window");
         }
 
-        private void OnWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
+        private async void OnWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
         {
+            if (_shutdownCleanupCompleted)
+            {
+                args.Cancel = false;
+                return;
+            }
+
             try
             {
                 SaveWindowDimensions();
@@ -1187,22 +1195,44 @@ namespace Easydict.WinUI
                         ex,
                         isTerminating: false,
                         isHandled: true);
-                    args.Cancel = false;
                 }
-
             }
 
-            args.Cancel = false;
+            args.Cancel = true;
             CrashDiagnostics.Log(
                 $"[WindowClosing] Closing, shutdownRequested={_isSystemShutdownRequested}, memoryAbB={IsMemoryAbVariantB()}");
+
+            if (_shutdownCleanupTask is not null)
+            {
+                return;
+            }
+
             try
             {
-                CleanupServices();
+                _shutdownCleanupTask = CleanupServicesAsync();
+                await _shutdownCleanupTask;
             }
             catch (Exception ex) when (!CrashDiagnostics.IsProcessFatal(ex))
             {
                 CrashDiagnostics.LogException(
                     "App.OnWindowClosing.CleanupServices",
+                    ex,
+                    isTerminating: false,
+                    isHandled: true);
+            }
+            finally
+            {
+                _shutdownCleanupCompleted = true;
+            }
+
+            try
+            {
+                _window?.Close();
+            }
+            catch (COMException ex)
+            {
+                CrashDiagnostics.LogException(
+                    "App.OnWindowClosing.Close",
                     ex,
                     isTerminating: false,
                     isHandled: true);
@@ -1252,43 +1282,70 @@ namespace Easydict.WinUI
             settings.Save();
         }
 
-        public static void CleanupServices()
-        {
-            _ = CleanupServicesAsync();
-        }
 
         public static async Task CleanupServicesAsync()
         {
             var app = Instance;
+            var ocrService = app.BeginCleanupServices();
+            try
+            {
+                if (ocrService is not null)
+                {
+                    // Resume on the UI thread before disposing WinUI windows below.
+                    await ocrService.DisposeAsync();
+                }
+            }
+            finally
+            {
+                app.FinishCleanupServices();
+            }
+        }
 
+        private static void CleanupServicesSynchronously()
+        {
+            var app = Instance;
+            var ocrService = app.BeginCleanupServices();
+            try
+            {
+                // WM_ENDSESSION cannot pump asynchronous continuations. Force-stop
+                // the OCR worker instead of blocking the UI thread on DisposeAsync().
+                ocrService?.Dispose();
+            }
+            finally
+            {
+                app.FinishCleanupServices();
+            }
+        }
+
+        private OcrTranslateService? BeginCleanupServices()
+        {
             // Dispose OCR signal event first — this unblocks the listener thread's WaitOne()
             // which throws ObjectDisposedException, causing the thread to exit gracefully.
-            app._ocrSignalEvent?.Dispose();
-            app._ocrSignalEvent = null;
+            _ocrSignalEvent?.Dispose();
+            _ocrSignalEvent = null;
 
             // Wait briefly for the signal thread to finish to avoid races during teardown
-            if (app._ocrSignalThread?.IsAlive == true)
+            if (_ocrSignalThread?.IsAlive == true)
             {
-                app._ocrSignalThread.Join(TimeSpan.FromSeconds(2));
+                _ocrSignalThread.Join(TimeSpan.FromSeconds(2));
             }
-            app._ocrSignalThread = null;
+            _ocrSignalThread = null;
 
-            app._mouseHookService?.Dispose();
-            app._popButtonService?.Dispose();
-            app._clipboardService?.Dispose();
-            app._hotkeyService?.Dispose();
-            app._trayIconService?.Dispose();
+            _mouseHookService?.Dispose();
+            _popButtonService?.Dispose();
+            _clipboardService?.Dispose();
+            _hotkeyService?.Dispose();
+            _trayIconService?.Dispose();
 
-            var ocrService = Interlocked.Exchange(ref app._ocrTranslateService, null);
-            if (ocrService is not null)
-            {
-                await ocrService.DisposeAsync().ConfigureAwait(false);
-            }
+            return Interlocked.Exchange(ref _ocrTranslateService, null);
+        }
 
+        private void FinishCleanupServices()
+        {
             FixedWindowService.Instance.Dispose();
             MiniWindowService.Instance.Dispose();
             TextToSpeechService.StopIfInitialized();
-            app.UnregisterSystemMessageHandlers();
+            UnregisterSystemMessageHandlers();
         }
 
         /// <summary>
@@ -1508,7 +1565,7 @@ namespace Easydict.WinUI
                         _isSystemShutdownRequested = true;
                         CrashDiagnostics.Log(
                             $"[AppWindow] WM_ENDSESSION confirmed, reasonFlags=0x{unchecked((nuint)lParam):X}");
-                        CleanupServices();
+                        CleanupServicesSynchronously();
                         Environment.Exit(0);
 
                         return 0;

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -664,15 +664,6 @@ namespace Easydict.WinUI
         // OcrTranslateService captures DispatcherQueue. Called from all OCR entry points
         // (hotkeys, tray menu, shell context menu signal, browser extension signal,
         // protocol activation).
-        internal static async Task ReleasePpOcrV6ModelAsync(string modelId)
-        {
-            var service = Instance._ocrTranslateService;
-            if (service is not null)
-            {
-                await service.ReleasePpOcrV6ModelAsync(modelId).ConfigureAwait(false);
-            }
-        }
-
         private OcrTranslateService? EnsureOcrTranslateService()
         {
             if (_ocrTranslateService != null) return _ocrTranslateService;
@@ -688,6 +679,15 @@ namespace Easydict.WinUI
                 System.Diagnostics.Debug.WriteLine($"[App] OcrTranslateService lazy init failed: {ex}");
             }
             return _ocrTranslateService;
+        }
+
+        internal static async Task ReleasePpOcrV6ModelAsync(string modelId)
+        {
+            var service = Instance._ocrTranslateService;
+            if (service is not null)
+            {
+                await service.ReleasePpOcrV6ModelAsync(modelId).ConfigureAwait(false);
+            }
         }
 
         private async void ShowOcrFailureDialog(OcrFailureReason reason)
@@ -1254,6 +1254,11 @@ namespace Easydict.WinUI
 
         public static void CleanupServices()
         {
+            _ = CleanupServicesAsync();
+        }
+
+        public static async Task CleanupServicesAsync()
+        {
             var app = Instance;
 
             // Dispose OCR signal event first — this unblocks the listener thread's WaitOne()
@@ -1273,8 +1278,13 @@ namespace Easydict.WinUI
             app._clipboardService?.Dispose();
             app._hotkeyService?.Dispose();
             app._trayIconService?.Dispose();
-            app._ocrTranslateService?.Dispose();
-            app._ocrTranslateService = null;
+
+            var ocrService = Interlocked.Exchange(ref app._ocrTranslateService, null);
+            if (ocrService is not null)
+            {
+                await ocrService.DisposeAsync().ConfigureAwait(false);
+            }
+
             FixedWindowService.Instance.Dispose();
             MiniWindowService.Instance.Dispose();
             TextToSpeechService.StopIfInitialized();
@@ -1498,7 +1508,7 @@ namespace Easydict.WinUI
                         _isSystemShutdownRequested = true;
                         CrashDiagnostics.Log(
                             $"[AppWindow] WM_ENDSESSION confirmed, reasonFlags=0x{unchecked((nuint)lParam):X}");
-                        _trayIconService?.ExitApplication();
+                        CleanupServices();
                         Environment.Exit(0);
 
                         return 0;

--- a/dotnet/src/Easydict.WinUI/Easydict.WinUI.csproj
+++ b/dotnet/src/Easydict.WinUI/Easydict.WinUI.csproj
@@ -189,6 +189,8 @@
              in CI; otherwise test/release graphs can compile the same worker into the same
              obj path concurrently. Local dev keeps the default worker-copy behavior. -->
         <BuildWorkerOutputs Condition="'$(BuildWorkerOutputs)' == '' and '$(CI)' == 'true'">false</BuildWorkerOutputs>
+        <PublishWorkerOutputs Condition="'$(PublishWorkerOutputs)' == ''">true</PublishWorkerOutputs>
+        <WorkerPublishSelfContained Condition="'$(WorkerPublishSelfContained)' == ''">$(SelfContained)</WorkerPublishSelfContained>
         <!-- Release artifacts always ship the long-document worker, so do not also
              carry the in-process PDF/MuPDF/PdfPig implementation in the host. Debug
              keeps it for local diagnostics and unit-test coverage. Override with
@@ -392,19 +394,66 @@
                                      Condition="'$(Platform)' != '' AND '$(Platform)' != 'AnyCPU'" />
         <_OcrWorkerFilesAnyCpu  Include="..\Easydict.Workers.Ocr\bin\$(Configuration)\net8.0-windows10.0.22621.0\**\*.*"
                                      Condition="'$(Platform)' == '' OR '$(Platform)' == 'AnyCPU'" />
+        <_LongDocWorkerFilesPlatformX64 Include="..\Easydict.Workers.LongDoc\bin\x64\$(Configuration)\net8.0-windows10.0.22621.0\**\*.*"
+                                        Condition="'$(Platform)' == 'x64'" />
+        <_LocalAiWorkerFilesPlatformX64 Include="..\Easydict.Workers.LocalAi\bin\x64\$(Configuration)\net8.0-windows10.0.22621.0\**\*.*"
+                                        Condition="'$(Platform)' == 'x64'" />
+        <_OcrWorkerFilesPlatformX64 Include="..\Easydict.Workers.Ocr\bin\x64\$(Configuration)\net8.0-windows10.0.22621.0\**\*.*"
+                                    Condition="'$(Platform)' == 'x64'" />
       </ItemGroup>
-      <Copy SourceFiles="@(_LongDocWorkerFilesPlatform);@(_LongDocWorkerFilesAnyCpu)"
-            DestinationFiles="@(_LongDocWorkerFilesPlatform->'$(TargetDir)workers\longdoc\%(RecursiveDir)%(Filename)%(Extension)');@(_LongDocWorkerFilesAnyCpu->'$(TargetDir)workers\longdoc\%(RecursiveDir)%(Filename)%(Extension)')"
+      <Copy SourceFiles="@(_LongDocWorkerFilesPlatform);@(_LongDocWorkerFilesAnyCpu);@(_LongDocWorkerFilesPlatformX64)"
+            DestinationFiles="@(_LongDocWorkerFilesPlatform->'$(TargetDir)workers\longdoc\%(RecursiveDir)%(Filename)%(Extension)');@(_LongDocWorkerFilesAnyCpu->'$(TargetDir)workers\longdoc\%(RecursiveDir)%(Filename)%(Extension)');@(_LongDocWorkerFilesPlatformX64->'$(TargetDir)workers\longdoc\%(RecursiveDir)%(Filename)%(Extension)')"
             SkipUnchangedFiles="true"
-            Condition="'@(_LongDocWorkerFilesPlatform)@(_LongDocWorkerFilesAnyCpu)' != ''" />
-      <Copy SourceFiles="@(_LocalAiWorkerFilesPlatform);@(_LocalAiWorkerFilesAnyCpu)"
-            DestinationFiles="@(_LocalAiWorkerFilesPlatform->'$(TargetDir)workers\localai\%(RecursiveDir)%(Filename)%(Extension)');@(_LocalAiWorkerFilesAnyCpu->'$(TargetDir)workers\localai\%(RecursiveDir)%(Filename)%(Extension)')"
+            Condition="'@(_LongDocWorkerFilesPlatform)@(_LongDocWorkerFilesAnyCpu)@(_LongDocWorkerFilesPlatformX64)' != ''" />
+      <Copy SourceFiles="@(_LocalAiWorkerFilesPlatform);@(_LocalAiWorkerFilesAnyCpu);@(_LocalAiWorkerFilesPlatformX64)"
+            DestinationFiles="@(_LocalAiWorkerFilesPlatform->'$(TargetDir)workers\localai\%(RecursiveDir)%(Filename)%(Extension)');@(_LocalAiWorkerFilesAnyCpu->'$(TargetDir)workers\localai\%(RecursiveDir)%(Filename)%(Extension)');@(_LocalAiWorkerFilesPlatformX64->'$(TargetDir)workers\localai\%(RecursiveDir)%(Filename)%(Extension)')"
             SkipUnchangedFiles="true"
-            Condition="'@(_LocalAiWorkerFilesPlatform)@(_LocalAiWorkerFilesAnyCpu)' != ''" />
-      <Copy SourceFiles="@(_OcrWorkerFilesPlatform);@(_OcrWorkerFilesAnyCpu)"
-            DestinationFiles="@(_OcrWorkerFilesPlatform->'$(TargetDir)workers\ocr\%(RecursiveDir)%(Filename)%(Extension)');@(_OcrWorkerFilesAnyCpu->'$(TargetDir)workers\ocr\%(RecursiveDir)%(Filename)%(Extension)')"
+            Condition="'@(_LocalAiWorkerFilesPlatform)@(_LocalAiWorkerFilesAnyCpu)@(_LocalAiWorkerFilesPlatformX64)' != ''" />
+      <Copy SourceFiles="@(_OcrWorkerFilesPlatform);@(_OcrWorkerFilesAnyCpu);@(_OcrWorkerFilesPlatformX64)"
+            DestinationFiles="@(_OcrWorkerFilesPlatform->'$(TargetDir)workers\ocr\%(RecursiveDir)%(Filename)%(Extension)');@(_OcrWorkerFilesAnyCpu->'$(TargetDir)workers\ocr\%(RecursiveDir)%(Filename)%(Extension)');@(_OcrWorkerFilesPlatformX64->'$(TargetDir)workers\ocr\%(RecursiveDir)%(Filename)%(Extension)')"
             SkipUnchangedFiles="true"
-            Condition="'@(_OcrWorkerFilesPlatform)@(_OcrWorkerFilesAnyCpu)' != ''" />
+            Condition="'@(_OcrWorkerFilesPlatform)@(_OcrWorkerFilesAnyCpu)@(_OcrWorkerFilesPlatformX64)' != ''" />
+    </Target>
+
+    <PropertyGroup>
+      <_WorkerRid Condition="'$(RuntimeIdentifier)' != '' and $(RuntimeIdentifier.Contains('win-'))">$(RuntimeIdentifier)</_WorkerRid>
+      <_WorkerRid Condition="'$(_WorkerRid)' == '' and '$(Platform)' == 'x64'">win-x64</_WorkerRid>
+      <_WorkerRid Condition="'$(_WorkerRid)' == '' and '$(Platform)' == 'X64'">win-x64</_WorkerRid>
+      <_WorkerRid Condition="'$(_WorkerRid)' == '' and '$(Platform)' == 'x86'">win-x86</_WorkerRid>
+      <_WorkerRid Condition="'$(_WorkerRid)' == '' and '$(Platform)' == 'X86'">win-x86</_WorkerRid>
+      <_WorkerRid Condition="'$(_WorkerRid)' == '' and ('$(Platform)' == 'ARM64' OR '$(Platform)' == 'arm64' OR '$(Platform)' == 'Arm64')">win-arm64</_WorkerRid>
+      <_WorkerRid Condition="'$(_WorkerRid)' == ''">win-x64</_WorkerRid>
+      <_WorkerPublishArgs Condition="'$(WorkerPublishSelfContained)' == 'true'">--self-contained true</_WorkerPublishArgs>
+      <_WorkerPublishArgs Condition="'$(WorkerPublishSelfContained)' != 'true'">--self-contained false</_WorkerPublishArgs>
+      <_WorkerPublishPlatform Condition="'$(Platform)' != '' AND '$(Platform)' != 'AnyCPU'">$(Platform)</_WorkerPublishPlatform>
+      <_WorkerPublishPlatform Condition="'$(Platform)' == 'AnyCPU' OR '$(Platform)' == ''">x64</_WorkerPublishPlatform>
+      <_WorkerPublishPlatform Condition="'$(_WorkerPublishPlatform)' == 'X64'">x64</_WorkerPublishPlatform>
+      <_WorkerPublishPlatform Condition="'$(_WorkerPublishPlatform)' == 'X86'">x86</_WorkerPublishPlatform>
+      <_WorkerPublishPlatform Condition="'$(_WorkerPublishPlatform)' == 'ARM64' OR '$(_WorkerPublishPlatform)' == 'Arm64'">arm64</_WorkerPublishPlatform>
+    </PropertyGroup>
+
+    <Target Name="PublishWorkerOutputs"
+            AfterTargets="Publish"
+            Condition="'$(PublishWorkerOutputs)' == 'true' AND '$(PublishDir)' != '' AND '$(IsPublishable)' != 'false'">
+      <Message Importance="high" Text="[Workers] Publishing workers to $(PublishDir)workers\ (RID=$(_WorkerRid), SelfContained=$(WorkerPublishSelfContained), Platform=$(_WorkerPublishPlatform))" />
+      <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)..\Easydict.Workers.LongDoc\Easydict.Workers.LongDoc.csproj&quot; --configuration $(Configuration) --runtime $(_WorkerRid) $(_WorkerPublishArgs) --output &quot;$(PublishDir)workers\longdoc&quot; -p:Platform=$(_WorkerPublishPlatform) -p:PublishReadyToRun=false"
+            Condition="Exists('$(MSBuildThisFileDirectory)..\Easydict.Workers.LongDoc\Easydict.Workers.LongDoc.csproj') and '$(_WorkerRid)' != 'win-x86'" />
+      <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)..\Easydict.Workers.LocalAi\Easydict.Workers.LocalAi.csproj&quot; --configuration $(Configuration) --runtime $(_WorkerRid) $(_WorkerPublishArgs) --output &quot;$(PublishDir)workers\localai&quot; -p:Platform=$(_WorkerPublishPlatform) -p:PublishReadyToRun=false"
+            Condition="Exists('$(MSBuildThisFileDirectory)..\Easydict.Workers.LocalAi\Easydict.Workers.LocalAi.csproj') and '$(_WorkerRid)' != 'win-x86'" />
+      <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)..\Easydict.Workers.Ocr\Easydict.Workers.Ocr.csproj&quot; --configuration $(Configuration) --runtime $(_WorkerRid) $(_WorkerPublishArgs) --output &quot;$(PublishDir)workers\ocr&quot; -p:Platform=$(_WorkerPublishPlatform) -p:PublishReadyToRun=false"
+            Condition="Exists('$(MSBuildThisFileDirectory)..\Easydict.Workers.Ocr\Easydict.Workers.Ocr.csproj') and '$(_WorkerRid)' != 'win-x86'" />
+      <Warning Condition="'$(_WorkerRid)' == 'win-x86'" Text="[Workers] win-x86 has no workers (MuPDF.NET/ORT lack stable x86 runtimes). Host will fall back to in-proc paths." />
+    </Target>
+
+    <Target Name="ValidateWorkerPublish"
+            AfterTargets="PublishWorkerOutputs"
+            Condition="'$(PublishWorkerOutputs)' == 'true' AND '$(PublishDir)' != '' AND '$(_WorkerRid)' != 'win-x86'">
+      <Error Condition="!Exists('$(PublishDir)workers\ocr\Easydict.Workers.Ocr.exe')"
+             Text="Worker publish failed: $(PublishDir)workers\ocr\Easydict.Workers.Ocr.exe not found. Check PublishWorkerOutputs. Disable with -p:PublishWorkerOutputs=false if intentional." />
+      <Error Condition="!Exists('$(PublishDir)workers\longdoc\Easydict.Workers.LongDoc.exe')"
+             Text="Worker publish failed: $(PublishDir)workers\longdoc\Easydict.Workers.LongDoc.exe not found." />
+      <Error Condition="!Exists('$(PublishDir)workers\localai\Easydict.Workers.LocalAi.exe')"
+             Text="Worker publish failed: $(PublishDir)workers\localai\Easydict.Workers.LocalAi.exe not found." />
     </Target>
 
     <!-- FlaUI for proper UI Automation text selection -->

--- a/dotnet/src/Easydict.WinUI/Easydict.WinUI.csproj
+++ b/dotnet/src/Easydict.WinUI/Easydict.WinUI.csproj
@@ -1,23 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-    <!-- Workaround for `Payload contains two or more files with the same destination path 'onnxruntime.dll'`.
-         Both Intel.ML.OnnxRuntime.OpenVino 1.21.0 (referenced via Easydict.OpenVINO, needed for the
-         OpenVINO EP that targets NPU) and Microsoft.Windows.AI.MachineLearning 2.0.300 (transitive
-         from Microsoft.WindowsAppSDK 2.x — Windows ML's own ORT build with DirectML EP) ship
-         runtimes/win-x64/native/onnxruntime.dll. AppX packaging refuses the duplicate destination.
-         We keep the Intel-shipped runtime (it has the OpenVINO EP we actually use) and drop the
-         Microsoft.Windows.AI.MachineLearning native asset via a sweep across every collection the
-         publish / AppX pipeline pulls files from. -->
+    <!-- Workaround for duplicate runtimes/win-x64/native/onnxruntime.dll.
+
+         Root cause: WinUI references out-of-process worker executables via
+         ProjectReference (ReferenceOutputAssembly=false). Even with that flag,
+         their PackageReference closures flow transitively into WinUI's
+         project.assets.json and then into the WinUI publish graph:
+
+           Easydict.Workers.Ocr      -> Microsoft.ML.OnnxRuntime.DirectML 1.21.0
+           Easydict.Workers.LocalAi  -> Microsoft.ML.OnnxRuntime 1.21.0
+           Microsoft.WindowsAppSDK   -> Microsoft.Windows.AI.MachineLearning 2.0.300  (ORT+DirectML build)
+
+         All three ship runtimes/win-x64/native/onnxruntime.dll at the same
+         RelativePath, and the SDK's _HandleFileConflictsForPublish
+         (CheckForDuplicateItemMetadata on ResolvedFileToPublish.RelativePath)
+         trips NETSDK1152.
+
+         Workers publish independently into workers/{kind}/ via the Makefile
+         and the host loads ONNX only from the downloaded runtime dir or from
+         the worker process — WinUI itself never needs a bundled onnxruntime.dll.
+         So we collapse the duplicates to a single winner.
+
+         Why two targets: ComputeFilesToPublish *creates* ResolvedFileToPublish,
+         so a single target cannot both run before it (to handle
+         ReferenceCopyLocalPaths etc) and after it (to handle
+         ResolvedFileToPublish). DedupeOnnxRuntime runs before publish
+         materialization; DedupeOnnxRuntimeForPublish runs right between
+         ComputeFilesToPublish and _HandleFileConflictsForPublish. -->
     <Target Name="DedupeOnnxRuntime"
             AfterTargets="ResolveAssemblyReferences;ResolvePackageAssets;ResolveRuntimePackAssets;_ResolveCopyLocalAssetsForRuntimeDependencies"
             BeforeTargets="_CopyFilesMarkedCopyLocal;ComputeFilesToPublish;_ComputeResolvedFilesToPublishTypes;_GetPackagingOutputs;GenerateAppxPackageRecipe">
         <ItemGroup>
             <ReferenceCopyLocalPaths
                 Remove="@(ReferenceCopyLocalPaths)"
-                Condition="'%(Filename)%(Extension)' == 'onnxruntime.dll' AND
-                           $([System.String]::Copy('%(FullPath)').ToLowerInvariant().Contains('microsoft.windows.ai.machinelearning'))" />
-            <ResolvedFileToPublish
-                Remove="@(ResolvedFileToPublish)"
                 Condition="'%(Filename)%(Extension)' == 'onnxruntime.dll' AND
                            $([System.String]::Copy('%(FullPath)').ToLowerInvariant().Contains('microsoft.windows.ai.machinelearning'))" />
             <RuntimeCopyLocalItems
@@ -40,6 +55,30 @@
                 Remove="@(PackagingOutputs)"
                 Condition="'%(Filename)%(Extension)' == 'onnxruntime.dll' AND
                            $([System.String]::Copy('%(FullPath)').ToLowerInvariant().Contains('microsoft.windows.ai.machinelearning'))" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="DedupeOnnxRuntimeForPublish"
+            AfterTargets="ComputeFilesToPublish"
+            BeforeTargets="_HandleFileConflictsForPublish">
+        <ItemGroup>
+            <_OnnxDupe Include="@(ResolvedFileToPublish)"
+                       Condition="'%(Filename)%(Extension)' == 'onnxruntime.dll'" />
+            <_OnnxWinner Include="@(_OnnxDupe)" Condition="'%(_OnnxDupe.Identity)' != ''" />
+        </ItemGroup>
+        <PropertyGroup>
+            <_OnnxWinnerFullPath Condition="'@(_OnnxWinner)' != ''">%(_OnnxWinner.FullPath)</_OnnxWinnerFullPath>
+            <_OnnxWinnerFullPath Condition="'@(_OnnxWinner)' != ''">$([System.IO.Path]::GetFullPath('$(_OnnxWinnerFullPath)'))</_OnnxWinnerFullPath>
+        </PropertyGroup>
+        <ItemGroup Condition="'@(_OnnxWinner)' != ''">
+            <ResolvedFileToPublish
+                Remove="@(ResolvedFileToPublish)"
+                Condition="'%(Filename)%(Extension)' == 'onnxruntime.dll' AND
+                           $([System.String]::Copy('%(FullPath)').ToLowerInvariant()) != $([System.String]::Copy('$(_OnnxWinnerFullPath)').ToLowerInvariant())" />
+            <_ResolvedCopyLocalPublishAssets
+                Remove="@(_ResolvedCopyLocalPublishAssets)"
+                Condition="'%(Filename)%(Extension)' == 'onnxruntime.dll' AND
+                           $([System.String]::Copy('%(FullPath)').ToLowerInvariant()) != $([System.String]::Copy('$(_OnnxWinnerFullPath)').ToLowerInvariant())" />
         </ItemGroup>
     </Target>
 

--- a/dotnet/src/Easydict.WinUI/Models/OcrEngineType.cs
+++ b/dotnet/src/Easydict.WinUI/Models/OcrEngineType.cs
@@ -18,5 +18,10 @@ public enum OcrEngineType
     /// <summary>
     /// Use a custom OpenAI-compatible vision API.
     /// </summary>
-    CustomApi = 2
+    CustomApi = 2,
+
+    /// <summary>
+    /// Use the local PP-OCRv6 ONNX pipeline.
+    /// </summary>
+    PpOcrV6 = 3
 }

--- a/dotnet/src/Easydict.WinUI/Models/OcrResult.cs
+++ b/dotnet/src/Easydict.WinUI/Models/OcrResult.cs
@@ -34,6 +34,8 @@ public record OcrLine
 {
     public string Text { get; init; } = string.Empty;
 
+    public float? Confidence { get; init; }
+
     /// <summary>
     /// Bounding rectangle in physical pixels relative to the source image.
     /// </summary>

--- a/dotnet/src/Easydict.WinUI/Services/ModelDownloadClient.cs
+++ b/dotnet/src/Easydict.WinUI/Services/ModelDownloadClient.cs
@@ -23,10 +23,12 @@ public sealed class ModelDownloadClient : IDisposable
     private static readonly TimeSpan SourceProbeTimeout = TimeSpan.FromSeconds(5);
 
     private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
     private bool _disposed;
 
     public ModelDownloadClient(HttpClient? httpClient = null)
     {
+        _ownsHttpClient = httpClient is null;
         _httpClient = httpClient ?? CreateProxyAwareHttpClient();
     }
 
@@ -225,6 +227,9 @@ public sealed class ModelDownloadClient : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        _httpClient.Dispose();
+        if (_ownsHttpClient)
+        {
+            _httpClient.Dispose();
+        }
     }
 }

--- a/dotnet/src/Easydict.WinUI/Services/OcrServiceFactory.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrServiceFactory.cs
@@ -32,11 +32,17 @@ public static class OcrServiceFactory
         var resolved = options ?? OcrServiceOptions.FromSettings(SettingsService.Instance);
         var client = httpClient ?? GetSharedHttpClient(SettingsService.Instance);
 
-        if (SettingsService.Instance.UseOcrWorker && resolved.Engine == OcrEngineType.WindowsNative)
+        if (resolved.Engine == OcrEngineType.PpOcrV6
+            || (SettingsService.Instance.UseOcrWorker && resolved.Engine == OcrEngineType.WindowsNative))
         {
             return new Workers.OcrWorkerClient(
                 SettingsService.Instance,
-                CreateInProc(resolved, client));
+                new WindowsOcrService(),
+                resolved.Engine,
+                resolved.Model,
+                SettingsService.Instance.PpOcrV6ThreadCount,
+                SettingsService.Instance.PpOcrV6AllowFallback,
+                SettingsService.Instance.PpOcrV6UseGpu);
         }
 
         return CreateInProc(resolved, client);

--- a/dotnet/src/Easydict.WinUI/Services/OcrServiceFactory.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrServiceFactory.cs
@@ -26,7 +26,7 @@ public static class OcrServiceFactory
     /// Optional shared <see cref="HttpClient"/> for API-based engines.
     /// If null, a shared client with a 3-minute timeout is used.
     /// </param>
-    /// <returns>An <see cref="IOcrService"/> ready to recognize text.</returns>
+    /// <returns>An <see cref="IOcrService"/> ready to recognize text. The caller owns the returned service.</returns>
     public static IOcrService Create(OcrServiceOptions? options = null, HttpClient? httpClient = null)
     {
         var resolved = options ?? OcrServiceOptions.FromSettings(SettingsService.Instance);

--- a/dotnet/src/Easydict.WinUI/Services/OcrServiceFactory.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrServiceFactory.cs
@@ -30,7 +30,6 @@ public static class OcrServiceFactory
     public static IOcrService Create(OcrServiceOptions? options = null, HttpClient? httpClient = null)
     {
         var resolved = options ?? OcrServiceOptions.FromSettings(SettingsService.Instance);
-        var client = httpClient ?? GetSharedHttpClient(SettingsService.Instance);
 
         if (resolved.Engine == OcrEngineType.PpOcrV6
             || (SettingsService.Instance.UseOcrWorker && resolved.Engine == OcrEngineType.WindowsNative))
@@ -45,18 +44,20 @@ public static class OcrServiceFactory
                 SettingsService.Instance.PpOcrV6UseGpu);
         }
 
-        return CreateInProc(resolved, client);
+        return CreateInProc(resolved, httpClient);
     }
 
     internal static IOcrService CreateInProc(OcrServiceOptions resolved, HttpClient? httpClient = null)
     {
-        var client = httpClient ?? GetSharedHttpClient(SettingsService.Instance);
-        return resolved.Engine switch
+        if (resolved.Engine is not (OcrEngineType.Ollama or OcrEngineType.CustomApi))
         {
-            OcrEngineType.Ollama => new OllamaOcrService(client, resolved),
-            OcrEngineType.CustomApi => new CustomApiOcrService(client, resolved),
-            _ => new WindowsOcrService()
-        };
+            return new WindowsOcrService();
+        }
+
+        var client = httpClient ?? GetSharedHttpClient(SettingsService.Instance);
+        return resolved.Engine == OcrEngineType.Ollama
+            ? new OllamaOcrService(client, resolved)
+            : new CustomApiOcrService(client, resolved);
     }
 
     internal static HttpClient CreateProxyAwareHttpClient(

--- a/dotnet/src/Easydict.WinUI/Services/OcrServiceOptions.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrServiceOptions.cs
@@ -76,7 +76,9 @@ public sealed record OcrServiceOptions
             settings.OcrEngine,
             settings.OcrApiKey,
             settings.OcrEndpoint,
-            settings.OcrModel,
+            settings.OcrEngine == OcrEngineType.PpOcrV6
+                ? settings.PpOcrV6ModelId
+                : settings.OcrModel,
             settings.OcrSystemPrompt,
             settings.OcrEnableThinking);
     }

--- a/dotnet/src/Easydict.WinUI/Services/OcrServiceOptions.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrServiceOptions.cs
@@ -89,12 +89,14 @@ public sealed record OcrServiceOptions
     public static string GetDefaultEndpoint(OcrEngineType engine) => engine switch
     {
         OcrEngineType.CustomApi => DefaultCustomApiEndpoint,
+        OcrEngineType.PpOcrV6 => string.Empty,
         _ => DefaultOllamaEndpoint,
     };
 
     public static string GetDefaultModel(OcrEngineType engine) => engine switch
     {
         OcrEngineType.CustomApi => DefaultCustomApiModel,
+        OcrEngineType.PpOcrV6 => Easydict.SidecarClient.Protocol.PpOcrV6ModelCatalog.SmallId,
         _ => DefaultOllamaModel,
     };
 
@@ -111,7 +113,10 @@ public sealed record OcrServiceOptions
         var normalized = model?.Trim();
         return string.IsNullOrWhiteSpace(normalized) ||
                string.Equals(normalized, DefaultOllamaModel, StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(normalized, DefaultCustomApiModel, StringComparison.OrdinalIgnoreCase);
+               string.Equals(normalized, DefaultCustomApiModel, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(normalized, Easydict.SidecarClient.Protocol.PpOcrV6ModelCatalog.TinyId, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(normalized, Easydict.SidecarClient.Protocol.PpOcrV6ModelCatalog.SmallId, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(normalized, Easydict.SidecarClient.Protocol.PpOcrV6ModelCatalog.MediumId, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? NormalizeOptional(string? value)

--- a/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
@@ -217,6 +217,36 @@ public sealed class OcrTranslateService : IDisposable
         return _ppOcrV6Client;
     }
 
+    internal async Task ReleasePpOcrV6ModelAsync(string modelId)
+    {
+        if (_ppOcrV6ClientKey?.ModelId != modelId)
+        {
+            return;
+        }
+
+        try
+        {
+            _currentCts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        if (!await _ocrPipelineLock.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false))
+        {
+            throw new IOException("PP-OCRv6 is busy and could not be released safely.");
+        }
+
+        try
+        {
+            DisposePpOcrV6Client();
+        }
+        finally
+        {
+            _ocrPipelineLock.Release();
+        }
+    }
+
     private void DisposePpOcrV6Client()
     {
         _ppOcrV6Client?.Dispose();

--- a/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using Easydict.WinUI.Models;
+using Easydict.WinUI.Services.Workers;
 using Microsoft.UI.Dispatching;
 
 namespace Easydict.WinUI.Services;
@@ -22,6 +24,9 @@ public sealed class OcrTranslateService
     private readonly ScreenCaptureService _captureService = new();
     private readonly DispatcherQueue _dispatcherQueue;
     private readonly Action<OcrFailureReason>? _failureReporter;
+    private OcrWorkerClient? _ppOcrV6Client;
+    private PpOcrV6ClientKey? _ppOcrV6ClientKey;
+    private readonly SemaphoreSlim _ocrPipelineLock = new(1, 1);
     // Concurrency guard: only one OCR operation can run at a time.
     // Owned by RunOcrPipelineAsync — only that method creates and disposes.
     // Other code may Cancel() but must NOT Dispose().
@@ -94,6 +99,7 @@ public sealed class OcrTranslateService
     {
         using var cts = new CancellationTokenSource();
         var previousCts = Interlocked.Exchange(ref _currentCts, cts);
+        var pipelineLockAcquired = false;
         try
         {
             CancelPreviousOperation(previousCts);
@@ -101,12 +107,14 @@ public sealed class OcrTranslateService
             if (capture is null) return null;
 
             cts.Token.ThrowIfCancellationRequested();
+            await _ocrPipelineLock.WaitAsync(cts.Token).ConfigureAwait(false);
+            pipelineLockAcquired = true;
 
             using (capture)
             {
                 var ocrOptions = OcrServiceOptions.FromSettings(SettingsService.Instance);
                 LogOcrDiagnostics(label, ocrOptions);
-                var ocrEngine = OcrServiceFactory.Create(ocrOptions);
+                var ocrEngine = GetOcrEngine(ocrOptions);
                 if (!ocrEngine.IsAvailable)
                 {
                     var message = $"[OcrTranslate] {label} OCR engine unavailable";
@@ -164,9 +172,63 @@ public sealed class OcrTranslateService
         }
         finally
         {
+            if (pipelineLockAcquired)
+            {
+                _ocrPipelineLock.Release();
+            }
             Interlocked.CompareExchange(ref _currentCts, null, cts);
         }
     }
+
+    private IOcrService GetOcrEngine(OcrServiceOptions options)
+    {
+        if (options.Engine != OcrEngineType.PpOcrV6)
+        {
+            DisposePpOcrV6Client();
+            return OcrServiceFactory.Create(options);
+        }
+
+        var settings = SettingsService.Instance;
+        var key = new PpOcrV6ClientKey(
+            options.Model,
+            Math.Clamp(settings.PpOcrV6ThreadCount, 1, 16),
+            settings.PpOcrV6UseGpu,
+            settings.PpOcrV6AllowFallback);
+        if (_ppOcrV6Client is null || _ppOcrV6ClientKey != key)
+        {
+            DisposePpOcrV6Client();
+            _ppOcrV6Client = new OcrWorkerClient(
+                settings,
+                new WindowsOcrService(),
+                OcrEngineType.PpOcrV6,
+                options.Model,
+                key.ThreadCount,
+                key.AllowFallback,
+                key.UseGpu);
+            _ppOcrV6ClientKey = key;
+        }
+
+        return _ppOcrV6Client;
+    }
+
+    private void DisposePpOcrV6Client()
+    {
+        _ppOcrV6Client?.Dispose();
+        _ppOcrV6Client = null;
+        _ppOcrV6ClientKey = null;
+    }
+
+    public void Dispose()
+    {
+        DisposePpOcrV6Client();
+        _ocrPipelineLock.Dispose();
+    }
+
+    private readonly record struct PpOcrV6ClientKey(
+        string ModelId,
+        int ThreadCount,
+        bool UseGpu,
+        bool AllowFallback);
 
     internal static void CancelPreviousOperation(CancellationTokenSource? previousCts)
     {

--- a/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
@@ -20,7 +20,7 @@ internal enum OcrFailureReason
 /// Orchestrates the OCR translation flow: Screenshot → OCR → Translate.
 /// All operations are asynchronous and non-blocking to the UI thread.
 /// </summary>
-public sealed class OcrTranslateService : IDisposable
+public sealed class OcrTranslateService : IDisposable, IAsyncDisposable
 {
     private bool _disposed;
     private readonly ScreenCaptureService _captureService = new();
@@ -116,31 +116,41 @@ public sealed class OcrTranslateService : IDisposable
             {
                 var ocrOptions = OcrServiceOptions.FromSettings(SettingsService.Instance);
                 LogOcrDiagnostics(label, ocrOptions);
-                var ocrEngine = GetOcrEngine(ocrOptions);
-                if (!ocrEngine.IsAvailable)
+                var (ocrEngine, ownedByCaller) = await GetOcrEngineAsync(ocrOptions).ConfigureAwait(false);
+                try
                 {
-                    var message = $"[OcrTranslate] {label} OCR engine unavailable";
-                    Debug.WriteLine(message);
-                    CrashDiagnostics.Log(message);
-                    ReportFailure(OcrFailureReason.EngineUnavailable);
-                    return null;
+                    if (!ocrEngine.IsAvailable)
+                    {
+                        var message = $"[OcrTranslate] {label} OCR engine unavailable";
+                        Debug.WriteLine(message);
+                        CrashDiagnostics.Log(message);
+                        ReportFailure(OcrFailureReason.EngineUnavailable);
+                        return null;
+                    }
+
+                    var preferredLanguage = GetPreferredOcrLanguage();
+                    var ocrResult = await ocrEngine.RecognizeAsync(
+                        capture, preferredLanguage, cts.Token).ConfigureAwait(false);
+
+                    cts.Token.ThrowIfCancellationRequested();
+
+                    if (string.IsNullOrWhiteSpace(ocrResult.Text))
+                    {
+                        Debug.WriteLine($"[OcrTranslate] No text recognized ({label})");
+                        ReportFailure(OcrFailureReason.NoTextRecognized);
+                        return null;
+                    }
+
+                    Debug.WriteLine($"[OcrTranslate] {label}: {ocrResult.Text.Length} chars recognized");
+                    return ocrResult.Text;
                 }
-
-                var preferredLanguage = GetPreferredOcrLanguage();
-                var ocrResult = await ocrEngine.RecognizeAsync(
-                    capture, preferredLanguage, cts.Token).ConfigureAwait(false);
-
-                cts.Token.ThrowIfCancellationRequested();
-
-                if (string.IsNullOrWhiteSpace(ocrResult.Text))
+                finally
                 {
-                    Debug.WriteLine($"[OcrTranslate] No text recognized ({label})");
-                    ReportFailure(OcrFailureReason.NoTextRecognized);
-                    return null;
+                    if (ownedByCaller)
+                    {
+                        await DisposeAsync(ocrEngine).ConfigureAwait(false);
+                    }
                 }
-
-                Debug.WriteLine($"[OcrTranslate] {label}: {ocrResult.Text.Length} chars recognized");
-                return ocrResult.Text;
             }
         }
         catch (TimeoutException ex)
@@ -182,13 +192,13 @@ public sealed class OcrTranslateService : IDisposable
         }
     }
 
-    private IOcrService GetOcrEngine(OcrServiceOptions options)
+    private async Task<(IOcrService Engine, bool OwnedByCaller)> GetOcrEngineAsync(OcrServiceOptions options)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (options.Engine != OcrEngineType.PpOcrV6)
         {
-            DisposePpOcrV6Client();
-            return OcrServiceFactory.Create(options);
+            await DisposePpOcrV6ClientAsync().ConfigureAwait(false);
+            return (OcrServiceFactory.Create(options), true);
         }
 
         var settings = SettingsService.Instance;
@@ -202,7 +212,7 @@ public sealed class OcrTranslateService : IDisposable
             settings.PpOcrV6AllowFallback);
         if (_ppOcrV6Client is null || _ppOcrV6ClientKey != key)
         {
-            DisposePpOcrV6Client();
+            await DisposePpOcrV6ClientAsync().ConfigureAwait(false);
             _ppOcrV6Client = new OcrWorkerClient(
                 settings,
                 new WindowsOcrService(),
@@ -214,12 +224,24 @@ public sealed class OcrTranslateService : IDisposable
             _ppOcrV6ClientKey = key;
         }
 
-        return _ppOcrV6Client;
+        return (_ppOcrV6Client, false);
+    }
+
+    private static async ValueTask DisposeAsync(IOcrService service)
+    {
+        if (service is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            (service as IDisposable)?.Dispose();
+        }
     }
 
     internal async Task ReleasePpOcrV6ModelAsync(string modelId)
     {
-        if (_ppOcrV6ClientKey?.ModelId != modelId)
+        if (_disposed || _ppOcrV6ClientKey?.ModelId != modelId)
         {
             return;
         }
@@ -239,7 +261,7 @@ public sealed class OcrTranslateService : IDisposable
 
         try
         {
-            DisposePpOcrV6Client();
+            await DisposePpOcrV6ClientAsync().ConfigureAwait(false);
         }
         finally
         {
@@ -252,6 +274,16 @@ public sealed class OcrTranslateService : IDisposable
         _ppOcrV6Client?.Dispose();
         _ppOcrV6Client = null;
         _ppOcrV6ClientKey = null;
+    }
+
+    private async ValueTask DisposePpOcrV6ClientAsync()
+    {
+        var client = Interlocked.Exchange(ref _ppOcrV6Client, null);
+        _ppOcrV6ClientKey = null;
+        if (client is not null)
+        {
+            await client.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     public void Dispose()
@@ -271,22 +303,35 @@ public sealed class OcrTranslateService : IDisposable
         {
         }
 
-        if (_ocrPipelineLock.Wait(TimeSpan.FromSeconds(5)))
-        {
-            try
-            {
-                DisposePpOcrV6Client();
-            }
-            finally
-            {
-                _ocrPipelineLock.Release();
-                _ocrPipelineLock.Dispose();
-            }
+        DisposePpOcrV6Client();
+    }
 
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
             return;
         }
 
-        DisposePpOcrV6Client();
+        _disposed = true;
+        var cts = Interlocked.Exchange(ref _currentCts, null);
+        try
+        {
+            cts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        await _ocrPipelineLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await DisposePpOcrV6ClientAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _ocrPipelineLock.Release();
+        }
     }
 
     private readonly record struct PpOcrV6ClientKey(

--- a/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/OcrTranslateService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Easydict.SidecarClient.Protocol;
 using Easydict.WinUI.Models;
 using Easydict.WinUI.Services.Workers;
 using Microsoft.UI.Dispatching;
@@ -19,8 +20,9 @@ internal enum OcrFailureReason
 /// Orchestrates the OCR translation flow: Screenshot → OCR → Translate.
 /// All operations are asynchronous and non-blocking to the UI thread.
 /// </summary>
-public sealed class OcrTranslateService
+public sealed class OcrTranslateService : IDisposable
 {
+    private bool _disposed;
     private readonly ScreenCaptureService _captureService = new();
     private readonly DispatcherQueue _dispatcherQueue;
     private readonly Action<OcrFailureReason>? _failureReporter;
@@ -182,6 +184,7 @@ public sealed class OcrTranslateService
 
     private IOcrService GetOcrEngine(OcrServiceOptions options)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         if (options.Engine != OcrEngineType.PpOcrV6)
         {
             DisposePpOcrV6Client();
@@ -191,7 +194,10 @@ public sealed class OcrTranslateService
         var settings = SettingsService.Instance;
         var key = new PpOcrV6ClientKey(
             options.Model,
-            Math.Clamp(settings.PpOcrV6ThreadCount, 1, 16),
+            Math.Clamp(
+                settings.PpOcrV6ThreadCount,
+                PpOcrV6ModelCatalog.MinThreadCount,
+                PpOcrV6ModelCatalog.MaxThreadCount),
             settings.PpOcrV6UseGpu,
             settings.PpOcrV6AllowFallback);
         if (_ppOcrV6Client is null || _ppOcrV6ClientKey != key)
@@ -220,8 +226,37 @@ public sealed class OcrTranslateService
 
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        var cts = Interlocked.Exchange(ref _currentCts, null);
+        try
+        {
+            cts?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        if (_ocrPipelineLock.Wait(TimeSpan.FromSeconds(5)))
+        {
+            try
+            {
+                DisposePpOcrV6Client();
+            }
+            finally
+            {
+                _ocrPipelineLock.Release();
+                _ocrPipelineLock.Dispose();
+            }
+
+            return;
+        }
+
         DisposePpOcrV6Client();
-        _ocrPipelineLock.Dispose();
     }
 
     private readonly record struct PpOcrV6ClientKey(
@@ -270,7 +305,15 @@ public sealed class OcrTranslateService
     /// </summary>
     public IReadOnlyList<Models.OcrLanguage> GetAvailableLanguages()
     {
-        return OcrServiceFactory.Create().GetAvailableLanguages();
+        var service = OcrServiceFactory.Create();
+        try
+        {
+            return service.GetAvailableLanguages();
+        }
+        finally
+        {
+            (service as IDisposable)?.Dispose();
+        }
     }
 
     private static string? GetPreferredOcrLanguage()

--- a/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
@@ -37,11 +37,11 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
         var model = PpOcrV6ModelCatalog.Get(modelId);
         var lockKey = Path.Combine(_store.RootDirectory, model.Id);
         var downloadLock = DownloadLocks.GetOrAdd(lockKey, static _ => new SemaphoreSlim(1, 1));
-        await downloadLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         var stagingDirectory = Path.Combine(
             _store.RootDirectory,
             $".{model.Id}.{Guid.NewGuid():N}.staging");
         string? publishedDirectory = null;
+        await downloadLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {

--- a/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
@@ -1,0 +1,188 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using Easydict.SidecarClient.Protocol;
+
+namespace Easydict.WinUI.Services;
+
+public sealed record PpOcrV6DownloadProgress(
+    string FileName,
+    long BytesDownloaded,
+    long TotalBytes,
+    double Percentage);
+
+public sealed class PpOcrV6ModelDownloadService : IDisposable
+{
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> DownloadLocks = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ModelDownloadClient _client;
+    private readonly PpOcrV6ModelStore _store;
+    private bool _disposed;
+
+    public PpOcrV6ModelDownloadService(
+        HttpClient? httpClient = null,
+        PpOcrV6ModelStore? store = null)
+    {
+        _client = new ModelDownloadClient(httpClient);
+        _store = store ?? new PpOcrV6ModelStore();
+    }
+
+    public PpOcrV6ModelStore Store => _store;
+
+    public async Task<PpOcrV6ModelState> DownloadAsync(
+        string modelId,
+        IProgress<PpOcrV6DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var model = PpOcrV6ModelCatalog.Get(modelId);
+        var lockKey = Path.Combine(_store.RootDirectory, model.Id);
+        var downloadLock = DownloadLocks.GetOrAdd(lockKey, static _ => new SemaphoreSlim(1, 1));
+        await downloadLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var stagingDirectory = Path.Combine(
+            _store.RootDirectory,
+            $".{model.Id}.{Guid.NewGuid():N}.staging");
+        string? publishedDirectory = null;
+
+        try
+        {
+            if (await _store.ValidateAsync(model.Id, cancellationToken).ConfigureAwait(false)
+                == PpOcrV6ModelState.Installed)
+            {
+                return PpOcrV6ModelState.Installed;
+            }
+
+            Directory.CreateDirectory(stagingDirectory);
+            long completedBytes = 0;
+            foreach (var artifact in model.Artifacts)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var targetPath = Path.Combine(stagingDirectory, artifact.FileName);
+                var stage = $"PP-OCRv6 {model.Id} {artifact.FileName}";
+                var artifactProgress = new Progress<ModelDownloadProgress>(value =>
+                {
+                    progress?.Report(new PpOcrV6DownloadProgress(
+                        artifact.FileName,
+                        completedBytes + Math.Max(0, value.BytesDownloaded),
+                        model.DownloadSizeBytes,
+                        model.DownloadSizeBytes > 0
+                            ? (completedBytes + Math.Max(0, value.BytesDownloaded)) * 100.0 / model.DownloadSizeBytes
+                            : -1));
+                });
+
+                await _client.DownloadWithRetryAsync(
+                    [artifact.Url],
+                    targetPath,
+                    stage,
+                    artifactProgress,
+                    cancellationToken).ConfigureAwait(false);
+                await ValidateArtifactAsync(artifact, targetPath, cancellationToken)
+                    .ConfigureAwait(false);
+                completedBytes += artifact.SizeBytes;
+            }
+
+            var finalPaths = _store.GetPaths(model.Id);
+            publishedDirectory = $"{finalPaths.Directory}.{Guid.NewGuid():N}.published";
+            Directory.CreateDirectory(publishedDirectory);
+            foreach (var artifact in model.Artifacts)
+            {
+                File.Move(
+                    Path.Combine(stagingDirectory, artifact.FileName),
+                    Path.Combine(publishedDirectory, artifact.FileName),
+                    overwrite: true);
+            }
+
+            await File.WriteAllTextAsync(
+                Path.Combine(publishedDirectory, PpOcrV6ModelStore.CompletionSentinelName),
+                $"{model.Id}{Environment.NewLine}{DateTimeOffset.UtcNow:O}",
+                cancellationToken).ConfigureAwait(false);
+
+            var backupDirectory = $"{finalPaths.Directory}.{Guid.NewGuid():N}.backup";
+            var oldDirectoryMoved = false;
+            try
+            {
+                if (Directory.Exists(finalPaths.Directory))
+                {
+                    Directory.Move(finalPaths.Directory, backupDirectory);
+                    oldDirectoryMoved = true;
+                }
+
+                Directory.Move(publishedDirectory, finalPaths.Directory);
+                if (oldDirectoryMoved)
+                {
+                    TryDeleteDirectory(backupDirectory);
+                }
+            }
+            catch
+            {
+                TryDeleteDirectory(finalPaths.Directory);
+                if (oldDirectoryMoved && Directory.Exists(backupDirectory))
+                {
+                    Directory.Move(backupDirectory, finalPaths.Directory);
+                }
+                throw;
+            }
+
+            return await _store.ValidateAsync(model.Id, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            TryDeleteDirectory(stagingDirectory);
+            if (publishedDirectory is not null)
+            {
+                TryDeleteDirectory(publishedDirectory);
+            }
+            downloadLock.Release();
+        }
+    }
+
+    private static async Task ValidateArtifactAsync(
+        PpOcrV6Artifact artifact,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        var fileInfo = new FileInfo(path);
+        if (fileInfo.Length != artifact.SizeBytes)
+        {
+            throw new InvalidDataException(
+                $"Unexpected size for {artifact.FileName}: expected {artifact.SizeBytes}, got {fileInfo.Length}.");
+        }
+
+        await using var stream = File.OpenRead(path);
+        using var sha = SHA256.Create();
+        var actualHash = Convert.ToHexString(
+            await sha.ComputeHashAsync(stream, cancellationToken)).ToLowerInvariant();
+        if (!string.Equals(actualHash, artifact.Sha256, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"SHA-256 mismatch for {artifact.FileName}: expected {artifact.Sha256}, got {actualHash}.");
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _client.Dispose();
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
@@ -98,6 +98,7 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
 
             var backupDirectory = $"{finalPaths.Directory}.{Guid.NewGuid():N}.backup";
             var oldDirectoryMoved = false;
+            var publishedDirectoryMoved = false;
             try
             {
                 if (Directory.Exists(finalPaths.Directory))
@@ -107,6 +108,7 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
                 }
 
                 Directory.Move(publishedDirectory, finalPaths.Directory);
+                publishedDirectoryMoved = true;
                 if (oldDirectoryMoved)
                 {
                     TryDeleteDirectory(backupDirectory);
@@ -114,11 +116,21 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
             }
             catch
             {
-                TryDeleteDirectory(finalPaths.Directory);
+                if (publishedDirectoryMoved)
+                {
+                    TryDeleteDirectory(finalPaths.Directory);
+                }
+
                 if (oldDirectoryMoved && Directory.Exists(backupDirectory))
                 {
+                    if (Directory.Exists(finalPaths.Directory))
+                    {
+                        TryDeleteDirectory(finalPaths.Directory);
+                    }
+
                     Directory.Move(backupDirectory, finalPaths.Directory);
                 }
+
                 throw;
             }
 

--- a/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
@@ -147,6 +147,30 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
         }
     }
 
+    public async Task RemoveAsync(
+        string modelId,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var model = PpOcrV6ModelCatalog.Get(modelId);
+        var lockKey = Path.Combine(_store.RootDirectory, model.Id);
+        var downloadLock = DownloadLocks.GetOrAdd(lockKey, static _ => new SemaphoreSlim(1, 1));
+        await downloadLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var paths = _store.GetPaths(model.Id);
+            if (Directory.Exists(paths.Directory))
+            {
+                Directory.Delete(paths.Directory, recursive: true);
+            }
+        }
+        finally
+        {
+            downloadLock.Release();
+        }
+    }
+
     private static async Task ValidateArtifactAsync(
         PpOcrV6Artifact artifact,
         string path,

--- a/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/PpOcrV6ModelDownloadService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Security.Cryptography;
 using Easydict.SidecarClient.Protocol;
 
 namespace Easydict.WinUI.Services;
@@ -45,8 +44,7 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
 
         try
         {
-            if (await _store.ValidateAsync(model.Id, cancellationToken).ConfigureAwait(false)
-                == PpOcrV6ModelState.Installed)
+            if (_store.GetStateBySize(model.Id) == PpOcrV6ModelState.Installed)
             {
                 return PpOcrV6ModelState.Installed;
             }
@@ -75,8 +73,12 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
                     stage,
                     artifactProgress,
                     cancellationToken).ConfigureAwait(false);
-                await ValidateArtifactAsync(artifact, targetPath, cancellationToken)
-                    .ConfigureAwait(false);
+                var downloadedSize = new FileInfo(targetPath).Length;
+                if (downloadedSize != artifact.SizeBytes)
+                {
+                    throw new InvalidDataException(
+                        $"Unexpected size for {artifact.FileName}: expected {artifact.SizeBytes}, got {downloadedSize}.");
+                }
                 completedBytes += artifact.SizeBytes;
             }
 
@@ -134,7 +136,7 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
                 throw;
             }
 
-            return await _store.ValidateAsync(model.Id, cancellationToken).ConfigureAwait(false);
+            return _store.GetStateBySize(model.Id);
         }
         finally
         {
@@ -168,29 +170,6 @@ public sealed class PpOcrV6ModelDownloadService : IDisposable
         finally
         {
             downloadLock.Release();
-        }
-    }
-
-    private static async Task ValidateArtifactAsync(
-        PpOcrV6Artifact artifact,
-        string path,
-        CancellationToken cancellationToken)
-    {
-        var fileInfo = new FileInfo(path);
-        if (fileInfo.Length != artifact.SizeBytes)
-        {
-            throw new InvalidDataException(
-                $"Unexpected size for {artifact.FileName}: expected {artifact.SizeBytes}, got {fileInfo.Length}.");
-        }
-
-        await using var stream = File.OpenRead(path);
-        using var sha = SHA256.Create();
-        var actualHash = Convert.ToHexString(
-            await sha.ComputeHashAsync(stream, cancellationToken)).ToLowerInvariant();
-        if (!string.Equals(actualHash, artifact.Sha256, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidDataException(
-                $"SHA-256 mismatch for {artifact.FileName}: expected {artifact.Sha256}, got {actualHash}.");
         }
     }
 

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -331,6 +331,7 @@ public sealed class SettingsService
     public string? OcrApiKey { get; set; }
     public string OcrEndpoint { get; set; } = OcrServiceOptions.DefaultEndpoint;
     public string OcrModel { get; set; } = OcrServiceOptions.DefaultModel;
+    public string PpOcrV6ModelId { get; set; } = PpOcrV6ModelCatalog.SmallId;
     public string OcrSystemPrompt { get; set; } = "Extract all the text from this image perfectly. Output ONLY the extracted text, without any conversational filler, markdown formatting, or introductory words.";
 
     /// <summary>
@@ -821,6 +822,18 @@ public sealed class SettingsService
         OcrApiKey = GetSensitiveSetting(nameof(OcrApiKey));
         OcrEndpoint = GetValue(nameof(OcrEndpoint), OcrServiceOptions.DefaultEndpoint);
         OcrModel = GetValue(nameof(OcrModel), OcrServiceOptions.DefaultModel);
+        var legacyPpOcrV6Model = PpOcrV6ModelCatalog.TryGet(OcrModel, out _)
+            ? OcrModel
+            : PpOcrV6ModelCatalog.SmallId;
+        PpOcrV6ModelId = GetValue(nameof(PpOcrV6ModelId), legacyPpOcrV6Model);
+        if (!PpOcrV6ModelCatalog.TryGet(PpOcrV6ModelId, out _))
+        {
+            PpOcrV6ModelId = PpOcrV6ModelCatalog.SmallId;
+        }
+        if (PpOcrV6ModelCatalog.TryGet(OcrModel, out _))
+        {
+            OcrModel = OcrServiceOptions.DefaultModel;
+        }
         OcrSystemPrompt = GetValue(nameof(OcrSystemPrompt), "Extract all the text from this image perfectly. Output ONLY the extracted text, without any conversational filler, markdown formatting, or introductory words.");
         OcrEnableThinking = GetValue(nameof(OcrEnableThinking), false);
         PpOcrV6ThreadCount = Math.Clamp(
@@ -1088,6 +1101,9 @@ public sealed class SettingsService
         SaveSensitiveSetting(nameof(OcrApiKey), OcrApiKey, preserveUnmigratedSensitiveSettings);
         _settings[nameof(OcrEndpoint)] = OcrEndpoint;
         _settings[nameof(OcrModel)] = OcrModel;
+        _settings[nameof(PpOcrV6ModelId)] = PpOcrV6ModelCatalog.TryGet(PpOcrV6ModelId, out _)
+            ? PpOcrV6ModelId
+            : PpOcrV6ModelCatalog.SmallId;
         _settings[nameof(OcrSystemPrompt)] = OcrSystemPrompt;
         _settings[nameof(OcrEnableThinking)] = OcrEnableThinking;
         _settings[nameof(PpOcrV6ThreadCount)] = Math.Clamp(

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -339,6 +339,10 @@ public sealed class SettingsService
     /// </summary>
     public bool OcrEnableThinking { get; set; }
 
+    public int PpOcrV6ThreadCount { get; set; } = 4;
+    public bool PpOcrV6UseGpu { get; set; }
+    public bool PpOcrV6AllowFallback { get; set; } = true;
+
     // Layout detection settings (long document translation)
 
     /// <summary>
@@ -813,6 +817,9 @@ public sealed class SettingsService
         OcrModel = GetValue(nameof(OcrModel), OcrServiceOptions.DefaultModel);
         OcrSystemPrompt = GetValue(nameof(OcrSystemPrompt), "Extract all the text from this image perfectly. Output ONLY the extracted text, without any conversational filler, markdown formatting, or introductory words.");
         OcrEnableThinking = GetValue(nameof(OcrEnableThinking), false);
+        PpOcrV6ThreadCount = Math.Clamp(GetValue(nameof(PpOcrV6ThreadCount), 4), 1, 16);
+        PpOcrV6UseGpu = GetValue(nameof(PpOcrV6UseGpu), false);
+        PpOcrV6AllowFallback = GetValue(nameof(PpOcrV6AllowFallback), true);
 
         AlwaysOnTop = GetValue(nameof(AlwaysOnTop), false);
         TtsSpeed = GetValue(nameof(TtsSpeed), 1.0);
@@ -1074,6 +1081,9 @@ public sealed class SettingsService
         _settings[nameof(OcrModel)] = OcrModel;
         _settings[nameof(OcrSystemPrompt)] = OcrSystemPrompt;
         _settings[nameof(OcrEnableThinking)] = OcrEnableThinking;
+        _settings[nameof(PpOcrV6ThreadCount)] = Math.Clamp(PpOcrV6ThreadCount, 1, 16);
+        _settings[nameof(PpOcrV6UseGpu)] = PpOcrV6UseGpu;
+        _settings[nameof(PpOcrV6AllowFallback)] = PpOcrV6AllowFallback;
 
         _settings[nameof(AlwaysOnTop)] = AlwaysOnTop;
         _settings[nameof(TtsSpeed)] = TtsSpeed;

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using Easydict.TranslationService;
 using Easydict.TranslationService.Services;
 using Easydict.TranslationService.Services.AgentCli;
+using Easydict.SidecarClient.Protocol;
 using Easydict.WindowsAI;
 using Easydict.WindowsAI.Services;
 using Easydict.WinUI.Models;
@@ -339,7 +340,7 @@ public sealed class SettingsService
     /// </summary>
     public bool OcrEnableThinking { get; set; }
 
-    public int PpOcrV6ThreadCount { get; set; } = 4;
+    public int PpOcrV6ThreadCount { get; set; } = PpOcrV6ModelCatalog.DefaultThreadCount;
     public bool PpOcrV6UseGpu { get; set; }
     public bool PpOcrV6AllowFallback { get; set; } = true;
 
@@ -817,7 +818,10 @@ public sealed class SettingsService
         OcrModel = GetValue(nameof(OcrModel), OcrServiceOptions.DefaultModel);
         OcrSystemPrompt = GetValue(nameof(OcrSystemPrompt), "Extract all the text from this image perfectly. Output ONLY the extracted text, without any conversational filler, markdown formatting, or introductory words.");
         OcrEnableThinking = GetValue(nameof(OcrEnableThinking), false);
-        PpOcrV6ThreadCount = Math.Clamp(GetValue(nameof(PpOcrV6ThreadCount), 4), 1, 16);
+        PpOcrV6ThreadCount = Math.Clamp(
+            GetValue(nameof(PpOcrV6ThreadCount), PpOcrV6ModelCatalog.DefaultThreadCount),
+            PpOcrV6ModelCatalog.MinThreadCount,
+            PpOcrV6ModelCatalog.MaxThreadCount);
         PpOcrV6UseGpu = GetValue(nameof(PpOcrV6UseGpu), false);
         PpOcrV6AllowFallback = GetValue(nameof(PpOcrV6AllowFallback), true);
 
@@ -1081,7 +1085,10 @@ public sealed class SettingsService
         _settings[nameof(OcrModel)] = OcrModel;
         _settings[nameof(OcrSystemPrompt)] = OcrSystemPrompt;
         _settings[nameof(OcrEnableThinking)] = OcrEnableThinking;
-        _settings[nameof(PpOcrV6ThreadCount)] = Math.Clamp(PpOcrV6ThreadCount, 1, 16);
+        _settings[nameof(PpOcrV6ThreadCount)] = Math.Clamp(
+            PpOcrV6ThreadCount,
+            PpOcrV6ModelCatalog.MinThreadCount,
+            PpOcrV6ModelCatalog.MaxThreadCount);
         _settings[nameof(PpOcrV6UseGpu)] = PpOcrV6UseGpu;
         _settings[nameof(PpOcrV6AllowFallback)] = PpOcrV6AllowFallback;
 

--- a/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/SettingsService.cs
@@ -340,8 +340,13 @@ public sealed class SettingsService
     /// </summary>
     public bool OcrEnableThinking { get; set; }
 
+    /// <summary>CPU inference threads for PP-OCRv6. Range: 1-16. Default: 4.</summary>
     public int PpOcrV6ThreadCount { get; set; } = PpOcrV6ModelCatalog.DefaultThreadCount;
+
+    /// <summary>Use the DirectML GPU provider for PP-OCRv6 when available.</summary>
     public bool PpOcrV6UseGpu { get; set; }
+
+    /// <summary>Fall back to Windows OCR when PP-OCRv6 is unavailable or fails.</summary>
     public bool PpOcrV6AllowFallback { get; set; } = true;
 
     // Layout detection settings (long document translation)

--- a/dotnet/src/Easydict.WinUI/Services/TrayIconService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TrayIconService.cs
@@ -246,7 +246,7 @@ public sealed class TrayIconService : IDisposable
         menu.Items.Add(new MenuFlyoutSeparator());
 
         var exitItem = new MenuFlyoutItem { Text = L("TrayExit") };
-        exitItem.Click += (_, _) => ExitApplication();
+        exitItem.Click += async (_, _) => await ExitApplicationAsync();
         SetTip(exitItem);
         menu.Items.Add(exitItem);
 
@@ -356,14 +356,13 @@ public sealed class TrayIconService : IDisposable
     /// <summary>
     /// Exit the application completely.
     /// </summary>
-    public void ExitApplication()
+    public async Task ExitApplicationAsync()
     {
         CrashDiagnostics.Log($"[TrayExit] Exit requested. pid={Environment.ProcessId}");
 
         try
         {
-            // Clean up all services including Win32 hooks before exit.
-            App.CleanupServices();
+            await App.CleanupServicesAsync().ConfigureAwait(true);
             CrashDiagnostics.Log($"[TrayExit] Cleanup completed. pid={Environment.ProcessId}");
         }
         catch (Exception ex)
@@ -375,7 +374,6 @@ public sealed class TrayIconService : IDisposable
         {
             try
             {
-                // Terminate the WinUI message loop.
                 Application.Current.Exit();
             }
             catch (Exception ex)
@@ -385,9 +383,6 @@ public sealed class TrayIconService : IDisposable
             }
 
             CrashDiagnostics.Log($"[TrayExit] Forcing process exit. pid={Environment.ProcessId}");
-
-            // Fallback: force process termination if any stubborn threads remain.
-            // This ensures the process doesn't become a zombie.
             Environment.Exit(0);
         }
     }

--- a/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
+++ b/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
@@ -12,30 +12,67 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
 
     private readonly SettingsService _settings;
     private readonly IOcrService _fallback;
+    private readonly OcrEngineType _engine;
+    private readonly string? _modelId;
+    private readonly int _threadCount;
+    private readonly bool _useGpu;
+    private readonly PpOcrV6ModelStore _modelStore;
     private readonly WorkerSpawner _spawner = new();
     private readonly Func<CancellationToken, Task<SidecarClient.SidecarClient>>? _spawnOverride;
+    private readonly bool _allowFallback;
     private bool _disposed;
 
-    public OcrWorkerClient(SettingsService settings, IOcrService fallback)
+    public OcrWorkerClient(
+        SettingsService settings,
+        IOcrService fallback,
+        OcrEngineType engine = OcrEngineType.WindowsNative,
+        string? modelId = null,
+        int? threadCount = null,
+        bool? allowFallback = null,
+        bool? useGpu = null)
     {
         _settings = settings;
         _fallback = fallback;
+        _engine = engine;
+        _modelId = engine == OcrEngineType.PpOcrV6 ? modelId ?? settings.OcrModel : null;
+        _threadCount = Math.Clamp(threadCount ?? settings.PpOcrV6ThreadCount, 1, 16);
+        _allowFallback = allowFallback ?? settings.PpOcrV6AllowFallback;
+        _useGpu = useGpu ?? settings.PpOcrV6UseGpu;
+        _modelStore = new PpOcrV6ModelStore();
     }
 
     internal OcrWorkerClient(
         SettingsService settings,
         IOcrService fallback,
         Func<CancellationToken, Task<SidecarClient.SidecarClient>> spawnOverride)
-        : this(settings, fallback)
+        : this(settings, fallback, OcrEngineType.WindowsNative)
     {
         _spawnOverride = spawnOverride;
     }
 
-    public string ServiceId => "windows_ocr_worker";
-    public string DisplayName => "Windows OCR Worker";
-    public bool IsAvailable => _fallback.IsAvailable;
+    public string ServiceId => _engine == OcrEngineType.PpOcrV6 ? "pp_ocrv6" : "windows_ocr_worker";
+    public string DisplayName => _engine == OcrEngineType.PpOcrV6 ? "PP-OCRv6" : "Windows OCR Worker";
+    public bool IsAvailable => _engine == OcrEngineType.PpOcrV6
+        ? IsPpOcrV6ModelInstalled() || (_allowFallback && _fallback.IsAvailable)
+        : _fallback.IsAvailable;
 
-    public IReadOnlyList<OcrLanguage> GetAvailableLanguages() => _fallback.GetAvailableLanguages();
+    public IReadOnlyList<OcrLanguage> GetAvailableLanguages()
+    {
+        if (_engine != OcrEngineType.PpOcrV6)
+        {
+            return _fallback.GetAvailableLanguages();
+        }
+
+        return PpOcrV6ModelCatalog.TryGet(_modelId, out var model)
+            ? model!.Languages.Select(tag => new OcrLanguage { Tag = tag, DisplayName = tag }).ToList()
+            : [];
+    }
+
+    private bool IsPpOcrV6ModelInstalled()
+    {
+        return PpOcrV6ModelCatalog.TryGet(_modelId, out var model)
+            && _modelStore.GetStateByPresence(model!.Id) == PpOcrV6ModelState.Installed;
+    }
 
     public async Task<OcrResult> RecognizeAsync(
         ReadOnlyMemory<byte> pixelData,
@@ -73,7 +110,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
             {
                 client = await SpawnConfiguredAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (CanFallbackToInProc(ex))
+            catch (Exception ex) when (CanFallback(ex))
             {
                 Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR: {ex.Message}");
                 return await _fallback.RecognizeAsync(
@@ -95,15 +132,31 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
                         PixelWidth = pixelWidth,
                         PixelHeight = pixelHeight,
                         PreferredLanguageTag = preferredLanguageTag,
+                        Engine = _engine == OcrEngineType.PpOcrV6
+                            ? OcrEngines.PpOcrV6
+                            : OcrEngines.WindowsNative,
+                        ModelId = _engine == OcrEngineType.PpOcrV6 ? _modelId : null,
+                        ThreadCount = _engine == OcrEngineType.PpOcrV6 ? _threadCount : null,
+                        UseGpu = _engine == OcrEngineType.PpOcrV6 && _useGpu,
                     },
                     timeoutMs: 0,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 return MapResult(dto);
             }
-            catch (SidecarProcessExitedException ex) when (CanFallbackToInProc(ex))
+            catch (SidecarProcessExitedException ex) when (CanFallback(ex))
             {
                 Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR after worker exit: {ex.Message}");
+                return await _fallback.RecognizeAsync(
+                    pixelData,
+                    pixelWidth,
+                    pixelHeight,
+                    preferredLanguageTag,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (SidecarErrorException ex) when (CanFallback(ex))
+            {
+                Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR after worker error: {ex.Message}");
                 return await _fallback.RecognizeAsync(
                     pixelData,
                     pixelWidth,
@@ -156,6 +209,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
             Text = line.Words is { Count: > 0 }
                 ? OcrTextMerger.MergeWords(line.Words)
                 : line.Text,
+            Confidence = line.Confidence,
             BoundingRect = new OcrRect(
                 line.BoundingRect.X,
                 line.BoundingRect.Y,
@@ -209,6 +263,31 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
 
     internal static bool CanFallbackToInProc(Exception ex)
     {
+        return ex is WorkerStartFailedException
+            or WorkerVersionMismatchException
+            or FileNotFoundException
+            or SidecarProcessExitedException;
+    }
+
+    internal bool CanFallback(Exception ex)
+    {
+        if (_engine == OcrEngineType.PpOcrV6 && !_allowFallback)
+        {
+            return false;
+        }
+
+        if (ex is SidecarErrorException sidecarError)
+        {
+            return sidecarError.Error.Code is
+                "model_missing" or
+                "model_invalid" or
+                "runtime_missing" or
+                "gpu_unavailable" or
+                "inference_error" or
+                "service_error" or
+                "internal_error";
+        }
+
         return ex is WorkerStartFailedException
             or WorkerVersionMismatchException
             or FileNotFoundException

--- a/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
+++ b/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
@@ -5,7 +5,7 @@ using Easydict.WinUI.Models;
 
 namespace Easydict.WinUI.Services.Workers;
 
-internal sealed class OcrWorkerClient : IOcrService, IDisposable
+internal sealed class OcrWorkerClient : IOcrService, IDisposable, IAsyncDisposable
 {
     private const string WorkerSubdir = "ocr";
     private const string WorkerExeName = "Easydict.Workers.Ocr.exe";
@@ -24,7 +24,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
     private readonly bool _allowFallback;
     private readonly SemaphoreSlim _recognizeLock = new(1, 1);
     private SidecarClient.SidecarClient? _client;
-    private bool _disposed;
+    private int _disposed;
 
     public OcrWorkerClient(
         SettingsService settings,
@@ -38,7 +38,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
         _settings = settings;
         _fallback = fallback;
         _engine = engine;
-        _modelId = engine == OcrEngineType.PpOcrV6 ? modelId ?? settings.OcrModel : null;
+        _modelId = engine == OcrEngineType.PpOcrV6 ? modelId ?? settings.PpOcrV6ModelId : null;
         _threadCount = Math.Clamp(
             threadCount ?? settings.PpOcrV6ThreadCount,
             PpOcrV6ModelCatalog.MinThreadCount,
@@ -88,7 +88,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
         string? preferredLanguageTag = null,
         CancellationToken cancellationToken = default)
     {
-        if (_disposed) throw new ObjectDisposedException(nameof(OcrWorkerClient));
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
 
@@ -115,7 +115,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
             await _recognizeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                ObjectDisposedException.ThrowIf(_disposed, this);
+                ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
                 var client = await GetClientAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
@@ -232,7 +232,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
 
     private async Task<SidecarClient.SidecarClient> GetClientAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
         if (_client is { IsRunning: true })
         {
             return _client;
@@ -258,14 +258,10 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
 
         try
         {
-            await client.StopAsync(gracefulTimeoutMs: 2_000).ConfigureAwait(false);
+            await client.DisposeAsync().ConfigureAwait(false);
         }
         catch
         {
-        }
-        finally
-        {
-            client.Dispose();
         }
     }
 
@@ -384,6 +380,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
             return sidecarError.Error.Code is
                 WorkerErrorCodes.ModelMissing or
                 WorkerErrorCodes.ModelInvalid or
+                WorkerErrorCodes.UnsupportedLanguage or
                 WorkerErrorCodes.RuntimeMissing or
                 WorkerErrorCodes.GpuUnavailable or
                 WorkerErrorCodes.InferenceError or
@@ -396,28 +393,30 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
-            return;
-        }
-
-        _disposed = true;
-        if (_recognizeLock.Wait(TimeSpan.FromSeconds(5)))
-        {
-            try
-            {
-                _client?.Dispose();
-                _client = null;
-            }
-            finally
-            {
-                _recognizeLock.Release();
-            }
-
             return;
         }
 
         var client = Interlocked.Exchange(ref _client, null);
         client?.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        await _recognizeLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await InvalidateClientAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _recognizeLock.Release();
+        }
     }
 }

--- a/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
+++ b/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
@@ -9,6 +9,8 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
 {
     private const string WorkerSubdir = "ocr";
     private const string WorkerExeName = "Easydict.Workers.Ocr.exe";
+    private const int WindowsOcrRequestTimeoutMs = 60_000;
+    private const int PpOcrV6RequestTimeoutMs = 120_000;
 
     private readonly SettingsService _settings;
     private readonly IOcrService _fallback;
@@ -37,7 +39,10 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
         _fallback = fallback;
         _engine = engine;
         _modelId = engine == OcrEngineType.PpOcrV6 ? modelId ?? settings.OcrModel : null;
-        _threadCount = Math.Clamp(threadCount ?? settings.PpOcrV6ThreadCount, 1, 16);
+        _threadCount = Math.Clamp(
+            threadCount ?? settings.PpOcrV6ThreadCount,
+            PpOcrV6ModelCatalog.MinThreadCount,
+            PpOcrV6ModelCatalog.MaxThreadCount);
         _allowFallback = allowFallback ?? settings.PpOcrV6AllowFallback;
         _useGpu = useGpu ?? settings.PpOcrV6UseGpu;
         _modelStore = new PpOcrV6ModelStore();
@@ -73,7 +78,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
     private bool IsPpOcrV6ModelInstalled()
     {
         return PpOcrV6ModelCatalog.TryGet(_modelId, out var model)
-            && _modelStore.GetStateByPresence(model!.Id) == PpOcrV6ModelState.Installed;
+            && _modelStore.GetStateBySize(model!.Id) == PpOcrV6ModelState.Installed;
     }
 
     public async Task<OcrResult> RecognizeAsync(
@@ -110,6 +115,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
             await _recognizeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
+                ObjectDisposedException.ThrowIf(_disposed, this);
                 var client = await GetClientAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
@@ -128,7 +134,9 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
                             ThreadCount = _engine == OcrEngineType.PpOcrV6 ? _threadCount : null,
                             UseGpu = _engine == OcrEngineType.PpOcrV6 && _useGpu,
                         },
-                        timeoutMs: 0,
+                        timeoutMs: _engine == OcrEngineType.PpOcrV6
+                            ? PpOcrV6RequestTimeoutMs
+                            : WindowsOcrRequestTimeoutMs,
                         cancellationToken: cancellationToken).ConfigureAwait(false);
 
                     var result = MapResult(dto);
@@ -142,6 +150,22 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     await InvalidateClientAsync().ConfigureAwait(false);
+                    throw;
+                }
+                catch (SidecarTimeoutException ex)
+                {
+                    await InvalidateClientAsync().ConfigureAwait(false);
+                    if (CanFallback(ex))
+                    {
+                        Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR after worker timeout: {ex.Message}");
+                        return await _fallback.RecognizeAsync(
+                            pixelData,
+                            pixelWidth,
+                            pixelHeight,
+                            preferredLanguageTag,
+                            cancellationToken).ConfigureAwait(false);
+                    }
+
                     throw;
                 }
                 catch (SidecarProcessExitedException ex)
@@ -162,7 +186,11 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
                 }
                 catch (SidecarErrorException ex)
                 {
-                    await InvalidateClientAsync().ConfigureAwait(false);
+                    if (!IsRequestScopedError(ex.Error.Code))
+                    {
+                        await InvalidateClientAsync().ConfigureAwait(false);
+                    }
+
                     if (CanFallback(ex))
                     {
                         Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR after worker error: {ex.Message}");
@@ -177,7 +205,10 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
                     throw;
                 }
             }
-            catch (Exception ex) when (CanFallback(ex))
+            catch (Exception ex) when (ex is not SidecarErrorException
+                                        && ex is not SidecarTimeoutException
+                                        && ex is not SidecarProcessExitedException
+                                        && CanFallback(ex))
             {
                 await InvalidateClientAsync().ConfigureAwait(false);
                 Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR: {ex.Message}");
@@ -201,6 +232,7 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
 
     private async Task<SidecarClient.SidecarClient> GetClientAsync(CancellationToken cancellationToken)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         if (_client is { IsRunning: true })
         {
             return _client;
@@ -218,11 +250,22 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
 
     private async Task InvalidateClientAsync()
     {
-        var client = _client;
-        _client = null;
-        if (client is not null)
+        var client = Interlocked.Exchange(ref _client, null);
+        if (client is null)
         {
-            await client.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            await client.StopAsync(gracefulTimeoutMs: 2_000).ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+        finally
+        {
+            client.Dispose();
         }
     }
 
@@ -317,7 +360,16 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
         return ex is WorkerStartFailedException
             or WorkerVersionMismatchException
             or FileNotFoundException
-            or SidecarProcessExitedException;
+            or SidecarProcessExitedException
+            or SidecarTimeoutException;
+    }
+
+    private static bool IsRequestScopedError(string code)
+    {
+        return code is WorkerErrorCodes.InvalidParams
+            or WorkerErrorCodes.ModelMissing
+            or WorkerErrorCodes.ModelInvalid
+            or WorkerErrorCodes.UnsupportedLanguage;
     }
 
     internal bool CanFallback(Exception ex)
@@ -330,13 +382,13 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
         if (ex is SidecarErrorException sidecarError)
         {
             return sidecarError.Error.Code is
-                "model_missing" or
-                "model_invalid" or
-                "runtime_missing" or
-                "gpu_unavailable" or
-                "inference_error" or
-                "service_error" or
-                "internal_error";
+                WorkerErrorCodes.ModelMissing or
+                WorkerErrorCodes.ModelInvalid or
+                WorkerErrorCodes.RuntimeMissing or
+                WorkerErrorCodes.GpuUnavailable or
+                WorkerErrorCodes.InferenceError or
+                WorkerErrorCodes.ServiceError or
+                WorkerErrorCodes.Internal;
         }
 
         return CanFallbackToInProc(ex);
@@ -350,8 +402,22 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
         }
 
         _disposed = true;
-        _client?.Dispose();
-        _client = null;
-        _recognizeLock.Dispose();
+        if (_recognizeLock.Wait(TimeSpan.FromSeconds(5)))
+        {
+            try
+            {
+                _client?.Dispose();
+                _client = null;
+            }
+            finally
+            {
+                _recognizeLock.Release();
+            }
+
+            return;
+        }
+
+        var client = Interlocked.Exchange(ref _client, null);
+        client?.Dispose();
     }
 }

--- a/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
+++ b/dotnet/src/Easydict.WinUI/Services/Workers/OcrWorkerClient.cs
@@ -20,6 +20,8 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
     private readonly WorkerSpawner _spawner = new();
     private readonly Func<CancellationToken, Task<SidecarClient.SidecarClient>>? _spawnOverride;
     private readonly bool _allowFallback;
+    private readonly SemaphoreSlim _recognizeLock = new(1, 1);
+    private SidecarClient.SidecarClient? _client;
     private bool _disposed;
 
     public OcrWorkerClient(
@@ -105,13 +107,79 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
                 await stream.WriteAsync(pixelData, cancellationToken).ConfigureAwait(false);
             }
 
-            SidecarClient.SidecarClient client;
+            await _recognizeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                client = await SpawnConfiguredAsync(cancellationToken).ConfigureAwait(false);
+                var client = await GetClientAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var dto = await client.SendRequestAsync<OcrResultDto>(
+                        OcrMethods.Recognize,
+                        new OcrRecognizeParams
+                        {
+                            PixelDataPath = tempPath,
+                            PixelWidth = pixelWidth,
+                            PixelHeight = pixelHeight,
+                            PreferredLanguageTag = preferredLanguageTag,
+                            Engine = _engine == OcrEngineType.PpOcrV6
+                                ? OcrEngines.PpOcrV6
+                                : OcrEngines.WindowsNative,
+                            ModelId = _engine == OcrEngineType.PpOcrV6 ? _modelId : null,
+                            ThreadCount = _engine == OcrEngineType.PpOcrV6 ? _threadCount : null,
+                            UseGpu = _engine == OcrEngineType.PpOcrV6 && _useGpu,
+                        },
+                        timeoutMs: 0,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    var result = MapResult(dto);
+                    if (_engine != OcrEngineType.PpOcrV6)
+                    {
+                        await InvalidateClientAsync().ConfigureAwait(false);
+                    }
+
+                    return result;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    await InvalidateClientAsync().ConfigureAwait(false);
+                    throw;
+                }
+                catch (SidecarProcessExitedException ex)
+                {
+                    await InvalidateClientAsync().ConfigureAwait(false);
+                    if (CanFallback(ex))
+                    {
+                        Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR after worker exit: {ex.Message}");
+                        return await _fallback.RecognizeAsync(
+                            pixelData,
+                            pixelWidth,
+                            pixelHeight,
+                            preferredLanguageTag,
+                            cancellationToken).ConfigureAwait(false);
+                    }
+
+                    throw new InvalidOperationException($"OCR worker exited unexpectedly (code={ex.ExitCode})", ex);
+                }
+                catch (SidecarErrorException ex)
+                {
+                    await InvalidateClientAsync().ConfigureAwait(false);
+                    if (CanFallback(ex))
+                    {
+                        Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR after worker error: {ex.Message}");
+                        return await _fallback.RecognizeAsync(
+                            pixelData,
+                            pixelWidth,
+                            pixelHeight,
+                            preferredLanguageTag,
+                            cancellationToken).ConfigureAwait(false);
+                    }
+
+                    throw;
+                }
             }
             catch (Exception ex) when (CanFallback(ex))
             {
+                await InvalidateClientAsync().ConfigureAwait(false);
                 Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR: {ex.Message}");
                 return await _fallback.RecognizeAsync(
                     pixelData,
@@ -120,58 +188,41 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
                     preferredLanguageTag,
                     cancellationToken).ConfigureAwait(false);
             }
-
-            await using var clientLease = client.ConfigureAwait(false);
-            try
+            finally
             {
-                var dto = await client.SendRequestAsync<OcrResultDto>(
-                    OcrMethods.Recognize,
-                    new OcrRecognizeParams
-                    {
-                        PixelDataPath = tempPath,
-                        PixelWidth = pixelWidth,
-                        PixelHeight = pixelHeight,
-                        PreferredLanguageTag = preferredLanguageTag,
-                        Engine = _engine == OcrEngineType.PpOcrV6
-                            ? OcrEngines.PpOcrV6
-                            : OcrEngines.WindowsNative,
-                        ModelId = _engine == OcrEngineType.PpOcrV6 ? _modelId : null,
-                        ThreadCount = _engine == OcrEngineType.PpOcrV6 ? _threadCount : null,
-                        UseGpu = _engine == OcrEngineType.PpOcrV6 && _useGpu,
-                    },
-                    timeoutMs: 0,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                return MapResult(dto);
-            }
-            catch (SidecarProcessExitedException ex) when (CanFallback(ex))
-            {
-                Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR after worker exit: {ex.Message}");
-                return await _fallback.RecognizeAsync(
-                    pixelData,
-                    pixelWidth,
-                    pixelHeight,
-                    preferredLanguageTag,
-                    cancellationToken).ConfigureAwait(false);
-            }
-            catch (SidecarErrorException ex) when (CanFallback(ex))
-            {
-                Debug.WriteLine($"[OcrWorker] Falling back to in-proc OCR after worker error: {ex.Message}");
-                return await _fallback.RecognizeAsync(
-                    pixelData,
-                    pixelWidth,
-                    pixelHeight,
-                    preferredLanguageTag,
-                    cancellationToken).ConfigureAwait(false);
-            }
-            catch (SidecarProcessExitedException ex)
-            {
-                throw new InvalidOperationException($"OCR worker exited unexpectedly (code={ex.ExitCode})", ex);
+                _recognizeLock.Release();
             }
         }
         finally
         {
             TryDelete(tempPath);
+        }
+    }
+
+    private async Task<SidecarClient.SidecarClient> GetClientAsync(CancellationToken cancellationToken)
+    {
+        if (_client is { IsRunning: true })
+        {
+            return _client;
+        }
+
+        if (_client is not null)
+        {
+            _client.Dispose();
+            _client = null;
+        }
+
+        _client = await SpawnConfiguredAsync(cancellationToken).ConfigureAwait(false);
+        return _client;
+    }
+
+    private async Task InvalidateClientAsync()
+    {
+        var client = _client;
+        _client = null;
+        if (client is not null)
+        {
+            await client.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -288,14 +339,19 @@ internal sealed class OcrWorkerClient : IOcrService, IDisposable
                 "internal_error";
         }
 
-        return ex is WorkerStartFailedException
-            or WorkerVersionMismatchException
-            or FileNotFoundException
-            or SidecarProcessExitedException;
+        return CanFallbackToInProc(ex);
     }
 
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _disposed = true;
+        _client?.Dispose();
+        _client = null;
+        _recognizeLock.Dispose();
     }
 }

--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -1424,4 +1424,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>إصدار تصحيح · أحدث إصدار {0} · عرض التحديث →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>يتوفر إصدار جديد {0} · عرض التحديث →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (محلي)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>نموذج PP-OCRv6</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 صغير جدًا</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 صغير</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 متوسط</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>التنزيل: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>اللغات: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>جارٍ التحقق من النموذج...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>تم التنزيل</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>إزالة</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>النموذج غير صالح — يلزم الإصلاح</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>إصلاح</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>لم يتم التنزيل</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>تنزيل</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>جارٍ التنزيل...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>فشل تنزيل PP-OCRv6</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>لم يجتز نموذج PP-OCRv6 التحقق النهائي من التكامل.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>إزالة نموذج PP-OCRv6</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>هل تريد إزالة النموذج الذي تم تنزيله '{0}'؟</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>فشلت إزالة PP-OCRv6</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>مؤشرات ترابط CPU</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>استخدام GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>الرجوع إلى OCR في Windows</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>اختبار PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>حدد منطقة على شاشتك لاختبار PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>تم إلغاء الاختبار.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>جارٍ المعالجة باستخدام PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>جارٍ المعالجة باستخدام PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>نجاح: تمت معالجة الصورة، ولكن لم يتم التعرف على أي نص.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[خطأ] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ar-SA/Resources.resw
@@ -982,6 +982,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>API مخصص</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>نموذج PP-OCRv6 غير متاح</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>نزّل نموذج PP-OCRv6 '{0}' قبل اختيار هذا المحرك.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>مفتاح API (اختياري)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -568,6 +568,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>Brugerdefineret API</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>PP-OCRv6-modellen er ikke tilgængelig</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>Download PP-OCRv6-modellen '{0}', før du vælger denne motor.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>API-nøgle (valgfri)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/da-DK/Resources.resw
@@ -1010,4 +1010,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>Debugbuild · Seneste version {0} · Se opdatering →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>Ny version {0} er tilgængelig · Se opdatering →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (lokal)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>PP-OCRv6-model</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 Mini</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 Lille</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 Mellemstor</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>Download: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>Sprog: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>Kontrollerer model...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>Downloadet</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>Fjern</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>Modellen er ugyldig — reparation påkrævet</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>Reparer</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>Ikke downloadet</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>Download</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>Downloader...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>Download af PP-OCRv6 mislykkedes</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>PP-OCRv6-modellen bestod ikke den endelige integritetskontrol.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>Fjern PP-OCRv6-model</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>Vil du fjerne den downloadede model '{0}'?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>PP-OCRv6 kunne ikke fjernes</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>CPU-tråde</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>Brug GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Brug Windows OCR som reserve</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>Test PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>Vælg et område på skærmen for at teste PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>Testen blev annulleret.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>Behandler med PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>Behandler med PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>Fuldført: Billedet blev behandlet, men ingen tekst blev genkendt.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[Fejl] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -1098,6 +1098,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>Benutzerdefinierte API</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>PP-OCRv6-Modell nicht verfügbar</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>Laden Sie das PP-OCRv6-Modell „{0}“ herunter, bevor Sie diese Engine auswählen.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>API-Schlüssel (optional)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/de-DE/Resources.resw
@@ -1429,4 +1429,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>Debugbuild · Neueste Version {0} · Update anzeigen →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>Neue Version {0} verfügbar · Update anzeigen →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (lokal)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>PP-OCRv6-Modell</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 Winzig</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 Klein</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 Mittel</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>Download: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>Sprachen: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>Modell wird überprüft...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>Heruntergeladen</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>Entfernen</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>Modell ungültig — Reparatur erforderlich</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>Reparieren</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>Nicht heruntergeladen</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>Herunterladen</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>Wird heruntergeladen...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>PP-OCRv6-Download fehlgeschlagen</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>Das PP-OCRv6-Modell hat die abschließende Integritätsprüfung nicht bestanden.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>PP-OCRv6-Modell entfernen</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>Das heruntergeladene Modell '{0}' entfernen?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>PP-OCRv6 konnte nicht entfernt werden</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>CPU-Threads</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>GPU verwenden (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Auf Windows OCR zurückgreifen</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>PP-OCRv6 testen</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>Wählen Sie einen Bereich auf dem Bildschirm aus, um PP-OCRv6 zu testen...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>Test abgebrochen.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>Verarbeitung mit PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>Verarbeitung mit PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>Erfolgreich: Das Bild wurde verarbeitet, aber es wurde kein Text erkannt.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[Fehler] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -1218,6 +1218,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>Custom API</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>PP-OCRv6 model unavailable</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>Download the PP-OCRv6 model '{0}' before selecting this engine.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>API Key (Optional)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/en-US/Resources.resw
@@ -1426,4 +1426,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>Debug build · Latest release {0} · View update →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>New version {0} available · View update →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (Local)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>PP-OCRv6 Model</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 Tiny</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 Small</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 Medium</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>Download: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>Languages: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>Checking model...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>Downloaded</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>Remove</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>Model invalid — repair required</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>Repair</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>Not downloaded</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>Download</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>Downloading...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>PP-OCRv6 download failed</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>The PP-OCRv6 model did not pass final integrity validation.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>Remove PP-OCRv6 model</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>Remove the downloaded model '{0}'?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>PP-OCRv6 removal failed</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>CPU Threads</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>Use GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Fallback to Windows OCR</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>Test PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>Select a region on your screen to test PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>Test cancelled.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>Processing with PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>Processing with PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>Success: image processed, but no text was recognized.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[Error] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -1098,6 +1098,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>API personnalisée</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>Modèle PP-OCRv6 indisponible</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>Téléchargez le modèle PP-OCRv6 « {0} » avant de sélectionner ce moteur.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>Clé API (facultatif)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/fr-FR/Resources.resw
@@ -1429,4 +1429,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>Version de débogage · Dernière version {0} · Voir la mise à jour →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>La nouvelle version {0} est disponible · Voir la mise à jour →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (local)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>Modèle PP-OCRv6</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 Très petit</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 Petit</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 Moyen</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>Téléchargement : {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>Langues : {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>Vérification du modèle...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>Téléchargé</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>Supprimer</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>Modèle non valide — réparation requise</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>Réparer</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>Non téléchargé</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>Télécharger</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>Téléchargement...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>Échec du téléchargement de PP-OCRv6</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>Le modèle PP-OCRv6 n’a pas réussi la validation finale de l’intégrité.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>Supprimer le modèle PP-OCRv6</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>Supprimer le modèle téléchargé '{0}' ?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>Échec de la suppression de PP-OCRv6</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>Threads CPU</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>Utiliser le GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Revenir à l’OCR Windows</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>Tester PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>Sélectionnez une zone de l’écran pour tester PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>Test annulé.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>Traitement avec PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>Traitement avec PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>Réussite : l’image a été traitée, mais aucun texte n’a été reconnu.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[Erreur] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -568,6 +568,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>कस्टम API</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>PP-OCRv6 मॉडल उपलब्ध नहीं है</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>इस इंजन को चुनने से पहले PP-OCRv6 मॉडल '{0}' डाउनलोड करें।</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>API कुंजी (वैकल्पिक)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/hi-IN/Resources.resw
@@ -1010,4 +1010,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>डीबग बिल्ड · नवीनतम रिलीज़ {0} · अपडेट देखें →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>नया संस्करण {0} उपलब्ध है · अपडेट देखें →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (स्थानीय)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>PP-OCRv6 मॉडल</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 अति लघु</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 छोटा</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 मध्यम</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>डाउनलोड: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>भाषाएँ: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>मॉडल की जाँच हो रही है...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>डाउनलोड किया गया</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>हटाएँ</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>मॉडल अमान्य है — सुधार आवश्यक है</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>सुधारें</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>डाउनलोड नहीं किया गया</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>डाउनलोड करें</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>डाउनलोड हो रहा है...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>PP-OCRv6 डाउनलोड विफल</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>PP-OCRv6 मॉडल अंतिम अखंडता सत्यापन में सफल नहीं हुआ।</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>PP-OCRv6 मॉडल हटाएँ</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>डाउनलोड किया गया मॉडल '{0}' हटाएँ?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>PP-OCRv6 को हटाना विफल रहा</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>CPU थ्रेड</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>GPU का उपयोग करें (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Windows OCR पर वापस जाएँ</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>PP-OCRv6 का परीक्षण करें</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>PP-OCRv6 का परीक्षण करने के लिए अपनी स्क्रीन पर कोई क्षेत्र चुनें...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>परीक्षण रद्द किया गया।</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>PP-OCRv6 GPU से प्रोसेस हो रहा है...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>PP-OCRv6 CPU से प्रोसेस हो रहा है...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>सफल: छवि प्रोसेस हुई, लेकिन कोई पाठ पहचाना नहीं गया।</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[त्रुटि] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -1370,4 +1370,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>Build debug · Rilis terbaru {0} · Lihat pembaruan →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>Versi baru {0} tersedia · Lihat pembaruan →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (Lokal)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>Model PP-OCRv6</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 Sangat Kecil</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 Kecil</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 Sedang</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>Unduhan: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>Bahasa: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>Memeriksa model...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>Sudah diunduh</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>Hapus</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>Model tidak valid — perlu diperbaiki</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>Perbaiki</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>Belum diunduh</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>Unduh</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>Mengunduh...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>Pengunduhan PP-OCRv6 gagal</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>Model PP-OCRv6 tidak lolos validasi integritas akhir.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>Hapus model PP-OCRv6</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>Hapus model yang telah diunduh '{0}'?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>Penghapusan PP-OCRv6 gagal</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>Utas CPU</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>Gunakan GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Beralih kembali ke Windows OCR</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>Uji PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>Pilih area di layar untuk menguji PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>Pengujian dibatalkan.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>Memproses dengan PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>Memproses dengan PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>Berhasil: gambar diproses, tetapi tidak ada teks yang dikenali.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[Kesalahan] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/id-ID/Resources.resw
@@ -928,6 +928,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>API Kustom</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>Model PP-OCRv6 tidak tersedia</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>Unduh model PP-OCRv6 '{0}' sebelum memilih mesin ini.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>Kunci API (Opsional)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -1416,4 +1416,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>Build di debug · Ultima versione {0} · Visualizza aggiornamento →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>Nuova versione {0} disponibile · Visualizza aggiornamento →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (locale)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>Modello PP-OCRv6</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 Mini</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 Piccolo</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 Medio</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>Download: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>Lingue: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>Verifica del modello...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>Scaricato</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>Rimuovi</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>Modello non valido — riparazione necessaria</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>Ripara</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>Non scaricato</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>Scarica</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>Download in corso...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>Download di PP-OCRv6 non riuscito</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>Il modello PP-OCRv6 non ha superato la convalida finale dell’integrità.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>Rimuovi il modello PP-OCRv6</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>Rimuovere il modello scaricato '{0}'?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>Rimozione di PP-OCRv6 non riuscita</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>Thread CPU</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>Usa GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Usa Windows OCR come alternativa</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>Testa PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>Seleziona un’area dello schermo per testare PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>Test annullato.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>Elaborazione con PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>Elaborazione con PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>Operazione riuscita: l’immagine è stata elaborata, ma non è stato riconosciuto alcun testo.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[Errore] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/it-IT/Resources.resw
@@ -974,6 +974,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>API personalizzata</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>Modello PP-OCRv6 non disponibile</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>Scarica il modello PP-OCRv6 '{0}' prima di selezionare questo motore.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>Chiave API (facoltativa)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -1140,6 +1140,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>カスタム API</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>PP-OCRv6 モデルを利用できません</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>このエンジンを選択する前に PP-OCRv6 モデル「{0}」をダウンロードしてください。</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>API キー（任意）</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ja-JP/Resources.resw
@@ -1429,4 +1429,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>デバッグ ビルド · 最新リリース {0} · 更新を表示 →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>新しいバージョン {0} を利用できます · 更新を表示 →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (ローカル)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>PP-OCRv6 モデル</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 超小型</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 小型</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 中型</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>ダウンロード: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>言語: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>モデルを確認しています...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>ダウンロード済み</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>削除</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>モデルが無効です — 修復が必要です</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>修復</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>未ダウンロード</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>ダウンロード</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>ダウンロードしています...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>PP-OCRv6 のダウンロードに失敗しました</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>PP-OCRv6 モデルは最終整合性検証に合格しませんでした。</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>PP-OCRv6 モデルの削除</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>ダウンロード済みのモデル '{0}' を削除しますか?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>PP-OCRv6 の削除に失敗しました</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>CPU スレッド</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>GPU を使用 (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Windows OCR にフォールバック</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>PP-OCRv6 をテスト</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>PP-OCRv6 をテストする画面上の領域を選択してください...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>テストをキャンセルしました。</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>PP-OCRv6 GPU で処理しています...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>PP-OCRv6 CPU で処理しています...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>成功: 画像は処理されましたが、テキストは認識されませんでした。</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[エラー] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -1429,4 +1429,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>디버그 빌드 · 최신 릴리스 {0} · 업데이트 보기 →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>새 버전 {0}을 사용할 수 있습니다 · 업데이트 보기 →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (로컬)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>PP-OCRv6 모델</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 초소형</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 소형</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 중형</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>다운로드: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>언어: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>모델 확인 중...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>다운로드됨</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>제거</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>모델이 잘못됨 — 복구 필요</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>복구</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>다운로드되지 않음</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>다운로드</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>다운로드 중...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>PP-OCRv6 다운로드 실패</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>PP-OCRv6 모델이 최종 무결성 검증을 통과하지 못했습니다.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>PP-OCRv6 모델 제거</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>다운로드한 모델 '{0}'을(를) 제거하시겠습니까?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>PP-OCRv6 제거 실패</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>CPU 스레드</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>GPU 사용 (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Windows OCR로 대체</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>PP-OCRv6 테스트</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>PP-OCRv6를 테스트할 화면 영역을 선택하세요...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>테스트가 취소되었습니다.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>PP-OCRv6 GPU로 처리 중...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>PP-OCRv6 CPU로 처리 중...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>성공: 이미지가 처리되었지만 텍스트가 인식되지 않았습니다.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[오류] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ko-KR/Resources.resw
@@ -1140,6 +1140,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>사용자 지정 API</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>PP-OCRv6 모델을 사용할 수 없음</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>이 엔진을 선택하기 전에 PP-OCRv6 모델 '{0}'을(를) 다운로드하세요.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>API 키(선택 사항)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -568,6 +568,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>API Tersuai</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>Model PP-OCRv6 tidak tersedia</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>Muat turun model PP-OCRv6 '{0}' sebelum memilih enjin ini.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>Kunci API (Pilihan)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/ms-MY/Resources.resw
@@ -1010,4 +1010,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>Binaan nyahpepijat · Keluaran terkini {0} · Lihat kemas kini →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>Versi baharu {0} tersedia · Lihat kemas kini →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (Setempat)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>Model PP-OCRv6</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 Sangat Kecil</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 Kecil</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 Sederhana</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>Muat turun: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>Bahasa: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>Menyemak model...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>Dimuat turun</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>Alih keluar</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>Model tidak sah — pembaikan diperlukan</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>Baiki</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>Belum dimuat turun</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>Muat turun</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>Memuat turun...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>Muat turun PP-OCRv6 gagal</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>Model PP-OCRv6 tidak melepasi pengesahan integriti akhir.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>Alih keluar model PP-OCRv6</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>Alih keluar model yang dimuat turun '{0}'?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>Gagal mengalih keluar PP-OCRv6</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>Jalur CPU</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>Gunakan GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Gunakan Windows OCR sebagai sandaran</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>Uji PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>Pilih kawasan pada skrin anda untuk menguji PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>Ujian dibatalkan.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>Memproses dengan PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>Memproses dengan PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>Berjaya: imej diproses, tetapi tiada teks dikenal pasti.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[Ralat] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -1378,4 +1378,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>รุ่นดีบัก · รุ่นล่าสุด {0} · ดูการอัปเดต →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>มีเวอร์ชันใหม่ {0} พร้อมใช้งาน · ดูการอัปเดต →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (ภายในเครื่อง)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>โมเดล PP-OCRv6</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 เล็กจิ๋ว</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 เล็ก</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 กลาง</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>ดาวน์โหลด: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>ภาษา: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>กำลังตรวจสอบโมเดล...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>ดาวน์โหลดแล้ว</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>นำออก</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>โมเดลไม่ถูกต้อง — ต้องซ่อมแซม</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>ซ่อมแซม</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>ยังไม่ได้ดาวน์โหลด</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>ดาวน์โหลด</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>กำลังดาวน์โหลด...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>ดาวน์โหลด PP-OCRv6 ไม่สำเร็จ</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>โมเดล PP-OCRv6 ไม่ผ่านการตรวจสอบความสมบูรณ์ขั้นสุดท้าย</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>นำโมเดล PP-OCRv6 ออก</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>นำโมเดลที่ดาวน์โหลด '{0}' ออกหรือไม่</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>นำ PP-OCRv6 ออกไม่สำเร็จ</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>เธรด CPU</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>ใช้ GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>ใช้ Windows OCR แทน</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>ทดสอบ PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>เลือกพื้นที่บนหน้าจอเพื่อทดสอบ PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>ยกเลิกการทดสอบแล้ว</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>กำลังประมวลผลด้วย PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>กำลังประมวลผลด้วย PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>สำเร็จ: ประมวลผลรูปภาพแล้ว แต่ไม่พบข้อความ</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[ข้อผิดพลาด] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/th-TH/Resources.resw
@@ -936,6 +936,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>API ที่กำหนดเอง</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>ไม่พบโมเดล PP-OCRv6</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>ดาวน์โหลดโมเดล PP-OCRv6 '{0}' ก่อนเลือกเครื่องมือนี้</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>คีย์ API (ไม่บังคับ)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -1424,4 +1424,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>Bản dựng gỡ lỗi · Bản phát hành mới nhất {0} · Xem bản cập nhật →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>Đã có phiên bản mới {0} · Xem bản cập nhật →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6 (Cục bộ)</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>Mô hình PP-OCRv6</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 Siêu nhỏ</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 Nhỏ</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 Trung bình</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>Tải xuống: {0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>Ngôn ngữ: {0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>Đang kiểm tra mô hình...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>Đã tải xuống</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>Xóa</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>Mô hình không hợp lệ — cần sửa chữa</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>Sửa chữa</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>Chưa tải xuống</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>Tải xuống</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>Đang tải xuống...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>Tải PP-OCRv6 xuống không thành công</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>Mô hình PP-OCRv6 không vượt qua bước xác thực tính toàn vẹn cuối cùng.</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>Xóa mô hình PP-OCRv6</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>Xóa mô hình đã tải xuống '{0}'?</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>Không thể xóa PP-OCRv6</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>Luồng CPU</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>Sử dụng GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>Chuyển về Windows OCR</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>Kiểm tra PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>Chọn một vùng trên màn hình để kiểm tra PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>Đã hủy kiểm tra.</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>Đang xử lý bằng PP-OCRv6 GPU...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>Đang xử lý bằng PP-OCRv6 CPU...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>Thành công: hình ảnh đã được xử lý nhưng không nhận dạng được văn bản.</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[Lỗi] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/vi-VN/Resources.resw
@@ -982,6 +982,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>API Tùy chỉnh</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>Mô hình PP-OCRv6 không khả dụng</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>Hãy tải mô hình PP-OCRv6 '{0}' xuống trước khi chọn công cụ này.</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>Khóa API (Tùy chọn)</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -1218,6 +1218,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>自定义 API</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>PP-OCRv6 模型不可用</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>选择此引擎前请先下载 PP-OCRv6 模型“{0}”。</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>API 密钥（可选）</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-CN/Resources.resw
@@ -1426,4 +1426,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>调试构建 · 最新版本 {0} · 查看更新 →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>发现新版本 {0} · 查看更新 →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6（本地）</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>PP-OCRv6 模型</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 微型</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 小型</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 中型</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>下载：{0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>语言：{0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>正在检查模型...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>已下载</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>移除</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>模型无效 — 需要修复</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>修复</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>未下载</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>下载</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>正在下载...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>PP-OCRv6 下载失败</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>PP-OCRv6 模型未通过最终完整性验证。</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>移除 PP-OCRv6 模型</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>要移除已下载的模型 '{0}' 吗？</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>PP-OCRv6 移除失败</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>CPU 线程</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>使用 GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>回退到 Windows OCR</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>测试 PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>请选择屏幕上的区域以测试 PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>测试已取消。</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>正在使用 PP-OCRv6 GPU 处理...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>正在使用 PP-OCRv6 CPU 处理...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>成功：图像已处理，但未识别出文本。</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[错误] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -1173,6 +1173,12 @@
   <data name="OcrEngineCustomApi" xml:space="preserve">
     <value>自訂 API</value>
   </data>
+  <data name="PpOcrV6ModelUnavailableTitle" xml:space="preserve">
+    <value>PP-OCRv6 模型無法使用</value>
+  </data>
+  <data name="PpOcrV6ModelUnavailableMessage" xml:space="preserve">
+    <value>選擇此引擎前請先下載 PP-OCRv6 模型「{0}」。</value>
+  </data>
   <data name="OcrApiKey" xml:space="preserve">
     <value>API 金鑰（選填）</value>
   </data>

--- a/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
+++ b/dotnet/src/Easydict.WinUI/Strings/zh-TW/Resources.resw
@@ -1429,4 +1429,35 @@
   </data>
   <data name="PortableUpdateBanner_Debug" xml:space="preserve"><value>偵錯組建 · 最新版本 {0} · 查看更新 →</value></data>
   <data name="PortableUpdateBanner_Available" xml:space="preserve"><value>發現新版本 {0} · 查看更新 →</value></data>
+  <data name="PpOcrV6EngineLocal" xml:space="preserve"><value>PP-OCRv6（本機）</value></data>
+  <data name="PpOcrV6ModelLabel" xml:space="preserve"><value>PP-OCRv6 模型</value></data>
+  <data name="PpOcrV6ModelTiny" xml:space="preserve"><value>PP-OCRv6 微型</value></data>
+  <data name="PpOcrV6ModelSmall" xml:space="preserve"><value>PP-OCRv6 小型</value></data>
+  <data name="PpOcrV6ModelMedium" xml:space="preserve"><value>PP-OCRv6 中型</value></data>
+  <data name="PpOcrV6DownloadSize" xml:space="preserve"><value>下載：{0:F1} MB</value></data>
+  <data name="PpOcrV6LanguageCount" xml:space="preserve"><value>語言：{0}</value></data>
+  <data name="PpOcrV6StatusChecking" xml:space="preserve"><value>正在檢查模型...</value></data>
+  <data name="PpOcrV6StatusDownloaded" xml:space="preserve"><value>已下載</value></data>
+  <data name="PpOcrV6ActionRemove" xml:space="preserve"><value>移除</value></data>
+  <data name="PpOcrV6StatusInvalid" xml:space="preserve"><value>模型無效 — 需要修復</value></data>
+  <data name="PpOcrV6ActionRepair" xml:space="preserve"><value>修復</value></data>
+  <data name="PpOcrV6StatusNotDownloaded" xml:space="preserve"><value>尚未下載</value></data>
+  <data name="PpOcrV6ActionDownload" xml:space="preserve"><value>下載</value></data>
+  <data name="PpOcrV6StatusDownloading" xml:space="preserve"><value>正在下載...</value></data>
+  <data name="PpOcrV6DownloadFailedTitle" xml:space="preserve"><value>PP-OCRv6 下載失敗</value></data>
+  <data name="PpOcrV6IntegrityValidationFailed" xml:space="preserve"><value>PP-OCRv6 模型未通過最終完整性驗證。</value></data>
+  <data name="PpOcrV6RemoveTitle" xml:space="preserve"><value>移除 PP-OCRv6 模型</value></data>
+  <data name="PpOcrV6RemoveMessage" xml:space="preserve"><value>要移除已下載的模型 '{0}' 嗎？</value></data>
+  <data name="PpOcrV6RemoveFailedTitle" xml:space="preserve"><value>PP-OCRv6 移除失敗</value></data>
+  <data name="PpOcrV6CpuThreads" xml:space="preserve"><value>CPU 執行緒</value></data>
+  <data name="PpOcrV6UseGpu" xml:space="preserve"><value>使用 GPU (DirectML)</value></data>
+  <data name="PpOcrV6Fallback" xml:space="preserve"><value>回復使用 Windows OCR</value></data>
+  <data name="PpOcrV6TestButton" xml:space="preserve"><value>測試 PP-OCRv6</value></data>
+  <data name="PpOcrV6TestSelectRegion" xml:space="preserve"><value>請選取螢幕上的區域以測試 PP-OCRv6...</value></data>
+  <data name="PpOcrV6TestCancelled" xml:space="preserve"><value>測試已取消。</value></data>
+  <data name="PpOcrV6TestProcessingGpu" xml:space="preserve"><value>正在使用 PP-OCRv6 GPU 處理...</value></data>
+  <data name="PpOcrV6TestProcessingCpu" xml:space="preserve"><value>正在使用 PP-OCRv6 CPU 處理...</value></data>
+  <data name="PpOcrV6TestNoText" xml:space="preserve"><value>成功：影像已處理，但未辨識出文字。</value></data>
+  <data name="PpOcrV6TestError" xml:space="preserve"><value>[錯誤] {0}</value></data>
+  <data name="PpOcrV6DownloadProgress" xml:space="preserve"><value>{0:F1} / {1:F1} MB</value></data>
 </root>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
@@ -1,0 +1,295 @@
+using System.Diagnostics;
+using Easydict.SidecarClient.Protocol;
+using Easydict.WinUI.Models;
+using Easydict.WinUI.Services;
+using Easydict.WinUI.Services.Workers;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Easydict.WinUI.Views;
+
+public sealed partial class SettingsPage
+{
+    private bool _ppOcrV6UiLoading;
+    private int _ppOcrV6StatusVersion;
+
+    private void InitializePpOcrV6Settings()
+    {
+        _ppOcrV6UiLoading = true;
+        try
+        {
+            PpOcrV6ModelCombo.Items.Clear();
+            foreach (var model in PpOcrV6ModelCatalog.Models)
+            {
+                PpOcrV6ModelCombo.Items.Add(new ComboBoxItem
+                {
+                    Content = model.DisplayName,
+                    Tag = model.Id,
+                });
+            }
+
+            var selectedModel = PpOcrV6ModelCatalog.TryGet(_settings.OcrModel, out _)
+                ? _settings.OcrModel
+                : PpOcrV6ModelCatalog.SmallId;
+            SelectComboByTag(PpOcrV6ModelCombo, selectedModel);
+            PpOcrV6ThreadCountBox.Value = Math.Clamp(_settings.PpOcrV6ThreadCount, 1, 16);
+            PpOcrV6GpuToggle.IsOn = _settings.PpOcrV6UseGpu;
+            PpOcrV6GpuToggle.IsEnabled = true;
+            PpOcrV6FallbackToggle.IsOn = _settings.PpOcrV6AllowFallback;
+        }
+        finally
+        {
+            _ppOcrV6UiLoading = false;
+        }
+
+        UpdatePpOcrV6ModelUi();
+    }
+
+    private string GetSelectedPpOcrV6ModelId()
+    {
+        return GetSelectedTag(PpOcrV6ModelCombo) ?? PpOcrV6ModelCatalog.SmallId;
+    }
+
+    private void UpdatePpOcrV6ModelUi()
+    {
+        if (GetSelectedOcrEngine() != OcrEngineType.PpOcrV6)
+        {
+            PpOcrV6Panel.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        PpOcrV6Panel.Visibility = Visibility.Visible;
+        var modelId = GetSelectedPpOcrV6ModelId();
+        var model = PpOcrV6ModelCatalog.Get(modelId);
+        PpOcrV6DownloadSizeText.Text = $"Download: {model.DownloadSizeBytes / 1_000_000d:F1} MB";
+        PpOcrV6LanguagesText.Text = $"Languages: {model.Languages.Count}";
+        PpOcrV6ModelStatusText.Text = "Checking model...";
+        PpOcrV6DownloadButton.Visibility = Visibility.Collapsed;
+        var version = ++_ppOcrV6StatusVersion;
+        _ = RefreshPpOcrV6ModelStatusAsync(modelId, version);
+    }
+
+    private async Task RefreshPpOcrV6ModelStatusAsync(string modelId, int version)
+    {
+        PpOcrV6ModelState state;
+        using var httpClient = OcrServiceFactory.CreateProxyAwareHttpClient(
+            _settings.ProxyEnabled,
+            _settings.ProxyUri,
+            _settings.ProxyBypassLocal);
+        using var service = new PpOcrV6ModelDownloadService(httpClient);
+        try
+        {
+            state = await service.Store.ValidateAsync(modelId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            state = PpOcrV6ModelState.Invalid;
+            Debug.WriteLine($"[SettingsPage] PP-OCRv6 model validation failed: {ex.Message}");
+        }
+
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (version != _ppOcrV6StatusVersion || GetSelectedPpOcrV6ModelId() != modelId)
+            {
+                return;
+            }
+
+            switch (state)
+            {
+                case PpOcrV6ModelState.Installed:
+                    PpOcrV6ModelStatusText.Text = "Downloaded";
+                    PpOcrV6DownloadButton.Visibility = Visibility.Collapsed;
+                    break;
+                case PpOcrV6ModelState.Invalid:
+                    PpOcrV6ModelStatusText.Text = "Model invalid — repair required";
+                    PpOcrV6DownloadButton.Content = "Repair";
+                    PpOcrV6DownloadButton.Visibility = Visibility.Visible;
+                    break;
+                default:
+                    PpOcrV6ModelStatusText.Text = "Not downloaded";
+                    PpOcrV6DownloadButton.Content = "Download";
+                    PpOcrV6DownloadButton.Visibility = Visibility.Visible;
+                    break;
+            }
+        });
+    }
+
+    private void OnPpOcrV6ModelChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_ppOcrV6UiLoading)
+        {
+            return;
+        }
+
+        UpdatePpOcrV6ModelUi();
+        OnSettingChanged(sender, e);
+    }
+
+    private void OnPpOcrV6ThreadCountChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        if (_ppOcrV6UiLoading)
+        {
+            return;
+        }
+
+        OnSettingChanged(sender, args);
+    }
+
+    private void OnPpOcrV6GpuToggled(object sender, RoutedEventArgs e)
+    {
+        if (_ppOcrV6UiLoading)
+        {
+            return;
+        }
+
+        OnSettingChanged(sender, e);
+    }
+
+    private void OnPpOcrV6FallbackToggled(object sender, RoutedEventArgs e)
+    {
+        if (_ppOcrV6UiLoading)
+        {
+            return;
+        }
+
+        OnSettingChanged(sender, e);
+    }
+
+    private async void OnDownloadPpOcrV6ModelClick(object sender, RoutedEventArgs e)
+    {
+        var modelId = GetSelectedPpOcrV6ModelId();
+        PpOcrV6DownloadButton.IsEnabled = false;
+        PpOcrV6ModelCombo.IsEnabled = false;
+        PpOcrV6DownloadProgress.Visibility = Visibility.Visible;
+        PpOcrV6DownloadProgressText.Visibility = Visibility.Visible;
+        PpOcrV6ModelStatusText.Text = "Downloading...";
+
+        try
+        {
+            using var httpClient = OcrServiceFactory.CreateProxyAwareHttpClient(
+                _settings.ProxyEnabled,
+                _settings.ProxyUri,
+                _settings.ProxyBypassLocal,
+                TimeSpan.FromMinutes(30));
+            using var service = new PpOcrV6ModelDownloadService(httpClient);
+            var progress = new Progress<PpOcrV6DownloadProgress>(value =>
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    PpOcrV6DownloadProgress.IsIndeterminate = value.Percentage < 0;
+                    if (value.Percentage >= 0)
+                    {
+                        PpOcrV6DownloadProgress.Value = value.Percentage;
+                    }
+                    PpOcrV6DownloadProgressText.Text =
+                        $"{value.BytesDownloaded / 1_000_000d:F1} / {value.TotalBytes / 1_000_000d:F1} MB";
+                });
+            });
+
+            var state = await service.DownloadAsync(modelId, progress);
+            if (state != PpOcrV6ModelState.Installed)
+            {
+                throw new InvalidDataException("PP-OCRv6 model did not pass final integrity validation.");
+            }
+
+            _settings.OcrModel = modelId;
+            _settings.Save();
+            UpdatePpOcrV6ModelUi();
+        }
+        catch (Exception ex)
+        {
+            PpOcrV6ModelStatusText.Text = "Download failed";
+            var dialog = new ContentDialog
+            {
+                Title = "PP-OCRv6 download failed",
+                Content = ex.Message,
+                CloseButtonText = "OK",
+                XamlRoot = XamlRoot,
+            };
+            await ShowDialogAsync(dialog);
+        }
+        finally
+        {
+            PpOcrV6DownloadButton.IsEnabled = true;
+            PpOcrV6ModelCombo.IsEnabled = true;
+            PpOcrV6DownloadProgress.Visibility = Visibility.Collapsed;
+            PpOcrV6DownloadProgressText.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    private async void OnTestPpOcrV6Click(object sender, RoutedEventArgs e)
+    {
+        PpOcrV6TestButton.IsEnabled = false;
+        PpOcrV6TestStatusBox.Text = "Select a region on your screen to test PP-OCRv6...";
+
+        try
+        {
+            var capture = await new ScreenCaptureService().CaptureRegionAsync();
+            if (capture is null)
+            {
+                PpOcrV6TestStatusBox.Text = "Test cancelled.";
+                return;
+            }
+
+            using (capture)
+            using (var ocr = new OcrWorkerClient(
+                       SettingsService.Instance,
+                       new WindowsOcrService(),
+                       OcrEngineType.PpOcrV6,
+                       GetSelectedPpOcrV6ModelId(),
+                       GetPpOcrV6ThreadCount(),
+                       allowFallback: false,
+                       useGpu: PpOcrV6GpuToggle.IsOn))
+            {
+                PpOcrV6TestStatusBox.Text = PpOcrV6GpuToggle.IsOn
+                    ? "Processing with PP-OCRv6 GPU..."
+                    : "Processing with PP-OCRv6 CPU...";
+                var result = await ocr.RecognizeAsync(capture);
+                PpOcrV6TestStatusBox.Text = string.IsNullOrWhiteSpace(result.Text)
+                    ? "Success: image processed, but no text was recognized."
+                    : result.Text;
+            }
+        }
+        catch (Exception ex)
+        {
+            PpOcrV6TestStatusBox.Text = $"[Error] {ex.Message}";
+        }
+        finally
+        {
+            PpOcrV6TestButton.IsEnabled = true;
+        }
+    }
+
+    private int GetPpOcrV6ThreadCount()
+    {
+        var value = PpOcrV6ThreadCountBox.Value;
+        return double.IsNaN(value)
+            ? Math.Clamp(_settings.PpOcrV6ThreadCount, 1, 16)
+            : Math.Clamp((int)Math.Round(value), 1, 16);
+    }
+
+    private void SavePpOcrV6Settings()
+    {
+        if (PpOcrV6ModelCombo.Items.Count == 0)
+        {
+            return;
+        }
+
+        if (GetSelectedOcrEngine() == OcrEngineType.PpOcrV6)
+        {
+            _settings.OcrModel = GetSelectedPpOcrV6ModelId();
+        }
+        _settings.PpOcrV6ThreadCount = GetPpOcrV6ThreadCount();
+        _settings.PpOcrV6UseGpu = PpOcrV6GpuToggle.IsOn;
+        _settings.PpOcrV6AllowFallback = PpOcrV6FallbackToggle.IsOn;
+    }
+
+    private bool PpOcrV6SettingsDifferFromSettings()
+    {
+        return GetSelectedOcrEngine() == OcrEngineType.PpOcrV6
+            && (!string.Equals(GetSelectedPpOcrV6ModelId(), _settings.OcrModel, StringComparison.Ordinal)
+                || GetPpOcrV6ThreadCount() != _settings.PpOcrV6ThreadCount
+                || PpOcrV6GpuToggle.IsOn != _settings.PpOcrV6UseGpu
+                || PpOcrV6FallbackToggle.IsOn != _settings.PpOcrV6AllowFallback);
+    }
+}

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Easydict.SidecarClient.Protocol;
+using Easydict.WinUI;
 using Easydict.WinUI.Models;
 using Easydict.WinUI.Services;
 using Easydict.WinUI.Services.Workers;
@@ -12,6 +13,7 @@ public sealed partial class SettingsPage
 {
     private bool _ppOcrV6UiLoading;
     private int _ppOcrV6StatusVersion;
+    private CancellationTokenSource? _ppOcrV6DownloadCts;
 
     private void InitializePpOcrV6Settings()
     {
@@ -87,7 +89,9 @@ public sealed partial class SettingsPage
 
         DispatcherQueue.TryEnqueue(() =>
         {
-            if (version != _ppOcrV6StatusVersion || GetSelectedPpOcrV6ModelId() != modelId)
+            if (_ppOcrV6DownloadCts is not null
+                || version != _ppOcrV6StatusVersion
+                || GetSelectedPpOcrV6ModelId() != modelId)
             {
                 return;
             }
@@ -96,7 +100,8 @@ public sealed partial class SettingsPage
             {
                 case PpOcrV6ModelState.Installed:
                     PpOcrV6ModelStatusText.Text = "Downloaded";
-                    PpOcrV6DownloadButton.Visibility = Visibility.Collapsed;
+                    PpOcrV6DownloadButton.Content = "Remove";
+                    PpOcrV6DownloadButton.Visibility = Visibility.Visible;
                     break;
                 case PpOcrV6ModelState.Invalid:
                     PpOcrV6ModelStatusText.Text = "Model invalid — repair required";
@@ -133,8 +138,27 @@ public sealed partial class SettingsPage
 
     private async void OnDownloadPpOcrV6ModelClick(object sender, RoutedEventArgs e)
     {
+        if (_ppOcrV6DownloadCts is not null)
+        {
+            _ppOcrV6DownloadCts.Cancel();
+            return;
+        }
+
         var modelId = GetSelectedPpOcrV6ModelId();
-        PpOcrV6DownloadButton.IsEnabled = false;
+        if (new PpOcrV6ModelStore().GetStateBySize(modelId) == PpOcrV6ModelState.Installed)
+        {
+            await RemovePpOcrV6ModelAsync(modelId);
+            return;
+        }
+
+        await DownloadPpOcrV6ModelAsync(modelId, sender, e);
+    }
+
+    private async Task DownloadPpOcrV6ModelAsync(string modelId, object sender, object e)
+    {
+        _ppOcrV6DownloadCts = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeCts.Token);
+        PpOcrV6DownloadButton.Content = "Cancel";
+        PpOcrV6DownloadButton.IsEnabled = true;
         PpOcrV6ModelCombo.IsEnabled = false;
         PpOcrV6DownloadProgress.Visibility = Visibility.Visible;
         PpOcrV6DownloadProgressText.Visibility = Visibility.Visible;
@@ -152,6 +176,11 @@ public sealed partial class SettingsPage
             {
                 DispatcherQueue.TryEnqueue(() =>
                 {
+                    if (_ppOcrV6DownloadCts?.IsCancellationRequested != false || _isUnloaded)
+                    {
+                        return;
+                    }
+
                     PpOcrV6DownloadProgress.IsIndeterminate = value.Percentage < 0;
                     if (value.Percentage >= 0)
                     {
@@ -162,7 +191,7 @@ public sealed partial class SettingsPage
                 });
             });
 
-            var state = await service.DownloadAsync(modelId, progress, _lifetimeCts.Token);
+            var state = await service.DownloadAsync(modelId, progress, _ppOcrV6DownloadCts.Token);
             if (state != PpOcrV6ModelState.Installed)
             {
                 throw new InvalidDataException("PP-OCRv6 model did not pass final integrity validation.");
@@ -174,12 +203,11 @@ public sealed partial class SettingsPage
             }
             OnSettingChanged(sender, e);
         }
-        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
         }
         catch (Exception ex)
         {
-            UpdatePpOcrV6ModelUi();
             var dialog = new ContentDialog
             {
                 Title = "PP-OCRv6 download failed",
@@ -191,10 +219,61 @@ public sealed partial class SettingsPage
         }
         finally
         {
-            PpOcrV6DownloadButton.IsEnabled = true;
+            _ppOcrV6DownloadCts.Dispose();
+            _ppOcrV6DownloadCts = null;
             PpOcrV6ModelCombo.IsEnabled = true;
             PpOcrV6DownloadProgress.Visibility = Visibility.Collapsed;
             PpOcrV6DownloadProgressText.Visibility = Visibility.Collapsed;
+            UpdatePpOcrV6ModelUi();
+        }
+    }
+
+    private async Task RemovePpOcrV6ModelAsync(string modelId)
+    {
+        var confirmDialog = new ContentDialog
+        {
+            Title = "Remove PP-OCRv6 model",
+            Content = $"Remove the downloaded model '{modelId}'?",
+            PrimaryButtonText = "Remove",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = XamlRoot,
+        };
+        if (await ShowDialogAsync(confirmDialog) != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        PpOcrV6DownloadButton.IsEnabled = false;
+        try
+        {
+            await App.ReleasePpOcrV6ModelAsync(modelId).ConfigureAwait(true);
+            using var httpClient = OcrServiceFactory.CreateProxyAwareHttpClient(
+                _settings.ProxyEnabled,
+                _settings.ProxyUri,
+                _settings.ProxyBypassLocal,
+                TimeSpan.FromMinutes(30));
+            using var service = new PpOcrV6ModelDownloadService(httpClient);
+            await service.RemoveAsync(modelId, _lifetimeCts.Token).ConfigureAwait(true);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            var dialog = new ContentDialog
+            {
+                Title = "PP-OCRv6 remove failed",
+                Content = ex.Message,
+                CloseButtonText = "OK",
+                XamlRoot = XamlRoot,
+            };
+            await ShowDialogAsync(dialog);
+        }
+        finally
+        {
+            PpOcrV6DownloadButton.IsEnabled = true;
+            UpdatePpOcrV6ModelUi();
         }
     }
 

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
@@ -248,12 +248,7 @@ public sealed partial class SettingsPage
         try
         {
             await App.ReleasePpOcrV6ModelAsync(modelId).ConfigureAwait(true);
-            using var httpClient = OcrServiceFactory.CreateProxyAwareHttpClient(
-                _settings.ProxyEnabled,
-                _settings.ProxyUri,
-                _settings.ProxyBypassLocal,
-                TimeSpan.FromMinutes(30));
-            using var service = new PpOcrV6ModelDownloadService(httpClient);
+            using var service = new PpOcrV6ModelDownloadService();
             await service.RemoveAsync(modelId, _lifetimeCts.Token).ConfigureAwait(true);
         }
         catch (OperationCanceledException)

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
@@ -32,7 +32,10 @@ public sealed partial class SettingsPage
                 ? _settings.OcrModel
                 : PpOcrV6ModelCatalog.SmallId;
             SelectComboByTag(PpOcrV6ModelCombo, selectedModel);
-            PpOcrV6ThreadCountBox.Value = Math.Clamp(_settings.PpOcrV6ThreadCount, 1, 16);
+            PpOcrV6ThreadCountBox.Value = Math.Clamp(
+                _settings.PpOcrV6ThreadCount,
+                PpOcrV6ModelCatalog.MinThreadCount,
+                PpOcrV6ModelCatalog.MaxThreadCount);
             PpOcrV6GpuToggle.IsOn = _settings.PpOcrV6UseGpu;
             PpOcrV6GpuToggle.IsEnabled = true;
             PpOcrV6FallbackToggle.IsOn = _settings.PpOcrV6AllowFallback;
@@ -66,20 +69,15 @@ public sealed partial class SettingsPage
         PpOcrV6ModelStatusText.Text = "Checking model...";
         PpOcrV6DownloadButton.Visibility = Visibility.Collapsed;
         var version = ++_ppOcrV6StatusVersion;
-        _ = RefreshPpOcrV6ModelStatusAsync(modelId, version);
+        RefreshPpOcrV6ModelStatusAsync(modelId, version);
     }
 
-    private async Task RefreshPpOcrV6ModelStatusAsync(string modelId, int version)
+    private void RefreshPpOcrV6ModelStatusAsync(string modelId, int version)
     {
         PpOcrV6ModelState state;
-        using var httpClient = OcrServiceFactory.CreateProxyAwareHttpClient(
-            _settings.ProxyEnabled,
-            _settings.ProxyUri,
-            _settings.ProxyBypassLocal);
-        using var service = new PpOcrV6ModelDownloadService(httpClient);
         try
         {
-            state = await service.Store.ValidateAsync(modelId).ConfigureAwait(false);
+            state = new PpOcrV6ModelStore().GetStateBySize(modelId);
         }
         catch (Exception ex)
         {
@@ -164,19 +162,24 @@ public sealed partial class SettingsPage
                 });
             });
 
-            var state = await service.DownloadAsync(modelId, progress);
+            var state = await service.DownloadAsync(modelId, progress, _lifetimeCts.Token);
             if (state != PpOcrV6ModelState.Installed)
             {
                 throw new InvalidDataException("PP-OCRv6 model did not pass final integrity validation.");
             }
 
-            _settings.OcrModel = modelId;
-            _settings.Save();
-            UpdatePpOcrV6ModelUi();
+            if (GetSelectedOcrEngine() == OcrEngineType.PpOcrV6)
+            {
+                _settings.OcrModel = modelId;
+            }
+            OnSettingChanged(sender, e);
+        }
+        catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+        {
         }
         catch (Exception ex)
         {
-            PpOcrV6ModelStatusText.Text = "Download failed";
+            UpdatePpOcrV6ModelUi();
             var dialog = new ContentDialog
             {
                 Title = "PP-OCRv6 download failed",
@@ -242,8 +245,8 @@ public sealed partial class SettingsPage
     {
         var value = PpOcrV6ThreadCountBox.Value;
         return double.IsNaN(value)
-            ? Math.Clamp(_settings.PpOcrV6ThreadCount, 1, 16)
-            : Math.Clamp((int)Math.Round(value), 1, 16);
+            ? Math.Clamp(_settings.PpOcrV6ThreadCount, PpOcrV6ModelCatalog.MinThreadCount, PpOcrV6ModelCatalog.MaxThreadCount)
+            : Math.Clamp((int)Math.Round(value), PpOcrV6ModelCatalog.MinThreadCount, PpOcrV6ModelCatalog.MaxThreadCount);
     }
 
     private void SavePpOcrV6Settings()
@@ -255,7 +258,11 @@ public sealed partial class SettingsPage
 
         if (GetSelectedOcrEngine() == OcrEngineType.PpOcrV6)
         {
-            _settings.OcrModel = GetSelectedPpOcrV6ModelId();
+            var modelId = GetSelectedPpOcrV6ModelId();
+            if (new PpOcrV6ModelStore().GetStateBySize(modelId) == PpOcrV6ModelState.Installed)
+            {
+                _settings.OcrModel = modelId;
+            }
         }
         _settings.PpOcrV6ThreadCount = GetPpOcrV6ThreadCount();
         _settings.PpOcrV6UseGpu = PpOcrV6GpuToggle.IsOn;

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
@@ -20,12 +20,19 @@ public sealed partial class SettingsPage
         _ppOcrV6UiLoading = true;
         try
         {
+            var loc = LocalizationService.Instance;
             PpOcrV6ModelCombo.Items.Clear();
             foreach (var model in PpOcrV6ModelCatalog.Models)
             {
                 PpOcrV6ModelCombo.Items.Add(new ComboBoxItem
                 {
-                    Content = model.DisplayName,
+                    Content = model.Id switch
+                    {
+                        PpOcrV6ModelCatalog.TinyId => loc.GetString("PpOcrV6ModelTiny"),
+                        PpOcrV6ModelCatalog.SmallId => loc.GetString("PpOcrV6ModelSmall"),
+                        PpOcrV6ModelCatalog.MediumId => loc.GetString("PpOcrV6ModelMedium"),
+                        _ => model.DisplayName,
+                    },
                     Tag = model.Id,
                 });
             }
@@ -65,11 +72,14 @@ public sealed partial class SettingsPage
         }
 
         PpOcrV6Panel.Visibility = Visibility.Visible;
+        var loc = LocalizationService.Instance;
         var modelId = GetSelectedPpOcrV6ModelId();
         var model = PpOcrV6ModelCatalog.Get(modelId);
-        PpOcrV6DownloadSizeText.Text = $"Download: {model.DownloadSizeBytes / 1_000_000d:F1} MB";
-        PpOcrV6LanguagesText.Text = $"Languages: {model.Languages.Count}";
-        PpOcrV6ModelStatusText.Text = "Checking model...";
+        PpOcrV6DownloadSizeText.Text = loc.GetString(
+            "PpOcrV6DownloadSize",
+            model.DownloadSizeBytes / 1_000_000d);
+        PpOcrV6LanguagesText.Text = loc.GetString("PpOcrV6LanguageCount", model.Languages.Count);
+        PpOcrV6ModelStatusText.Text = loc.GetString("PpOcrV6StatusChecking");
         PpOcrV6DownloadButton.Visibility = Visibility.Collapsed;
         var version = ++_ppOcrV6StatusVersion;
         _ = RefreshPpOcrV6ModelStatusAsync(modelId, version);
@@ -97,21 +107,22 @@ public sealed partial class SettingsPage
                 return;
             }
 
+            var loc = LocalizationService.Instance;
             switch (state)
             {
                 case PpOcrV6ModelState.Installed:
-                    PpOcrV6ModelStatusText.Text = "Downloaded";
-                    PpOcrV6DownloadButton.Content = "Remove";
+                    PpOcrV6ModelStatusText.Text = loc.GetString("PpOcrV6StatusDownloaded");
+                    PpOcrV6DownloadButton.Content = loc.GetString("PpOcrV6ActionRemove");
                     PpOcrV6DownloadButton.Visibility = Visibility.Visible;
                     break;
                 case PpOcrV6ModelState.Invalid:
-                    PpOcrV6ModelStatusText.Text = "Model invalid — repair required";
-                    PpOcrV6DownloadButton.Content = "Repair";
+                    PpOcrV6ModelStatusText.Text = loc.GetString("PpOcrV6StatusInvalid");
+                    PpOcrV6DownloadButton.Content = loc.GetString("PpOcrV6ActionRepair");
                     PpOcrV6DownloadButton.Visibility = Visibility.Visible;
                     break;
                 default:
-                    PpOcrV6ModelStatusText.Text = "Not downloaded";
-                    PpOcrV6DownloadButton.Content = "Download";
+                    PpOcrV6ModelStatusText.Text = loc.GetString("PpOcrV6StatusNotDownloaded");
+                    PpOcrV6DownloadButton.Content = loc.GetString("PpOcrV6ActionDownload");
                     PpOcrV6DownloadButton.Visibility = Visibility.Visible;
                     break;
             }
@@ -158,12 +169,12 @@ public sealed partial class SettingsPage
     private async Task DownloadPpOcrV6ModelAsync(string modelId, object sender, object e)
     {
         _ppOcrV6DownloadCts = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeCts.Token);
-        PpOcrV6DownloadButton.Content = "Cancel";
+        PpOcrV6DownloadButton.Content = LocalizationService.Instance.GetString("Cancel");
         PpOcrV6DownloadButton.IsEnabled = true;
         PpOcrV6ModelCombo.IsEnabled = false;
         PpOcrV6DownloadProgress.Visibility = Visibility.Visible;
         PpOcrV6DownloadProgressText.Visibility = Visibility.Visible;
-        PpOcrV6ModelStatusText.Text = "Downloading...";
+        PpOcrV6ModelStatusText.Text = LocalizationService.Instance.GetString("PpOcrV6StatusDownloading");
 
         try
         {
@@ -187,15 +198,18 @@ public sealed partial class SettingsPage
                     {
                         PpOcrV6DownloadProgress.Value = value.Percentage;
                     }
-                    PpOcrV6DownloadProgressText.Text =
-                        $"{value.BytesDownloaded / 1_000_000d:F1} / {value.TotalBytes / 1_000_000d:F1} MB";
+                    PpOcrV6DownloadProgressText.Text = LocalizationService.Instance.GetString(
+                        "PpOcrV6DownloadProgress",
+                        value.BytesDownloaded / 1_000_000d,
+                        value.TotalBytes / 1_000_000d);
                 });
             });
 
             var state = await service.DownloadAsync(modelId, progress, _ppOcrV6DownloadCts.Token);
             if (state != PpOcrV6ModelState.Installed)
             {
-                throw new InvalidDataException("PP-OCRv6 model did not pass final integrity validation.");
+                throw new InvalidDataException(
+                    LocalizationService.Instance.GetString("PpOcrV6IntegrityValidationFailed"));
             }
 
             OnSettingChanged(sender, e);
@@ -205,11 +219,12 @@ public sealed partial class SettingsPage
         }
         catch (Exception ex)
         {
+            var loc = LocalizationService.Instance;
             var dialog = new ContentDialog
             {
-                Title = "PP-OCRv6 download failed",
+                Title = loc.GetString("PpOcrV6DownloadFailedTitle"),
                 Content = ex.Message,
-                CloseButtonText = "OK",
+                CloseButtonText = loc.GetString("OK"),
                 XamlRoot = XamlRoot,
             };
             await ShowDialogAsync(dialog);
@@ -227,12 +242,13 @@ public sealed partial class SettingsPage
 
     private async Task RemovePpOcrV6ModelAsync(string modelId)
     {
+        var loc = LocalizationService.Instance;
         var confirmDialog = new ContentDialog
         {
-            Title = "Remove PP-OCRv6 model",
-            Content = $"Remove the downloaded model '{modelId}'?",
-            PrimaryButtonText = "Remove",
-            CloseButtonText = "Cancel",
+            Title = loc.GetString("PpOcrV6RemoveTitle"),
+            Content = loc.GetString("PpOcrV6RemoveMessage", modelId),
+            PrimaryButtonText = loc.GetString("PpOcrV6ActionRemove"),
+            CloseButtonText = loc.GetString("Cancel"),
             DefaultButton = ContentDialogButton.Close,
             XamlRoot = XamlRoot,
         };
@@ -255,9 +271,9 @@ public sealed partial class SettingsPage
         {
             var dialog = new ContentDialog
             {
-                Title = "PP-OCRv6 remove failed",
+                Title = loc.GetString("PpOcrV6RemoveFailedTitle"),
                 Content = ex.Message,
-                CloseButtonText = "OK",
+                CloseButtonText = loc.GetString("OK"),
                 XamlRoot = XamlRoot,
             };
             await ShowDialogAsync(dialog);
@@ -272,14 +288,15 @@ public sealed partial class SettingsPage
     private async void OnTestPpOcrV6Click(object sender, RoutedEventArgs e)
     {
         PpOcrV6TestButton.IsEnabled = false;
-        PpOcrV6TestStatusBox.Text = "Select a region on your screen to test PP-OCRv6...";
+        var loc = LocalizationService.Instance;
+        PpOcrV6TestStatusBox.Text = loc.GetString("PpOcrV6TestSelectRegion");
 
         try
         {
             var capture = await new ScreenCaptureService().CaptureRegionAsync();
             if (capture is null)
             {
-                PpOcrV6TestStatusBox.Text = "Test cancelled.";
+                PpOcrV6TestStatusBox.Text = loc.GetString("PpOcrV6TestCancelled");
                 return;
             }
 
@@ -293,18 +310,19 @@ public sealed partial class SettingsPage
                        allowFallback: false,
                        useGpu: PpOcrV6GpuToggle.IsOn))
             {
-                PpOcrV6TestStatusBox.Text = PpOcrV6GpuToggle.IsOn
-                    ? "Processing with PP-OCRv6 GPU..."
-                    : "Processing with PP-OCRv6 CPU...";
+                PpOcrV6TestStatusBox.Text = loc.GetString(
+                    PpOcrV6GpuToggle.IsOn
+                        ? "PpOcrV6TestProcessingGpu"
+                        : "PpOcrV6TestProcessingCpu");
                 var result = await ocr.RecognizeAsync(capture);
                 PpOcrV6TestStatusBox.Text = string.IsNullOrWhiteSpace(result.Text)
-                    ? "Success: image processed, but no text was recognized."
+                    ? loc.GetString("PpOcrV6TestNoText")
                     : result.Text;
             }
         }
         catch (Exception ex)
         {
-            PpOcrV6TestStatusBox.Text = $"[Error] {ex.Message}";
+            PpOcrV6TestStatusBox.Text = loc.GetString("PpOcrV6TestError", ex.Message);
         }
         finally
         {

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
@@ -125,34 +125,12 @@ public sealed partial class SettingsPage
         OnSettingChanged(sender, e);
     }
 
-    private void OnPpOcrV6ThreadCountChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    private void OnPpOcrV6SettingChanged(object sender, object e)
     {
-        if (_ppOcrV6UiLoading)
+        if (!_ppOcrV6UiLoading)
         {
-            return;
+            OnSettingChanged(sender, e);
         }
-
-        OnSettingChanged(sender, args);
-    }
-
-    private void OnPpOcrV6GpuToggled(object sender, RoutedEventArgs e)
-    {
-        if (_ppOcrV6UiLoading)
-        {
-            return;
-        }
-
-        OnSettingChanged(sender, e);
-    }
-
-    private void OnPpOcrV6FallbackToggled(object sender, RoutedEventArgs e)
-    {
-        if (_ppOcrV6UiLoading)
-        {
-            return;
-        }
-
-        OnSettingChanged(sender, e);
     }
 
     private async void OnDownloadPpOcrV6ModelClick(object sender, RoutedEventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.PpOcrV6.cs
@@ -30,8 +30,8 @@ public sealed partial class SettingsPage
                 });
             }
 
-            var selectedModel = PpOcrV6ModelCatalog.TryGet(_settings.OcrModel, out _)
-                ? _settings.OcrModel
+            var selectedModel = PpOcrV6ModelCatalog.TryGet(_settings.PpOcrV6ModelId, out _)
+                ? _settings.PpOcrV6ModelId
                 : PpOcrV6ModelCatalog.SmallId;
             SelectComboByTag(PpOcrV6ModelCombo, selectedModel);
             PpOcrV6ThreadCountBox.Value = Math.Clamp(
@@ -47,7 +47,8 @@ public sealed partial class SettingsPage
             _ppOcrV6UiLoading = false;
         }
 
-        UpdatePpOcrV6ModelUi();
+        PpOcrV6ThreadCountBox.Minimum = PpOcrV6ModelCatalog.MinThreadCount;
+        PpOcrV6ThreadCountBox.Maximum = PpOcrV6ModelCatalog.MaxThreadCount;
     }
 
     private string GetSelectedPpOcrV6ModelId()
@@ -71,15 +72,15 @@ public sealed partial class SettingsPage
         PpOcrV6ModelStatusText.Text = "Checking model...";
         PpOcrV6DownloadButton.Visibility = Visibility.Collapsed;
         var version = ++_ppOcrV6StatusVersion;
-        RefreshPpOcrV6ModelStatusAsync(modelId, version);
+        _ = RefreshPpOcrV6ModelStatusAsync(modelId, version);
     }
 
-    private void RefreshPpOcrV6ModelStatusAsync(string modelId, int version)
+    private async Task RefreshPpOcrV6ModelStatusAsync(string modelId, int version)
     {
         PpOcrV6ModelState state;
         try
         {
-            state = new PpOcrV6ModelStore().GetStateBySize(modelId);
+            state = await Task.Run(() => _ppOcrV6ModelStore.GetStateBySize(modelId)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -145,7 +146,7 @@ public sealed partial class SettingsPage
         }
 
         var modelId = GetSelectedPpOcrV6ModelId();
-        if (new PpOcrV6ModelStore().GetStateBySize(modelId) == PpOcrV6ModelState.Installed)
+        if (_ppOcrV6ModelStore.GetStateBySize(modelId) == PpOcrV6ModelState.Installed)
         {
             await RemovePpOcrV6ModelAsync(modelId);
             return;
@@ -197,10 +198,6 @@ public sealed partial class SettingsPage
                 throw new InvalidDataException("PP-OCRv6 model did not pass final integrity validation.");
             }
 
-            if (GetSelectedOcrEngine() == OcrEngineType.PpOcrV6)
-            {
-                _settings.OcrModel = modelId;
-            }
             OnSettingChanged(sender, e);
         }
         catch (OperationCanceledException)
@@ -287,7 +284,7 @@ public sealed partial class SettingsPage
             }
 
             using (capture)
-            using (var ocr = new OcrWorkerClient(
+            await using (var ocr = new OcrWorkerClient(
                        SettingsService.Instance,
                        new WindowsOcrService(),
                        OcrEngineType.PpOcrV6,
@@ -333,9 +330,9 @@ public sealed partial class SettingsPage
         if (GetSelectedOcrEngine() == OcrEngineType.PpOcrV6)
         {
             var modelId = GetSelectedPpOcrV6ModelId();
-            if (new PpOcrV6ModelStore().GetStateBySize(modelId) == PpOcrV6ModelState.Installed)
+            if (_ppOcrV6ModelStore.GetStateBySize(modelId) == PpOcrV6ModelState.Installed)
             {
-                _settings.OcrModel = modelId;
+                _settings.PpOcrV6ModelId = modelId;
             }
         }
         _settings.PpOcrV6ThreadCount = GetPpOcrV6ThreadCount();
@@ -346,7 +343,7 @@ public sealed partial class SettingsPage
     private bool PpOcrV6SettingsDifferFromSettings()
     {
         return GetSelectedOcrEngine() == OcrEngineType.PpOcrV6
-            && (!string.Equals(GetSelectedPpOcrV6ModelId(), _settings.OcrModel, StringComparison.Ordinal)
+            && (!string.Equals(GetSelectedPpOcrV6ModelId(), _settings.PpOcrV6ModelId, StringComparison.Ordinal)
                 || GetPpOcrV6ThreadCount() != _settings.PpOcrV6ThreadCount
                 || PpOcrV6GpuToggle.IsOn != _settings.PpOcrV6UseGpu
                 || PpOcrV6FallbackToggle.IsOn != _settings.PpOcrV6AllowFallback);

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -2488,7 +2488,67 @@
                                     <ComboBoxItem x:Name="OcrEngineCustomApiItem"
                                             Content="Custom API"
                                             Tag="CustomApi"/>
+                                    <ComboBoxItem x:Name="OcrEnginePpOcrV6Item"
+                                            Content="PP-OCRv6 (Local)"
+                                            Tag="PpOcrV6"/>
                                 </ComboBox>
+
+                                <StackPanel x:Name="PpOcrV6Panel"
+                                        Spacing="12"
+                                        Visibility="Collapsed">
+                                    <ComboBox x:Name="PpOcrV6ModelCombo"
+                                            Header="PP-OCRv6 Model"
+                                            Width="350"
+                                            SelectionChanged="OnPpOcrV6ModelChanged"/>
+                                    <TextBlock x:Name="PpOcrV6DownloadSizeText"
+                                            FontSize="12"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                    <TextBlock x:Name="PpOcrV6LanguagesText"
+                                            FontSize="12"
+                                            MaxWidth="450"
+                                            TextWrapping="Wrap"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                    <TextBlock x:Name="PpOcrV6ModelStatusText"
+                                            FontSize="13"/>
+                                    <Button x:Name="PpOcrV6DownloadButton"
+                                            Content="Download"
+                                            HorizontalAlignment="Left"
+                                            Click="OnDownloadPpOcrV6ModelClick"/>
+                                    <ProgressBar x:Name="PpOcrV6DownloadProgress"
+                                            Minimum="0"
+                                            Maximum="100"
+                                            Visibility="Collapsed"
+                                            Width="350"/>
+                                    <TextBlock x:Name="PpOcrV6DownloadProgressText"
+                                            Visibility="Collapsed"
+                                            FontSize="12"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                    <NumberBox x:Name="PpOcrV6ThreadCountBox"
+                                            Header="CPU Threads"
+                                            Minimum="1"
+                                            Maximum="16"
+                                            SpinButtonPlacementMode="Inline"
+                                            ValueChanged="OnPpOcrV6ThreadCountChanged"
+                                            Width="180"/>
+                                    <ToggleSwitch x:Name="PpOcrV6GpuToggle"
+                                            Header="Use GPU (DirectML)"
+                                            Toggled="OnPpOcrV6GpuToggled"/>
+                                    <ToggleSwitch x:Name="PpOcrV6FallbackToggle"
+                                            Header="Fallback to Windows OCR"
+                                            Toggled="OnPpOcrV6FallbackToggled"/>
+                                    <Button x:Name="PpOcrV6TestButton"
+                                            Content="Test PP-OCRv6"
+                                            HorizontalAlignment="Left"
+                                            Click="OnTestPpOcrV6Click"/>
+                                    <TextBox x:Name="PpOcrV6TestStatusBox"
+                                            Header="Test Result"
+                                            IsReadOnly="True"
+                                            Width="350"
+                                            MinHeight="32"
+                                            AcceptsReturn="True"
+                                            TextWrapping="Wrap"
+                                            HorizontalAlignment="Left"/>
+                                </StackPanel>
 
                                 <!-- Advanced OCR Settings -->
                                 <StackPanel x:Name="AdvancedOcrPanel"

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -2489,7 +2489,6 @@
                                             Content="Custom API"
                                             Tag="CustomApi"/>
                                     <ComboBoxItem x:Name="OcrEnginePpOcrV6Item"
-                                            Content="PP-OCRv6 (Local)"
                                             Tag="PpOcrV6"/>
                                 </ComboBox>
 
@@ -2497,7 +2496,6 @@
                                         Spacing="12"
                                         Visibility="Collapsed">
                                     <ComboBox x:Name="PpOcrV6ModelCombo"
-                                            Header="PP-OCRv6 Model"
                                             Width="350"
                                             SelectionChanged="OnPpOcrV6ModelChanged"/>
                                     <TextBlock x:Name="PpOcrV6DownloadSizeText"
@@ -2511,7 +2509,6 @@
                                     <TextBlock x:Name="PpOcrV6ModelStatusText"
                                             FontSize="13"/>
                                     <Button x:Name="PpOcrV6DownloadButton"
-                                            Content="Download"
                                             HorizontalAlignment="Left"
                                             Click="OnDownloadPpOcrV6ModelClick"/>
                                     <ProgressBar x:Name="PpOcrV6DownloadProgress"
@@ -2524,22 +2521,17 @@
                                             FontSize="12"
                                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                                     <NumberBox x:Name="PpOcrV6ThreadCountBox"
-                                            Header="CPU Threads"
                                             SpinButtonPlacementMode="Inline"
                                             ValueChanged="OnPpOcrV6SettingChanged"
                                             Width="180"/>
                                     <ToggleSwitch x:Name="PpOcrV6GpuToggle"
-                                            Header="Use GPU (DirectML)"
                                             Toggled="OnPpOcrV6SettingChanged"/>
                                     <ToggleSwitch x:Name="PpOcrV6FallbackToggle"
-                                            Header="Fallback to Windows OCR"
                                             Toggled="OnPpOcrV6SettingChanged"/>
                                     <Button x:Name="PpOcrV6TestButton"
-                                            Content="Test PP-OCRv6"
                                             HorizontalAlignment="Left"
                                             Click="OnTestPpOcrV6Click"/>
                                     <TextBox x:Name="PpOcrV6TestStatusBox"
-                                            Header="Test Result"
                                             IsReadOnly="True"
                                             Width="350"
                                             MinHeight="32"

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -2525,8 +2525,6 @@
                                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                                     <NumberBox x:Name="PpOcrV6ThreadCountBox"
                                             Header="CPU Threads"
-                                            Minimum="1"
-                                            Maximum="16"
                                             SpinButtonPlacementMode="Inline"
                                             ValueChanged="OnPpOcrV6SettingChanged"
                                             Width="180"/>

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml
@@ -2528,14 +2528,14 @@
                                             Minimum="1"
                                             Maximum="16"
                                             SpinButtonPlacementMode="Inline"
-                                            ValueChanged="OnPpOcrV6ThreadCountChanged"
+                                            ValueChanged="OnPpOcrV6SettingChanged"
                                             Width="180"/>
                                     <ToggleSwitch x:Name="PpOcrV6GpuToggle"
                                             Header="Use GPU (DirectML)"
-                                            Toggled="OnPpOcrV6GpuToggled"/>
+                                            Toggled="OnPpOcrV6SettingChanged"/>
                                     <ToggleSwitch x:Name="PpOcrV6FallbackToggle"
                                             Header="Fallback to Windows OCR"
-                                            Toggled="OnPpOcrV6FallbackToggled"/>
+                                            Toggled="OnPpOcrV6SettingChanged"/>
                                     <Button x:Name="PpOcrV6TestButton"
                                             Content="Test PP-OCRv6"
                                             HorizontalAlignment="Left"

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -4284,6 +4284,23 @@ public sealed partial class SettingsPage : Page
             }
         }
 
+        if (GetSelectedOcrEngine() == OcrEngineType.PpOcrV6)
+        {
+            var modelId = GetSelectedPpOcrV6ModelId();
+            if (new PpOcrV6ModelStore().GetStateBySize(modelId) != PpOcrV6ModelState.Installed)
+            {
+                var errorDialog = new ContentDialog
+                {
+                    Title = "PP-OCRv6 model unavailable",
+                    Content = $"Download the PP-OCRv6 model '{modelId}' before selecting this engine.",
+                    CloseButtonText = loc.GetString("OK"),
+                    XamlRoot = this.XamlRoot
+                };
+                await ShowDialogAsync(errorDialog);
+                return false;
+            }
+        }
+
         // Validate hotkey strings — an enabled hotkey that cannot be parsed
         // (or that has no modifier and is not a function key) would silently
         // fail to register, so block the save and tell the user.
@@ -4393,11 +4410,9 @@ public sealed partial class SettingsPage : Page
         _settings.OcrEngine = ocrOptions.Engine;
         _settings.OcrApiKey = ocrOptions.ApiKey;
         _settings.OcrEndpoint = ocrOptions.Endpoint;
-        if (ocrOptions.Engine != OcrEngineType.PpOcrV6
-            || new PpOcrV6ModelStore().GetStateBySize(ocrOptions.Model) == PpOcrV6ModelState.Installed)
-        {
-            _settings.OcrModel = ocrOptions.Model;
-        }
+        _settings.OcrModel = ocrOptions.Engine == OcrEngineType.PpOcrV6
+            ? GetSelectedPpOcrV6ModelId()
+            : ocrOptions.Model;
         _settings.OcrSystemPrompt = ocrOptions.SystemPrompt;
         _settings.OcrEnableThinking = ocrOptions.EnableThinking;
         SavePpOcrV6Settings();

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -2192,6 +2192,7 @@ public sealed partial class SettingsPage : Page
 
         try
         {
+            _ppOcrV6DownloadCts?.Cancel();
             _lifetimeCts.Cancel();
         }
         catch (ObjectDisposedException)

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -188,6 +188,7 @@ public sealed partial class SettingsPage : Page
 #endif
     };
     private readonly SettingsService _settings = SettingsService.Instance;
+    private readonly PpOcrV6ModelStore _ppOcrV6ModelStore = new();
     private bool _isLoading = true; // Prevent change detection during initial load
     private bool _isInitialized;
     private bool _isUnloaded;
@@ -2865,7 +2866,7 @@ public sealed partial class SettingsPage : Page
         return ocrOptions.Engine != _settings.OcrEngine
             || !SameSetting(ocrOptions.ApiKey, _settings.OcrApiKey)
             || !SameSetting(ocrOptions.Endpoint, _settings.OcrEndpoint)
-            || !SameSetting(ocrOptions.Model, _settings.OcrModel)
+            || (ocrOptions.Engine != OcrEngineType.PpOcrV6 && !SameSetting(ocrOptions.Model, _settings.OcrModel))
             || !SameSetting(ocrOptions.SystemPrompt, _settings.OcrSystemPrompt)
             || ocrOptions.EnableThinking != _settings.OcrEnableThinking
             || PpOcrV6SettingsDifferFromSettings()
@@ -3152,7 +3153,9 @@ public sealed partial class SettingsPage : Page
             SelectComboByTag(OcrEngineCombo, _settings.OcrEngine.ToString());
             OcrApiKeyBox.Password = _settings.OcrApiKey ?? string.Empty;
             OcrEndpointBox.Text = _settings.OcrEndpoint;
-            OcrModelBox.Text = _settings.OcrModel;
+            OcrModelBox.Text = PpOcrV6ModelCatalog.TryGet(_settings.OcrModel, out _)
+                ? OcrServiceOptions.DefaultModel
+                : _settings.OcrModel;
             OcrSystemPromptBox.Text = _settings.OcrSystemPrompt;
             OcrEnableThinkingToggle.IsOn = _settings.OcrEnableThinking;
             InitializePpOcrV6Settings();
@@ -3965,7 +3968,9 @@ public sealed partial class SettingsPage : Page
             engine,
             OcrApiKeyBox.Password,
             OcrEndpointBox.Text,
-            OcrModelBox.Text,
+            engine == OcrEngineType.PpOcrV6
+                ? GetSelectedPpOcrV6ModelId()
+                : OcrModelBox.Text,
             OcrSystemPromptBox.Text,
             OcrEnableThinkingToggle.IsOn);
     }
@@ -4287,12 +4292,12 @@ public sealed partial class SettingsPage : Page
         if (GetSelectedOcrEngine() == OcrEngineType.PpOcrV6)
         {
             var modelId = GetSelectedPpOcrV6ModelId();
-            if (new PpOcrV6ModelStore().GetStateBySize(modelId) != PpOcrV6ModelState.Installed)
+            if (await Task.Run(() => _ppOcrV6ModelStore.GetStateBySize(modelId)) != PpOcrV6ModelState.Installed)
             {
                 var errorDialog = new ContentDialog
                 {
-                    Title = "PP-OCRv6 model unavailable",
-                    Content = $"Download the PP-OCRv6 model '{modelId}' before selecting this engine.",
+                    Title = loc.GetString("PpOcrV6ModelUnavailableTitle"),
+                    Content = loc.GetString("PpOcrV6ModelUnavailableMessage", modelId),
                     CloseButtonText = loc.GetString("OK"),
                     XamlRoot = this.XamlRoot
                 };
@@ -4410,9 +4415,10 @@ public sealed partial class SettingsPage : Page
         _settings.OcrEngine = ocrOptions.Engine;
         _settings.OcrApiKey = ocrOptions.ApiKey;
         _settings.OcrEndpoint = ocrOptions.Endpoint;
-        _settings.OcrModel = ocrOptions.Engine == OcrEngineType.PpOcrV6
-            ? GetSelectedPpOcrV6ModelId()
-            : ocrOptions.Model;
+        if (ocrOptions.Engine != OcrEngineType.PpOcrV6)
+        {
+            _settings.OcrModel = ocrOptions.Model;
+        }
         _settings.OcrSystemPrompt = ocrOptions.SystemPrompt;
         _settings.OcrEnableThinking = ocrOptions.EnableThinking;
         SavePpOcrV6Settings();
@@ -4787,19 +4793,33 @@ public sealed partial class SettingsPage : Page
                     ProxyUriBox.Text,
                     ProxyBypassLocalToggle.IsOn);
                 var ocrEngine = OcrServiceFactory.Create(GetCurrentOcrServiceOptions(), httpClient);
-                var result = await ocrEngine.RecognizeAsync(capture, null, CancellationToken.None);
-
-                DispatcherQueue.TryEnqueue(() =>
+                try
                 {
-                    if (string.IsNullOrWhiteSpace(result.Text))
+                    var result = await ocrEngine.RecognizeAsync(capture, null, CancellationToken.None);
+
+                    DispatcherQueue.TryEnqueue(() =>
                     {
-                        OcrTestStatusBox.Text = "Success: Image processed, but no text was recognized.";
+                        if (string.IsNullOrWhiteSpace(result.Text))
+                        {
+                            OcrTestStatusBox.Text = "Success: Image processed, but no text was recognized.";
+                        }
+                        else
+                        {
+                            OcrTestStatusBox.Text = result.Text;
+                        }
+                    });
+                }
+                finally
+                {
+                    if (ocrEngine is IAsyncDisposable asyncDisposable)
+                    {
+                        await asyncDisposable.DisposeAsync();
                     }
                     else
                     {
-                        OcrTestStatusBox.Text = result.Text;
+                        (ocrEngine as IDisposable)?.Dispose();
                     }
-                });
+                }
             }
         }
         catch (Exception ex)

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -1672,6 +1672,7 @@ public sealed partial class SettingsPage : Page
         OcrEngineCombo.Header = loc.GetString("OcrEngine");
         OcrEngineNativeItem.Content = loc.GetString("OcrEngineNative");
         OcrEngineCustomApiItem.Content = loc.GetString("OcrEngineCustomApi");
+        OcrEnginePpOcrV6Item.Content = "PP-OCRv6 (Local)";
         OcrApiKeyHeaderText.Text = loc.GetString("OcrApiKey");
         OcrEndpointBox.Header = loc.GetString("OcrEndpoint");
         OcrModelBox.Header = loc.GetString("OcrModel");
@@ -2865,6 +2866,7 @@ public sealed partial class SettingsPage : Page
             || !SameSetting(ocrOptions.Model, _settings.OcrModel)
             || !SameSetting(ocrOptions.SystemPrompt, _settings.OcrSystemPrompt)
             || ocrOptions.EnableThinking != _settings.OcrEnableThinking
+            || PpOcrV6SettingsDifferFromSettings()
             || ProxyEnabledToggle.IsOn != _settings.ProxyEnabled
             || ProxyBypassLocalToggle.IsOn != _settings.ProxyBypassLocal
             || !SameSetting(ProxyUriBox.Text?.Trim() ?? "", _settings.ProxyUri)
@@ -3151,6 +3153,7 @@ public sealed partial class SettingsPage : Page
             OcrModelBox.Text = _settings.OcrModel;
             OcrSystemPromptBox.Text = _settings.OcrSystemPrompt;
             OcrEnableThinkingToggle.IsOn = _settings.OcrEnableThinking;
+            InitializePpOcrV6Settings();
             ApplyOcrEngineDefaultsIfNeeded(GetSelectedOcrEngine());
             UpdateOcrEngineUI();
 
@@ -4391,6 +4394,7 @@ public sealed partial class SettingsPage : Page
         _settings.OcrModel = ocrOptions.Model;
         _settings.OcrSystemPrompt = ocrOptions.SystemPrompt;
         _settings.OcrEnableThinking = ocrOptions.EnableThinking;
+        SavePpOcrV6Settings();
 
         // Save Built-in AI settings
         _settings.BuiltInAIModel = GetEditableComboValue(BuiltInModelCombo, "glm-4-flash-250414");
@@ -4688,6 +4692,13 @@ public sealed partial class SettingsPage : Page
         AdvancedOcrPanel.Visibility = isAdvanced ? Visibility.Visible : Visibility.Collapsed;
         OcrEndpointBox.PlaceholderText = OcrServiceOptions.GetDefaultEndpoint(engine);
         OcrModelBox.PlaceholderText = OcrServiceOptions.GetDefaultModel(engine);
+        PpOcrV6Panel.Visibility = engine == OcrEngineType.PpOcrV6
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        if (engine == OcrEngineType.PpOcrV6 && !_ppOcrV6UiLoading)
+        {
+            UpdatePpOcrV6ModelUi();
+        }
     }
 
     private void OnPasswordRevealButtonClick(object sender, RoutedEventArgs e)

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -16,6 +16,7 @@ using Easydict.OpenVINO.Services;
 using Easydict.WindowsAI.Services;
 using Easydict.WinUI.Models;
 using Easydict.WinUI.Services;
+using Easydict.SidecarClient.Protocol;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Media;
@@ -4391,7 +4392,11 @@ public sealed partial class SettingsPage : Page
         _settings.OcrEngine = ocrOptions.Engine;
         _settings.OcrApiKey = ocrOptions.ApiKey;
         _settings.OcrEndpoint = ocrOptions.Endpoint;
-        _settings.OcrModel = ocrOptions.Model;
+        if (ocrOptions.Engine != OcrEngineType.PpOcrV6
+            || new PpOcrV6ModelStore().GetStateBySize(ocrOptions.Model) == PpOcrV6ModelState.Installed)
+        {
+            _settings.OcrModel = ocrOptions.Model;
+        }
         _settings.OcrSystemPrompt = ocrOptions.SystemPrompt;
         _settings.OcrEnableThinking = ocrOptions.EnableThinking;
         SavePpOcrV6Settings();

--- a/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/Views/SettingsPage.xaml.cs
@@ -1674,7 +1674,7 @@ public sealed partial class SettingsPage : Page
         OcrEngineCombo.Header = loc.GetString("OcrEngine");
         OcrEngineNativeItem.Content = loc.GetString("OcrEngineNative");
         OcrEngineCustomApiItem.Content = loc.GetString("OcrEngineCustomApi");
-        OcrEnginePpOcrV6Item.Content = "PP-OCRv6 (Local)";
+        OcrEnginePpOcrV6Item.Content = loc.GetString("PpOcrV6EngineLocal");
         OcrApiKeyHeaderText.Text = loc.GetString("OcrApiKey");
         OcrEndpointBox.Header = loc.GetString("OcrEndpoint");
         OcrModelBox.Header = loc.GetString("OcrModel");
@@ -1683,6 +1683,13 @@ public sealed partial class SettingsPage : Page
         OcrEnableThinkingDescriptionText.Text = loc.GetString("OcrEnableThinkingDescription");
         TestOcrConnectionButton.Content = loc.GetString("TestOcrConnection");
         OcrTestStatusBox.Header = loc.GetString("OcrTestResult");
+        PpOcrV6ModelCombo.Header = loc.GetString("PpOcrV6ModelLabel");
+        PpOcrV6DownloadButton.Content = loc.GetString("PpOcrV6ActionDownload");
+        PpOcrV6ThreadCountBox.Header = loc.GetString("PpOcrV6CpuThreads");
+        PpOcrV6GpuToggle.Header = loc.GetString("PpOcrV6UseGpu");
+        PpOcrV6FallbackToggle.Header = loc.GetString("PpOcrV6Fallback");
+        PpOcrV6TestButton.Content = loc.GetString("PpOcrV6TestButton");
+        PpOcrV6TestStatusBox.Header = loc.GetString("OcrTestResult");
     }
 
     private void ApplyPasswordRevealLocalization(LocalizationService loc)

--- a/dotnet/src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj
+++ b/dotnet/src/Easydict.Workers.Ocr/Easydict.Workers.Ocr.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Easydict.SidecarClient\Easydict.SidecarClient.csproj" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.21.0" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Easydict.Workers.Ocr/PpOcrV6Pipeline.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/PpOcrV6Pipeline.cs
@@ -1,0 +1,551 @@
+using Easydict.SidecarClient.Protocol;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+
+namespace Easydict.Workers.Ocr;
+
+internal sealed class PpOcrV6ModelException : Exception
+{
+    public PpOcrV6ModelException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    public string Code { get; }
+}
+
+internal sealed class PpOcrV6Pipeline : IDisposable
+{
+    private const float DetectionThreshold = 0.2f;
+    private const float BoxThreshold = 0.45f;
+    private const float UnclipRatio = 1.4f;
+    private const int DetectionLimitSide = 64;
+    private const int DetectionMaxSide = 4000;
+    private const int RecognitionHeight = 48;
+    private const int RecognitionMaxWidth = 3200;
+
+    private readonly string _modelId;
+    private readonly int _threadCount;
+    private readonly bool _useGpu;
+    private readonly PpOcrV6ModelStore _store;
+    private InferenceSession? _detector;
+    private InferenceSession? _recognizer;
+    private string _detectorInputName = string.Empty;
+    private string _recognizerInputName = string.Empty;
+    private IReadOnlyList<string> _characters = [];
+    private bool _disposed;
+
+    public PpOcrV6Pipeline(
+        string modelId,
+        int threadCount,
+        bool useGpu = false,
+        PpOcrV6ModelStore? store = null)
+    {
+        _modelId = modelId;
+        _threadCount = Math.Clamp(threadCount, 1, 16);
+        _useGpu = useGpu;
+        _store = store ?? new PpOcrV6ModelStore();
+    }
+
+    public async Task<OcrResultDto> RecognizeAsync(
+        byte[] pixelData,
+        int width,
+        int height,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ValidateImage(pixelData, width, height);
+        await InitializeAsync(cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var detectionInput = PrepareDetectionInput(pixelData, width, height);
+        var detectionOutput = RunSession(
+            _detector!,
+            _detectorInputName,
+            detectionInput.Data,
+            detectionInput.Shape);
+        var boxes = DecodeDetection(
+            detectionOutput.Data,
+            detectionOutput.Shape,
+            width,
+            height,
+            detectionInput.InputWidth,
+            detectionInput.InputHeight);
+
+        var lines = new List<OcrLineDto>(boxes.Count);
+        foreach (var box in boxes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var crop = ExtractCrop(pixelData, width, height, box);
+            var recognitionInput = PrepareRecognitionInput(crop);
+            var recognitionOutput = RunSession(
+                _recognizer!,
+                _recognizerInputName,
+                recognitionInput.Data,
+                recognitionInput.Shape);
+            var (text, confidence) = DecodeRecognition(
+                recognitionOutput.Data,
+                recognitionOutput.Shape);
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                continue;
+            }
+
+            lines.Add(new OcrLineDto
+            {
+                Text = text,
+                Confidence = confidence,
+                BoundingRect = new OcrRectDto(box.X, box.Y, box.Width, box.Height),
+            });
+        }
+
+        var ordered = lines
+            .OrderBy(line => line.BoundingRect.Y)
+            .ThenBy(line => line.BoundingRect.X)
+            .ToList();
+        return new OcrResultDto
+        {
+            Text = string.Join(Environment.NewLine, ordered.Select(line => line.Text)),
+            Lines = ordered,
+            Engine = "ppOcrV6",
+            ModelId = _modelId,
+        };
+    }
+
+    private async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        if (_detector is not null && _recognizer is not null)
+        {
+            return;
+        }
+
+        var state = await _store.ValidateAsync(_modelId, cancellationToken).ConfigureAwait(false);
+        if (state == PpOcrV6ModelState.Missing)
+        {
+            throw new PpOcrV6ModelException("model_missing", $"PP-OCRv6 model '{_modelId}' is not installed.");
+        }
+        if (state != PpOcrV6ModelState.Installed)
+        {
+            throw new PpOcrV6ModelException("model_invalid", $"PP-OCRv6 model '{_modelId}' failed integrity validation.");
+        }
+
+        var paths = _store.GetPaths(_modelId);
+        _characters = await LoadCharacterDictionaryAsync(paths.RecognizerConfig, cancellationToken)
+            .ConfigureAwait(false);
+        if (_characters.Count == 0)
+        {
+            throw new PpOcrV6ModelException("model_invalid", "PP-OCRv6 recognition dictionary is empty.");
+        }
+
+        using var options = new SessionOptions
+        {
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+            ExecutionMode = ExecutionMode.ORT_SEQUENTIAL,
+            IntraOpNumThreads = _threadCount,
+            InterOpNumThreads = 1,
+        };
+        if (_useGpu)
+        {
+            try
+            {
+                options.AppendExecutionProvider_DML(0);
+            }
+            catch (Exception ex)
+            {
+                throw new PpOcrV6ModelException(
+                    "gpu_unavailable",
+                    $"DirectML GPU provider is unavailable: {ex.Message}");
+            }
+        }
+        try
+        {
+            _detector = new InferenceSession(paths.DetectorModel, options);
+            _recognizer = new InferenceSession(paths.RecognizerModel, options);
+            _detectorInputName = ValidateSession(_detector, "detector");
+            _recognizerInputName = ValidateSession(_recognizer, "recognizer");
+        }
+        catch (PpOcrV6ModelException)
+        {
+            DisposeSessions();
+            throw;
+        }
+        catch (Exception ex)
+        {
+            DisposeSessions();
+            throw new PpOcrV6ModelException("runtime_missing", $"Unable to load PP-OCRv6 ONNX sessions: {ex.Message}");
+        }
+    }
+
+    private static string ValidateSession(InferenceSession session, string name)
+    {
+        if (session.InputMetadata.Count != 1 || session.OutputMetadata.Count == 0)
+        {
+            throw new PpOcrV6ModelException("model_invalid", $"PP-OCRv6 {name} session has an unsupported tensor contract.");
+        }
+
+        var input = session.InputMetadata.Single();
+        if (input.Value.ElementType != typeof(float))
+        {
+            throw new PpOcrV6ModelException("model_invalid", $"PP-OCRv6 {name} input must be float32.");
+        }
+
+        return input.Key;
+    }
+
+    private static async Task<IReadOnlyList<string>> LoadCharacterDictionaryAsync(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        var lines = await File.ReadAllLinesAsync(path, cancellationToken).ConfigureAwait(false);
+        var result = new List<string>();
+        var inDictionary = false;
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("character_dict:", StringComparison.Ordinal))
+            {
+                inDictionary = true;
+                continue;
+            }
+            if (!inDictionary)
+            {
+                continue;
+            }
+            if (!trimmed.StartsWith("- ", StringComparison.Ordinal))
+            {
+                if (line.Length - trimmed.Length <= 2)
+                {
+                    break;
+                }
+                continue;
+            }
+
+            var value = trimmed[2..].TrimStart();
+            if (value.Length >= 2 && value[0] == '\'' && value[^1] == '\'')
+            {
+                value = value[1..^1].Replace("''", "'", StringComparison.Ordinal);
+            }
+            else if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+            {
+                value = value[1..^1];
+            }
+            else
+            {
+                value = value.Trim();
+            }
+            result.Add(value);
+        }
+
+        if (result.Count == 0 || result[^1] != " ")
+        {
+            result.Add(" ");
+        }
+
+        return result;
+    }
+
+    private static void ValidateImage(byte[] pixelData, int width, int height)
+    {
+        if (width <= 0 || height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), "OCR image dimensions must be positive.");
+        }
+        var expected = checked(width * height * 4);
+        if (pixelData.Length < expected)
+        {
+            throw new ArgumentException("OCR pixel buffer is shorter than the requested image dimensions.", nameof(pixelData));
+        }
+    }
+
+    private static DetectionInput PrepareDetectionInput(byte[] pixels, int width, int height)
+    {
+        var ratio = Math.Min(width, height) < DetectionLimitSide
+            ? DetectionLimitSide / (double)Math.Min(width, height)
+            : 1.0;
+        var scaledWidth = Math.Max(1, (int)Math.Round(width * ratio, MidpointRounding.ToEven));
+        var scaledHeight = Math.Max(1, (int)Math.Round(height * ratio, MidpointRounding.ToEven));
+        if (Math.Max(scaledWidth, scaledHeight) > DetectionMaxSide)
+        {
+            ratio = DetectionMaxSide / (double)Math.Max(scaledWidth, scaledHeight);
+            scaledWidth = Math.Max(1, (int)Math.Round(scaledWidth * ratio, MidpointRounding.ToEven));
+            scaledHeight = Math.Max(1, (int)Math.Round(scaledHeight * ratio, MidpointRounding.ToEven));
+        }
+
+        var inputWidth = RoundToMultipleOf32(scaledWidth);
+        var inputHeight = RoundToMultipleOf32(scaledHeight);
+        var channelSize = inputWidth * inputHeight;
+        var data = new float[3 * channelSize];
+        for (var y = 0; y < inputHeight; y++)
+        {
+            var sourceY = Math.Min(height - 1, (int)((y + 0.5) * height / inputHeight));
+            for (var x = 0; x < inputWidth; x++)
+            {
+                var sourceX = Math.Min(width - 1, (int)((x + 0.5) * width / inputWidth));
+                var source = (sourceY * width + sourceX) * 4;
+                var destination = y * inputWidth + x;
+                data[destination] = Normalize(pixels[source]);
+                data[channelSize + destination] = Normalize(pixels[source + 1]);
+                data[2 * channelSize + destination] = Normalize(pixels[source + 2]);
+            }
+        }
+
+        return new DetectionInput(data, [1, 3, inputHeight, inputWidth], inputWidth, inputHeight);
+    }
+
+    private static float Normalize(byte value)
+    {
+        var channel = value / 255f;
+        return (channel - 0.485f) / 0.229f;
+    }
+
+    private static int RoundToMultipleOf32(int value)
+    {
+        return Math.Max(32, (int)Math.Round(value / 32.0, MidpointRounding.ToEven) * 32);
+    }
+
+    private static List<PpBox> DecodeDetection(
+        float[] output,
+        int[] shape,
+        int originalWidth,
+        int originalHeight,
+        int inputWidth,
+        int inputHeight)
+    {
+        var mapHeight = shape.Length >= 4 ? shape[^2] : shape.Length == 3 ? shape[^2] : 0;
+        var mapWidth = shape.Length >= 3 ? shape[^1] : 0;
+        if (mapHeight <= 0 || mapWidth <= 0 || output.Length < mapHeight * mapWidth)
+        {
+            throw new PpOcrV6ModelException("model_invalid", "PP-OCRv6 detector output shape is unsupported.");
+        }
+
+        var probabilities = new float[mapHeight * mapWidth];
+        for (var i = 0; i < probabilities.Length; i++)
+        {
+            var value = output[i];
+            probabilities[i] = value is >= 0 and <= 1 ? value : 1f / (1f + MathF.Exp(-value));
+        }
+
+        var visited = new bool[probabilities.Length];
+        var queue = new int[probabilities.Length];
+        var boxes = new List<PpBox>();
+        for (var y = 0; y < mapHeight; y++)
+        {
+            for (var x = 0; x < mapWidth; x++)
+            {
+                var start = y * mapWidth + x;
+                if (visited[start] || probabilities[start] < DetectionThreshold)
+                {
+                    continue;
+                }
+
+                var head = 0;
+                var tail = 0;
+                queue[tail++] = start;
+                visited[start] = true;
+                var minX = x;
+                var maxX = x;
+                var minY = y;
+                var maxY = y;
+                var area = 0;
+                var score = 0f;
+                while (head < tail)
+                {
+                    var current = queue[head++];
+                    var currentX = current % mapWidth;
+                    var currentY = current / mapWidth;
+                    minX = Math.Min(minX, currentX);
+                    maxX = Math.Max(maxX, currentX);
+                    minY = Math.Min(minY, currentY);
+                    maxY = Math.Max(maxY, currentY);
+                    area++;
+                    score += probabilities[current];
+                    for (var dy = -1; dy <= 1; dy++)
+                    {
+                        for (var dx = -1; dx <= 1; dx++)
+                        {
+                            if (dx == 0 && dy == 0) continue;
+                            var nx = currentX + dx;
+                            var ny = currentY + dy;
+                            if (nx < 0 || nx >= mapWidth || ny < 0 || ny >= mapHeight) continue;
+                            var next = ny * mapWidth + nx;
+                            if (!visited[next] && probabilities[next] >= DetectionThreshold)
+                            {
+                                visited[next] = true;
+                                queue[tail++] = next;
+                            }
+                        }
+                    }
+                }
+
+                if (maxX - minX < 3 || maxY - minY < 3 || score / area < BoxThreshold)
+                {
+                    continue;
+                }
+
+                var distance = (maxX - minX + 1) * (maxY - minY + 1) * UnclipRatio /
+                               (2f * ((maxX - minX + 1) + (maxY - minY + 1)));
+                var x1 = (minX - distance) * originalWidth / (double)mapWidth;
+                var y1 = (minY - distance) * originalHeight / (double)mapHeight;
+                var x2 = (maxX + 1 + distance) * originalWidth / (double)mapWidth;
+                var y2 = (maxY + 1 + distance) * originalHeight / (double)mapHeight;
+                boxes.Add(new PpBox(
+                    Math.Clamp(x1, 0, originalWidth),
+                    Math.Clamp(y1, 0, originalHeight),
+                    Math.Clamp(x2 - x1, 0, originalWidth),
+                    Math.Clamp(y2 - y1, 0, originalHeight)));
+            }
+        }
+
+        return boxes
+            .OrderBy(box => box.Y)
+            .ThenBy(box => box.X)
+            .ToList();
+    }
+
+    private static ImageCrop ExtractCrop(byte[] pixels, int imageWidth, int imageHeight, PpBox box)
+    {
+        var left = Math.Clamp((int)Math.Floor(box.X), 0, imageWidth - 1);
+        var top = Math.Clamp((int)Math.Floor(box.Y), 0, imageHeight - 1);
+        var right = Math.Clamp((int)Math.Ceiling(box.X + box.Width), left + 1, imageWidth);
+        var bottom = Math.Clamp((int)Math.Ceiling(box.Y + box.Height), top + 1, imageHeight);
+        var width = right - left;
+        var height = bottom - top;
+        var source = new byte[width * height * 3];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var src = ((top + y) * imageWidth + left + x) * 4;
+                var dst = (y * width + x) * 3;
+                source[dst] = pixels[src];
+                source[dst + 1] = pixels[src + 1];
+                source[dst + 2] = pixels[src + 2];
+            }
+        }
+
+        if (height <= width * 1.5)
+        {
+            return new ImageCrop(source, width, height);
+        }
+
+        var rotated = new byte[source.Length];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var outputX = y;
+                var outputY = width - 1 - x;
+                var src = (y * width + x) * 3;
+                var dst = (outputY * height + outputX) * 3;
+                rotated[dst] = source[src];
+                rotated[dst + 1] = source[src + 1];
+                rotated[dst + 2] = source[src + 2];
+            }
+        }
+        return new ImageCrop(rotated, height, width);
+    }
+
+    private static RecognitionInput PrepareRecognitionInput(ImageCrop crop)
+    {
+        var targetWidth = Math.Clamp(
+            (int)Math.Ceiling(RecognitionHeight * (double)crop.Width / Math.Max(1, crop.Height)),
+            1,
+            RecognitionMaxWidth);
+        var channelSize = RecognitionHeight * targetWidth;
+        var data = new float[3 * channelSize];
+        for (var y = 0; y < RecognitionHeight; y++)
+        {
+            var sourceY = Math.Min(crop.Height - 1, (int)((y + 0.5) * crop.Height / RecognitionHeight));
+            for (var x = 0; x < targetWidth; x++)
+            {
+                var sourceX = Math.Min(crop.Width - 1, (int)((x + 0.5) * crop.Width / targetWidth));
+                var source = (sourceY * crop.Width + sourceX) * 3;
+                var destination = y * targetWidth + x;
+                data[destination] = crop.Pixels[source + 2] / 127.5f - 1f;
+                data[channelSize + destination] = crop.Pixels[source + 1] / 127.5f - 1f;
+                data[2 * channelSize + destination] = crop.Pixels[source] / 127.5f - 1f;
+            }
+        }
+        return new RecognitionInput(data, [1, 3, RecognitionHeight, targetWidth]);
+    }
+
+    private (float[] Data, int[] Shape) RunSession(
+        InferenceSession session,
+        string inputName,
+        float[] data,
+        int[] shape)
+    {
+        var tensor = new DenseTensor<float>(data, shape);
+        var input = NamedOnnxValue.CreateFromTensor(inputName, tensor);
+        using var results = session.Run([input]);
+        var output = results.First().AsTensor<float>();
+        return (output.ToArray(), output.Dimensions.ToArray());
+    }
+
+    private (string Text, float Confidence) DecodeRecognition(float[] output, int[] shape)
+    {
+        if (shape.Length != 3 || shape[0] != 1 || shape[2] <= 1)
+        {
+            throw new PpOcrV6ModelException("model_invalid", "PP-OCRv6 recognizer output shape is unsupported.");
+        }
+
+        var timeSteps = shape[1];
+        var classes = shape[2];
+        var previous = -1;
+        var confidenceSum = 0f;
+        var confidenceCount = 0;
+        var text = new System.Text.StringBuilder();
+        for (var time = 0; time < timeSteps; time++)
+        {
+            var offset = time * classes;
+            var bestClass = 0;
+            var bestValue = output[offset];
+            for (var cls = 1; cls < classes; cls++)
+            {
+                if (output[offset + cls] > bestValue)
+                {
+                    bestClass = cls;
+                    bestValue = output[offset + cls];
+                }
+            }
+
+            if (bestClass != 0 && bestClass != previous)
+            {
+                var characterIndex = bestClass - 1;
+                if (characterIndex >= 0 && characterIndex < _characters.Count)
+                {
+                    text.Append(_characters[characterIndex]);
+                    confidenceSum += bestValue;
+                    confidenceCount++;
+                }
+            }
+            previous = bestClass;
+        }
+
+        return (text.ToString(), confidenceCount == 0 ? 0f : confidenceSum / confidenceCount);
+    }
+
+    private void DisposeSessions()
+    {
+        _detector?.Dispose();
+        _recognizer?.Dispose();
+        _detector = null;
+        _recognizer = null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        DisposeSessions();
+    }
+
+    private sealed record DetectionInput(float[] Data, int[] Shape, int InputWidth, int InputHeight);
+    private sealed record RecognitionInput(float[] Data, int[] Shape);
+    private sealed record ImageCrop(byte[] Pixels, int Width, int Height);
+    private readonly record struct PpBox(double X, double Y, double Width, double Height);
+}

--- a/dotnet/src/Easydict.Workers.Ocr/PpOcrV6Pipeline.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/PpOcrV6Pipeline.cs
@@ -167,12 +167,12 @@ internal sealed class PpOcrV6Pipeline : IDisposable
         }
         catch (PpOcrV6ModelException)
         {
-            DisposeSessions();
+            Dispose();
             throw;
         }
         catch (Exception ex)
         {
-            DisposeSessions();
+            Dispose();
             throw new PpOcrV6ModelException("runtime_missing", $"Unable to load PP-OCRv6 ONNX sessions: {ex.Message}");
         }
     }
@@ -397,10 +397,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
             }
         }
 
-        return boxes
-            .OrderBy(box => box.Y)
-            .ThenBy(box => box.X)
-            .ToList();
+        return boxes;
     }
 
     private static ImageCrop ExtractCrop(byte[] pixels, int imageWidth, int imageHeight, PpBox box)
@@ -526,22 +523,18 @@ internal sealed class PpOcrV6Pipeline : IDisposable
         return (text.ToString(), confidenceCount == 0 ? 0f : confidenceSum / confidenceCount);
     }
 
-    private void DisposeSessions()
-    {
-        _detector?.Dispose();
-        _recognizer?.Dispose();
-        _detector = null;
-        _recognizer = null;
-    }
-
     public void Dispose()
     {
         if (_disposed)
         {
             return;
         }
+
         _disposed = true;
-        DisposeSessions();
+        _detector?.Dispose();
+        _recognizer?.Dispose();
+        _detector = null;
+        _recognizer = null;
     }
 
     private sealed record DetectionInput(float[] Data, int[] Shape, int InputWidth, int InputHeight);

--- a/dotnet/src/Easydict.Workers.Ocr/PpOcrV6Pipeline.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/PpOcrV6Pipeline.cs
@@ -305,9 +305,9 @@ internal sealed class PpOcrV6Pipeline : IDisposable
                 var sourceX = Math.Min(width - 1, (int)((x + 0.5) * width / inputWidth));
                 var source = (sourceY * width + sourceX) * 4;
                 var destination = y * inputWidth + x;
-                data[destination] = Normalize(pixels[source], 0);
+                data[destination] = Normalize(pixels[source + 2], 0);
                 data[channelSize + destination] = Normalize(pixels[source + 1], 1);
-                data[2 * channelSize + destination] = Normalize(pixels[source + 2], 2);
+                data[2 * channelSize + destination] = Normalize(pixels[source], 2);
             }
         }
 
@@ -335,7 +335,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
         int inputWidth,
         int inputHeight)
     {
-        var mapHeight = shape.Length >= 4 ? shape[^2] : shape.Length == 3 ? shape[^2] : 0;
+        var mapHeight = shape.Length >= 3 ? shape[^2] : 0;
         var mapWidth = shape.Length >= 3 ? shape[^1] : 0;
         if (mapHeight <= 0 || mapWidth <= 0 || output.Length < mapHeight * mapWidth)
         {

--- a/dotnet/src/Easydict.Workers.Ocr/PpOcrV6Pipeline.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/PpOcrV6Pipeline.cs
@@ -43,7 +43,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
         PpOcrV6ModelStore? store = null)
     {
         _modelId = modelId;
-        _threadCount = Math.Clamp(threadCount, 1, 16);
+        _threadCount = Math.Clamp(threadCount, PpOcrV6ModelCatalog.MinThreadCount, PpOcrV6ModelCatalog.MaxThreadCount);
         _useGpu = useGpu;
         _store = store ?? new PpOcrV6ModelStore();
     }
@@ -108,7 +108,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
         {
             Text = string.Join(Environment.NewLine, ordered.Select(line => line.Text)),
             Lines = ordered,
-            Engine = "ppOcrV6",
+            Engine = OcrEngines.PpOcrV6,
             ModelId = _modelId,
         };
     }
@@ -120,14 +120,14 @@ internal sealed class PpOcrV6Pipeline : IDisposable
             return;
         }
 
-        var state = await _store.ValidateAsync(_modelId, cancellationToken).ConfigureAwait(false);
+        var state = _store.GetStateBySize(_modelId);
         if (state == PpOcrV6ModelState.Missing)
         {
-            throw new PpOcrV6ModelException("model_missing", $"PP-OCRv6 model '{_modelId}' is not installed.");
+            throw new PpOcrV6ModelException(WorkerErrorCodes.ModelMissing, $"PP-OCRv6 model '{_modelId}' is not installed.");
         }
         if (state != PpOcrV6ModelState.Installed)
         {
-            throw new PpOcrV6ModelException("model_invalid", $"PP-OCRv6 model '{_modelId}' failed integrity validation.");
+            throw new PpOcrV6ModelException(WorkerErrorCodes.ModelInvalid, $"PP-OCRv6 model '{_modelId}' failed integrity validation.");
         }
 
         var paths = _store.GetPaths(_modelId);
@@ -135,7 +135,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
             .ConfigureAwait(false);
         if (_characters.Count == 0)
         {
-            throw new PpOcrV6ModelException("model_invalid", "PP-OCRv6 recognition dictionary is empty.");
+            throw new PpOcrV6ModelException(WorkerErrorCodes.ModelInvalid, "PP-OCRv6 recognition dictionary is empty.");
         }
 
         using var options = new SessionOptions
@@ -154,7 +154,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
             catch (Exception ex)
             {
                 throw new PpOcrV6ModelException(
-                    "gpu_unavailable",
+                    WorkerErrorCodes.GpuUnavailable,
                     $"DirectML GPU provider is unavailable: {ex.Message}");
             }
         }
@@ -164,30 +164,51 @@ internal sealed class PpOcrV6Pipeline : IDisposable
             _recognizer = new InferenceSession(paths.RecognizerModel, options);
             _detectorInputName = ValidateSession(_detector, "detector");
             _recognizerInputName = ValidateSession(_recognizer, "recognizer");
+            ValidateRecognizerClasses(_recognizer);
         }
         catch (PpOcrV6ModelException)
         {
-            Dispose();
+            ReleaseSessions();
             throw;
         }
         catch (Exception ex)
         {
-            Dispose();
-            throw new PpOcrV6ModelException("runtime_missing", $"Unable to load PP-OCRv6 ONNX sessions: {ex.Message}");
+            ReleaseSessions();
+            throw new PpOcrV6ModelException(WorkerErrorCodes.RuntimeMissing, $"Unable to load PP-OCRv6 ONNX sessions: {ex.Message}");
         }
+    }
+
+    private void ValidateRecognizerClasses(InferenceSession session)
+    {
+        var output = session.OutputMetadata.Values.FirstOrDefault(metadata =>
+            metadata.Dimensions.Length >= 3 && metadata.Dimensions[^1] > 0);
+        if (output is not null && output.Dimensions[^1] != _characters.Count + 1)
+        {
+            throw new PpOcrV6ModelException(
+                WorkerErrorCodes.ModelInvalid,
+                $"PP-OCRv6 recognizer dictionary has {_characters.Count} characters but the model exposes {output.Dimensions[^1] - 1} classes.");
+        }
+    }
+
+    private void ReleaseSessions()
+    {
+        _detector?.Dispose();
+        _recognizer?.Dispose();
+        _detector = null;
+        _recognizer = null;
     }
 
     private static string ValidateSession(InferenceSession session, string name)
     {
         if (session.InputMetadata.Count != 1 || session.OutputMetadata.Count == 0)
         {
-            throw new PpOcrV6ModelException("model_invalid", $"PP-OCRv6 {name} session has an unsupported tensor contract.");
+            throw new PpOcrV6ModelException(WorkerErrorCodes.ModelInvalid, $"PP-OCRv6 {name} session has an unsupported tensor contract.");
         }
 
         var input = session.InputMetadata.Single();
         if (input.Value.ElementType != typeof(float))
         {
-            throw new PpOcrV6ModelException("model_invalid", $"PP-OCRv6 {name} input must be float32.");
+            throw new PpOcrV6ModelException(WorkerErrorCodes.ModelInvalid, $"PP-OCRv6 {name} input must be float32.");
         }
 
         return input.Key;
@@ -284,19 +305,21 @@ internal sealed class PpOcrV6Pipeline : IDisposable
                 var sourceX = Math.Min(width - 1, (int)((x + 0.5) * width / inputWidth));
                 var source = (sourceY * width + sourceX) * 4;
                 var destination = y * inputWidth + x;
-                data[destination] = Normalize(pixels[source]);
-                data[channelSize + destination] = Normalize(pixels[source + 1]);
-                data[2 * channelSize + destination] = Normalize(pixels[source + 2]);
+                data[destination] = Normalize(pixels[source], 0);
+                data[channelSize + destination] = Normalize(pixels[source + 1], 1);
+                data[2 * channelSize + destination] = Normalize(pixels[source + 2], 2);
             }
         }
 
         return new DetectionInput(data, [1, 3, inputHeight, inputWidth], inputWidth, inputHeight);
     }
 
-    private static float Normalize(byte value)
+    private static readonly float[] DetectionMean = [0.485f, 0.456f, 0.406f];
+    private static readonly float[] DetectionStd = [0.229f, 0.224f, 0.225f];
+
+    private static float Normalize(byte value, int channel)
     {
-        var channel = value / 255f;
-        return (channel - 0.485f) / 0.229f;
+        return (value / 255f - DetectionMean[channel]) / DetectionStd[channel];
     }
 
     private static int RoundToMultipleOf32(int value)
@@ -316,7 +339,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
         var mapWidth = shape.Length >= 3 ? shape[^1] : 0;
         if (mapHeight <= 0 || mapWidth <= 0 || output.Length < mapHeight * mapWidth)
         {
-            throw new PpOcrV6ModelException("model_invalid", "PP-OCRv6 detector output shape is unsupported.");
+            throw new PpOcrV6ModelException(WorkerErrorCodes.ModelInvalid, "PP-OCRv6 detector output shape is unsupported.");
         }
 
         var probabilities = new float[mapHeight * mapWidth];
@@ -385,15 +408,13 @@ internal sealed class PpOcrV6Pipeline : IDisposable
 
                 var distance = (maxX - minX + 1) * (maxY - minY + 1) * UnclipRatio /
                                (2f * ((maxX - minX + 1) + (maxY - minY + 1)));
-                var x1 = (minX - distance) * originalWidth / (double)mapWidth;
-                var y1 = (minY - distance) * originalHeight / (double)mapHeight;
-                var x2 = (maxX + 1 + distance) * originalWidth / (double)mapWidth;
-                var y2 = (maxY + 1 + distance) * originalHeight / (double)mapHeight;
-                boxes.Add(new PpBox(
-                    Math.Clamp(x1, 0, originalWidth),
-                    Math.Clamp(y1, 0, originalHeight),
-                    Math.Clamp(x2 - x1, 0, originalWidth),
-                    Math.Clamp(y2 - y1, 0, originalHeight)));
+                var scaleX = originalWidth / (double)inputWidth;
+                var scaleY = originalHeight / (double)inputHeight;
+                var x1 = Math.Clamp((minX - distance) * inputWidth / mapWidth * scaleX, 0, originalWidth);
+                var y1 = Math.Clamp((minY - distance) * inputHeight / mapHeight * scaleY, 0, originalHeight);
+                var x2 = Math.Clamp((maxX + 1 + distance) * inputWidth / mapWidth * scaleX, 0, originalWidth);
+                var y2 = Math.Clamp((maxY + 1 + distance) * inputHeight / mapHeight * scaleY, 0, originalHeight);
+                boxes.Add(new PpBox(x1, y1, x2 - x1, y2 - y1));
             }
         }
 
@@ -484,7 +505,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
     {
         if (shape.Length != 3 || shape[0] != 1 || shape[2] <= 1)
         {
-            throw new PpOcrV6ModelException("model_invalid", "PP-OCRv6 recognizer output shape is unsupported.");
+            throw new PpOcrV6ModelException(WorkerErrorCodes.ModelInvalid, "PP-OCRv6 recognizer output shape is unsupported.");
         }
 
         var timeSteps = shape[1];
@@ -498,14 +519,24 @@ internal sealed class PpOcrV6Pipeline : IDisposable
             var offset = time * classes;
             var bestClass = 0;
             var bestValue = output[offset];
+            var maxLogit = bestValue;
             for (var cls = 1; cls < classes; cls++)
             {
-                if (output[offset + cls] > bestValue)
+                var logit = output[offset + cls];
+                if (logit > bestValue)
                 {
                     bestClass = cls;
-                    bestValue = output[offset + cls];
+                    bestValue = logit;
                 }
+                maxLogit = MathF.Max(maxLogit, logit);
             }
+
+            var expSum = 0f;
+            for (var cls = 0; cls < classes; cls++)
+            {
+                expSum += MathF.Exp(output[offset + cls] - maxLogit);
+            }
+            var bestProbability = MathF.Exp(bestValue - maxLogit) / expSum;
 
             if (bestClass != 0 && bestClass != previous)
             {
@@ -513,7 +544,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
                 if (characterIndex >= 0 && characterIndex < _characters.Count)
                 {
                     text.Append(_characters[characterIndex]);
-                    confidenceSum += bestValue;
+                    confidenceSum += bestProbability;
                     confidenceCount++;
                 }
             }
@@ -531,10 +562,7 @@ internal sealed class PpOcrV6Pipeline : IDisposable
         }
 
         _disposed = true;
-        _detector?.Dispose();
-        _recognizer?.Dispose();
-        _detector = null;
-        _recognizer = null;
+        ReleaseSessions();
     }
 
     private sealed record DetectionInput(float[] Data, int[] Shape, int InputWidth, int InputHeight);

--- a/dotnet/src/Easydict.Workers.Ocr/Program.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/Program.cs
@@ -16,6 +16,8 @@ internal static class Program
     };
 
     private static bool _configured;
+    private static PpOcrV6Pipeline? _ppOcrV6Pipeline;
+    private static PpOcrV6PipelineKey? _ppOcrV6PipelineKey;
 
     public static async Task<int> Main(string[] args)
     {
@@ -38,23 +40,29 @@ internal static class Program
             ],
         });
 
-        using var reader = new StreamReader(Console.OpenStandardInput());
-        string? line;
-        while ((line = await reader.ReadLineAsync()) is not null)
+        try
         {
-            if (string.IsNullOrWhiteSpace(line))
+            using var reader = new StreamReader(Console.OpenStandardInput());
+            string? line;
+            while ((line = await reader.ReadLineAsync()) is not null)
             {
-                continue;
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                if (await DispatchAsync(line))
+                {
+                    break;
+                }
             }
 
-            var shouldExit = await DispatchAsync(line);
-            if (shouldExit)
-            {
-                break;
-            }
+            return 0;
         }
-
-        return 0;
+        finally
+        {
+            DisposePpOcrV6Pipeline();
+        }
     }
 
     private static async Task<bool> DispatchAsync(string jsonLine)
@@ -87,6 +95,7 @@ internal static class Program
 
                 case WorkerMethods.Shutdown:
                     await WriteResponseAsync(request.Id, new { ok = true });
+                    DisposePpOcrV6Pipeline();
                     return true;
 
                 case OcrMethods.Recognize:
@@ -97,9 +106,10 @@ internal static class Program
                         return false;
                     }
 
-                    var result = await RecognizeAsync(ParseParams<OcrRecognizeParams>(request.Params));
+                    var parameters = ParseParams<OcrRecognizeParams>(request.Params);
+                    var result = await RecognizeAsync(parameters);
                     await WriteResponseAsync(request.Id, result);
-                    return true;
+                    return !string.Equals(parameters.Engine, OcrEngines.PpOcrV6, StringComparison.OrdinalIgnoreCase);
 
                 default:
                     await WriteErrorAsync(request.Id, IpcErrorCodes.MethodNotFound,
@@ -163,14 +173,22 @@ internal static class Program
             }
 
             var pixelData = await ReadPixelDataAsync(parameters).ConfigureAwait(false);
-            using var pipeline = new PpOcrV6Pipeline(
-                parameters.ModelId,
-                parameters.ThreadCount ?? Environment.ProcessorCount,
-                parameters.UseGpu);
-            return await pipeline.RecognizeAsync(
-                pixelData,
-                parameters.PixelWidth,
-                parameters.PixelHeight).ConfigureAwait(false);
+            var pipeline = GetPpOcrV6Pipeline(parameters);
+            try
+            {
+                return await pipeline.RecognizeAsync(
+                    pixelData,
+                    parameters.PixelWidth,
+                    parameters.PixelHeight).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (ReferenceEquals(_ppOcrV6Pipeline, pipeline))
+                {
+                    DisposePpOcrV6Pipeline();
+                }
+                throw;
+            }
         }
 
         var nativePixelData = await ReadPixelDataAsync(parameters).ConfigureAwait(false);
@@ -199,6 +217,29 @@ internal static class Program
             DetectedLanguage = ConvertLanguage(engine),
             Engine = OcrEngines.WindowsNative,
         };
+    }
+
+    private static PpOcrV6Pipeline GetPpOcrV6Pipeline(OcrRecognizeParams parameters)
+    {
+        var modelId = parameters.ModelId!;
+        var threadCount = Math.Clamp(parameters.ThreadCount ?? Environment.ProcessorCount, 1, 16);
+        var key = new PpOcrV6PipelineKey(modelId, threadCount, parameters.UseGpu);
+        if (_ppOcrV6Pipeline is not null && _ppOcrV6PipelineKey == key)
+        {
+            return _ppOcrV6Pipeline;
+        }
+
+        _ppOcrV6Pipeline?.Dispose();
+        _ppOcrV6Pipeline = new PpOcrV6Pipeline(modelId, threadCount, parameters.UseGpu);
+        _ppOcrV6PipelineKey = key;
+        return _ppOcrV6Pipeline;
+    }
+
+    private static void DisposePpOcrV6Pipeline()
+    {
+        _ppOcrV6Pipeline?.Dispose();
+        _ppOcrV6Pipeline = null;
+        _ppOcrV6PipelineKey = null;
     }
 
     private static async Task<byte[]> ReadPixelDataAsync(OcrRecognizeParams parameters)
@@ -285,33 +326,20 @@ internal static class Program
             : new OcrLanguageDto { Tag = language.LanguageTag, DisplayName = language.DisplayName };
     }
 
-    private static async Task WriteEventAsync(string eventName, object data)
-    {
-        await Console.Out.WriteLineAsync(JsonLineSerializer.Serialize(new
-        {
-            @event = eventName,
-            data,
-        }));
-        await Console.Out.FlushAsync();
-    }
+    private static Task WriteEventAsync(string eventName, object data) =>
+        WriteLineAsync(new { @event = eventName, data });
 
-    private static async Task WriteResponseAsync(string id, object result)
-    {
-        await Console.Out.WriteLineAsync(JsonLineSerializer.Serialize(new
-        {
-            id,
-            result,
-        }));
-        await Console.Out.FlushAsync();
-    }
+    private static Task WriteResponseAsync(string id, object result) =>
+        WriteLineAsync(new { id, result });
 
-    private static async Task WriteErrorAsync(string id, string code, string message)
+    private static Task WriteErrorAsync(string id, string code, string message) =>
+        WriteLineAsync(new { id, error = new { code, message } });
+
+    private readonly record struct PpOcrV6PipelineKey(string ModelId, int ThreadCount, bool UseGpu);
+
+    private static async Task WriteLineAsync(object value)
     {
-        await Console.Out.WriteLineAsync(JsonLineSerializer.Serialize(new
-        {
-            id,
-            error = new { code, message },
-        }));
+        await Console.Out.WriteLineAsync(JsonLineSerializer.Serialize(value));
         await Console.Out.FlushAsync();
     }
 }

--- a/dotnet/src/Easydict.Workers.Ocr/Program.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/Program.cs
@@ -112,6 +112,12 @@ internal static class Program
             await WriteErrorAsync(request.Id, WorkerErrorCodes.Cancelled, $"Request {request.Id} cancelled");
             return true;
         }
+        catch (PpOcrV6ModelException ex)
+        {
+            Trace.WriteLine($"[OcrWorker] PP-OCRv6 error ({ex.Code}): {ex.Message}");
+            await WriteErrorAsync(request.Id, ex.Code, ex.Message);
+            return true;
+        }
         catch (Exception ex)
         {
             Trace.WriteLine($"[OcrWorker] Unhandled exception in {request.Method}: {ex}");
@@ -135,31 +141,51 @@ internal static class Program
 
     private static async Task<OcrResultDto> RecognizeAsync(OcrRecognizeParams parameters)
     {
-        if (parameters.PixelWidth <= 0 || parameters.PixelHeight <= 0)
+        if (string.Equals(parameters.Engine, OcrEngines.PpOcrV6, StringComparison.OrdinalIgnoreCase))
         {
-            throw new ArgumentOutOfRangeException(nameof(parameters), "OCR image dimensions must be positive.");
+            if (string.IsNullOrWhiteSpace(parameters.ModelId))
+            {
+                throw new PpOcrV6ModelException("invalid_params", "PP-OCRv6 modelId is required.");
+            }
+
+            if (!PpOcrV6ModelCatalog.TryGet(parameters.ModelId, out _))
+            {
+                throw new PpOcrV6ModelException(
+                    "model_invalid",
+                    $"Unknown PP-OCRv6 model '{parameters.ModelId}'.");
+            }
+
+            if (!PpOcrV6ModelCatalog.SupportsLanguage(parameters.ModelId, parameters.PreferredLanguageTag))
+            {
+                throw new PpOcrV6ModelException(
+                    "unsupported_language",
+                    $"PP-OCRv6 model '{parameters.ModelId}' does not support '{parameters.PreferredLanguageTag}'.");
+            }
+
+            var pixelData = await ReadPixelDataAsync(parameters).ConfigureAwait(false);
+            using var pipeline = new PpOcrV6Pipeline(
+                parameters.ModelId,
+                parameters.ThreadCount ?? Environment.ProcessorCount,
+                parameters.UseGpu);
+            return await pipeline.RecognizeAsync(
+                pixelData,
+                parameters.PixelWidth,
+                parameters.PixelHeight).ConfigureAwait(false);
         }
 
-        var expectedLength = checked(parameters.PixelWidth * parameters.PixelHeight * 4);
-        var pixelData = await File.ReadAllBytesAsync(parameters.PixelDataPath);
-        if (pixelData.Length < expectedLength)
-        {
-            throw new ArgumentException(
-                $"pixel data length ({pixelData.Length}) is less than expected ({expectedLength})");
-        }
-
+        var nativePixelData = await ReadPixelDataAsync(parameters).ConfigureAwait(false);
         using var bitmap = new SoftwareBitmap(
             BitmapPixelFormat.Bgra8,
             parameters.PixelWidth,
             parameters.PixelHeight,
             BitmapAlphaMode.Ignore);
-        bitmap.CopyFromBuffer(pixelData.AsBuffer());
-        Array.Clear(pixelData);
+        bitmap.CopyFromBuffer(nativePixelData.AsBuffer());
+        Array.Clear(nativePixelData);
 
         var engine = CreateEngine(parameters.PreferredLanguageTag);
         if (engine is null)
         {
-            return new OcrResultDto();
+            return new OcrResultDto { Engine = OcrEngines.WindowsNative };
         }
 
         var winResult = await engine.RecognizeAsync(bitmap).AsTask();
@@ -171,7 +197,26 @@ internal static class Program
             Lines = lines,
             TextAngle = winResult.TextAngle,
             DetectedLanguage = ConvertLanguage(engine),
+            Engine = OcrEngines.WindowsNative,
         };
+    }
+
+    private static async Task<byte[]> ReadPixelDataAsync(OcrRecognizeParams parameters)
+    {
+        if (parameters.PixelWidth <= 0 || parameters.PixelHeight <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(parameters), "OCR image dimensions must be positive.");
+        }
+
+        var expectedLength = checked(parameters.PixelWidth * parameters.PixelHeight * 4);
+        var pixelData = await File.ReadAllBytesAsync(parameters.PixelDataPath).ConfigureAwait(false);
+        if (pixelData.Length < expectedLength)
+        {
+            throw new ArgumentException(
+                $"pixel data length ({pixelData.Length}) is less than expected ({expectedLength})");
+        }
+
+        return pixelData;
     }
 
     private static WinOcr.OcrEngine? CreateEngine(string? preferredLanguageTag)

--- a/dotnet/src/Easydict.Workers.Ocr/Program.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/Program.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text.Json;
 using Easydict.SidecarClient;
 using Easydict.SidecarClient.Protocol;
+using Microsoft.ML.OnnxRuntime;
 using Windows.Graphics.Imaging;
 using WinOcr = Windows.Media.Ocr;
 
@@ -120,13 +121,13 @@ internal static class Program
         catch (OperationCanceledException)
         {
             await WriteErrorAsync(request.Id, WorkerErrorCodes.Cancelled, $"Request {request.Id} cancelled");
-            return true;
+            return false;
         }
         catch (PpOcrV6ModelException ex)
         {
             Trace.WriteLine($"[OcrWorker] PP-OCRv6 error ({ex.Code}): {ex.Message}");
             await WriteErrorAsync(request.Id, ex.Code, ex.Message);
-            return true;
+            return false;
         }
         catch (Exception ex)
         {
@@ -155,20 +156,20 @@ internal static class Program
         {
             if (string.IsNullOrWhiteSpace(parameters.ModelId))
             {
-                throw new PpOcrV6ModelException("invalid_params", "PP-OCRv6 modelId is required.");
+                throw new PpOcrV6ModelException(WorkerErrorCodes.InvalidParams, "PP-OCRv6 modelId is required.");
             }
 
             if (!PpOcrV6ModelCatalog.TryGet(parameters.ModelId, out _))
             {
                 throw new PpOcrV6ModelException(
-                    "model_invalid",
+                    WorkerErrorCodes.ModelInvalid,
                     $"Unknown PP-OCRv6 model '{parameters.ModelId}'.");
             }
 
             if (!PpOcrV6ModelCatalog.SupportsLanguage(parameters.ModelId, parameters.PreferredLanguageTag))
             {
                 throw new PpOcrV6ModelException(
-                    "unsupported_language",
+                    WorkerErrorCodes.UnsupportedLanguage,
                     $"PP-OCRv6 model '{parameters.ModelId}' does not support '{parameters.PreferredLanguageTag}'.");
             }
 
@@ -181,7 +182,11 @@ internal static class Program
                     parameters.PixelWidth,
                     parameters.PixelHeight).ConfigureAwait(false);
             }
-            catch
+            catch (PpOcrV6ModelException)
+            {
+                throw;
+            }
+            catch (OnnxRuntimeException)
             {
                 if (ReferenceEquals(_ppOcrV6Pipeline, pipeline))
                 {
@@ -222,7 +227,10 @@ internal static class Program
     private static PpOcrV6Pipeline GetPpOcrV6Pipeline(OcrRecognizeParams parameters)
     {
         var modelId = parameters.ModelId!;
-        var threadCount = Math.Clamp(parameters.ThreadCount ?? Environment.ProcessorCount, 1, 16);
+        var threadCount = Math.Clamp(
+            parameters.ThreadCount ?? Environment.ProcessorCount,
+            PpOcrV6ModelCatalog.MinThreadCount,
+            PpOcrV6ModelCatalog.MaxThreadCount);
         var key = new PpOcrV6PipelineKey(modelId, threadCount, parameters.UseGpu);
         if (_ppOcrV6Pipeline is not null && _ppOcrV6PipelineKey == key)
         {

--- a/dotnet/src/Easydict.Workers.Ocr/Program.cs
+++ b/dotnet/src/Easydict.Workers.Ocr/Program.cs
@@ -186,13 +186,15 @@ internal static class Program
             {
                 throw;
             }
-            catch (OnnxRuntimeException)
+            catch (OnnxRuntimeException ex)
             {
                 if (ReferenceEquals(_ppOcrV6Pipeline, pipeline))
                 {
                     DisposePpOcrV6Pipeline();
                 }
-                throw;
+                throw new PpOcrV6ModelException(
+                    WorkerErrorCodes.InferenceError,
+                    $"PP-OCRv6 inference failed: {ex.Message}");
             }
         }
 

--- a/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/UITestHelper.cs
+++ b/dotnet/tests/Easydict.UIAutomation.Tests/Infrastructure/UITestHelper.cs
@@ -210,7 +210,7 @@ public static class UITestHelper
         {
             return !element.IsOffscreen;
         }
-        catch (PropertyNotSupportedException)
+        catch (Exception ex) when (ex is PropertyNotSupportedException or TimeoutException or COMException)
         {
             return true;
         }
@@ -244,11 +244,10 @@ public static class UITestHelper
     /// </summary>
     public static TextBox? FindInputTextBox(Window window, TimeSpan? timeout = null)
     {
-        var inputBox = window.FindFirstDescendant(cf => cf.ByAutomationId("InputTextBox"))?.AsTextBox()
-            ?? window.FindFirstDescendant(cf => cf.ByName("InputTextBox"))?.AsTextBox();
-        if (inputBox == null || inputBox.IsOffscreen)
+        var inputBox = FindByAutomationIdOrName(window, "InputTextBox")?.AsTextBox();
+        if (inputBox == null || !IsOnScreenOrUnknown(inputBox))
         {
-            var collapsed = window.FindFirstDescendant(cf => cf.ByAutomationId("SourceTextCollapsed"));
+            var collapsed = FindByAutomationIdOrName(window, "SourceTextCollapsed");
             if (collapsed != null)
             {
                 try { Mouse.Click(collapsed.GetClickablePoint()); } catch { /* ignore */ }
@@ -257,8 +256,7 @@ public static class UITestHelper
         }
 
         return Retry.WhileNull(
-            () => window.FindFirstDescendant(cf => cf.ByAutomationId("InputTextBox"))?.AsTextBox()
-                ?? window.FindFirstDescendant(cf => cf.ByName("InputTextBox"))?.AsTextBox(),
+            () => FindByAutomationIdOrName(window, "InputTextBox")?.AsTextBox(),
             timeout ?? TimeSpan.FromSeconds(10)).Result;
     }
 

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
@@ -38,6 +38,7 @@ public class OcrServiceFactoryTests
             var svc = OcrServiceFactory.Create();
 
             svc.Should().BeOfType(expected);
+            (svc as IDisposable)?.Dispose();
         }
         finally
         {
@@ -59,6 +60,7 @@ public class OcrServiceFactoryTests
             var svc = OcrServiceFactory.Create();
 
             svc.Should().BeOfType<WindowsOcrService>();
+            (svc as IDisposable)?.Dispose();
         }
         finally
         {
@@ -104,6 +106,7 @@ public class OcrServiceFactoryTests
             var svc = OcrServiceFactory.Create(options);
 
             svc.Should().BeOfType(expected);
+            (svc as IDisposable)?.Dispose();
         }
         finally
         {
@@ -157,6 +160,49 @@ public class OcrServiceFactoryTests
         PpOcrV6ModelCatalog.Models.Should().ContainSingle(model => model.Id == PpOcrV6ModelCatalog.MediumId);
         PpOcrV6ModelCatalog.Get(PpOcrV6ModelCatalog.MediumId).DownloadSizeBytes.Should().Be(138_739_282);
         PpOcrV6ModelCatalog.Get(PpOcrV6ModelCatalog.TinyId).Languages.Should().NotContain("ja");
+    }
+
+    [Theory]
+    [InlineData("zh", true)]
+    [InlineData("zh-Hans", true)]
+    [InlineData("zh-Hant", true)]
+    [InlineData("sr", true)]
+    [InlineData("sr-Latn", true)]
+    [InlineData("ja", false)]
+    public void PpOcrV6Catalog_SupportsBaseAndQualifiedLanguageTags(string languageTag, bool expected)
+    {
+        PpOcrV6ModelCatalog.SupportsLanguage(PpOcrV6ModelCatalog.TinyId, languageTag)
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void PpOcrV6ModelStore_GetStateBySize_DetectsMissingAndWrongSize()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Easydict", "ppocrv6-tests", Guid.NewGuid().ToString("N"));
+        var store = new PpOcrV6ModelStore(root);
+        var paths = store.GetPaths(PpOcrV6ModelCatalog.TinyId);
+        try
+        {
+            store.GetStateBySize(PpOcrV6ModelCatalog.TinyId).Should().Be(PpOcrV6ModelState.Missing);
+            Directory.CreateDirectory(paths.Directory);
+            File.WriteAllText(paths.CompletionSentinel, PpOcrV6ModelCatalog.TinyId);
+            store.GetStateBySize(PpOcrV6ModelCatalog.TinyId).Should().Be(PpOcrV6ModelState.Invalid);
+
+            foreach (var artifact in PpOcrV6ModelCatalog.Get(PpOcrV6ModelCatalog.TinyId).Artifacts)
+            {
+                using var stream = File.Create(Path.Combine(paths.Directory, artifact.FileName));
+                stream.SetLength(artifact.SizeBytes);
+            }
+
+            store.GetStateBySize(PpOcrV6ModelCatalog.TinyId).Should().Be(PpOcrV6ModelState.Installed);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
@@ -278,4 +278,58 @@ public class OcrServiceFactoryTests
 
         handler.Proxy.Should().BeNull();
     }
+
+    [Fact]
+    public async Task PpOcrV6ModelDownloadService_RemoveAsync_RemovesModelDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Easydict", "ppocrv6-remove-tests", Guid.NewGuid().ToString("N"));
+        var store = new PpOcrV6ModelStore(root);
+        var paths = store.GetPaths(PpOcrV6ModelCatalog.TinyId);
+        try
+        {
+            Directory.CreateDirectory(paths.Directory);
+            File.WriteAllText(paths.CompletionSentinel, PpOcrV6ModelCatalog.TinyId);
+            using var service = new PpOcrV6ModelDownloadService(
+                new HttpClient(new RecordingHttpMessageHandler()), store);
+
+            await service.RemoveAsync(PpOcrV6ModelCatalog.TinyId);
+
+            Directory.Exists(paths.Directory).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task PpOcrV6ModelDownloadService_RemoveAsync_HonorsCancellation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Easydict", "ppocrv6-remove-tests", Guid.NewGuid().ToString("N"));
+        var store = new PpOcrV6ModelStore(root);
+        var paths = store.GetPaths(PpOcrV6ModelCatalog.TinyId);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        try
+        {
+            Directory.CreateDirectory(paths.Directory);
+            using var service = new PpOcrV6ModelDownloadService(
+                new HttpClient(new RecordingHttpMessageHandler()), store);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                service.RemoveAsync(PpOcrV6ModelCatalog.TinyId, cts.Token));
+
+            Directory.Exists(paths.Directory).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
 }

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
@@ -169,10 +169,51 @@ public class OcrServiceFactoryTests
         {
             model.DownloadSizeBytes.Should().Be(model.Artifacts.Sum(artifact => artifact.SizeBytes));
             model.Languages.Should().NotBeEmpty();
-            model.Artifacts.Should().OnlyContain(artifact =>
-                artifact.SizeBytes > 0
-                && artifact.Sha256.Length == 64
-                && artifact.Sha256.All(Uri.IsHexDigit));
+            model.Artifacts.Select(artifact => artifact.FileName)
+                .Should().Equal(
+                    PpOcrV6ModelStore.DetectorModelFileName,
+                    PpOcrV6ModelStore.DetectorConfigFileName,
+                    PpOcrV6ModelStore.RecognizerModelFileName,
+                    PpOcrV6ModelStore.RecognizerConfigFileName);
+            model.Artifacts.Should().OnlyContain(artifact => artifact.SizeBytes > 0);
+
+            foreach (var artifact in model.Artifacts)
+            {
+                var isDetector = artifact.FileName.StartsWith("det.", StringComparison.Ordinal);
+                var modelName = isDetector ? model.DetectorModelName : model.RecognizerModelName;
+                var remoteName = artifact.FileName.EndsWith(".onnx", StringComparison.Ordinal)
+                    ? "inference.onnx"
+                    : "inference.yml";
+                artifact.Url.Should().Contain($"/{modelName}_onnx/");
+                artifact.Url.Should().EndWith($"/{remoteName}");
+            }
+
+            model.Artifacts.Select(artifact => artifact.Url).Should().OnlyHaveUniqueItems();
+        }
+    }
+
+    [Fact]
+    public void OcrServiceOptions_UsesDedicatedPpOcrV6ModelSetting()
+    {
+        var originalEngine = _settings.OcrEngine;
+        var originalModel = _settings.OcrModel;
+        var originalPpModel = _settings.PpOcrV6ModelId;
+        try
+        {
+            _settings.OcrEngine = OcrEngineType.PpOcrV6;
+            _settings.OcrModel = "custom-api-model";
+            _settings.PpOcrV6ModelId = PpOcrV6ModelCatalog.TinyId;
+
+            OcrServiceOptions.FromSettings(_settings).Model.Should().Be(PpOcrV6ModelCatalog.TinyId);
+
+            _settings.OcrEngine = OcrEngineType.CustomApi;
+            OcrServiceOptions.FromSettings(_settings).Model.Should().Be("custom-api-model");
+        }
+        finally
+        {
+            _settings.OcrEngine = originalEngine;
+            _settings.OcrModel = originalModel;
+            _settings.PpOcrV6ModelId = originalPpModel;
         }
     }
 
@@ -226,6 +267,8 @@ public class OcrServiceFactoryTests
             {
                 using var stream = File.Create(Path.Combine(paths.Directory, artifact.FileName));
                 stream.SetLength(artifact.SizeBytes);
+                stream.Position = 0;
+                stream.WriteByte(0xA5);
             }
 
             store.GetStateBySize(PpOcrV6ModelCatalog.TinyId).Should().Be(PpOcrV6ModelState.Installed);
@@ -260,6 +303,20 @@ public class OcrServiceFactoryTests
 
         OcrTranslateService.FormatEndpointForDiagnostics(options)
             .Should().Be("<redacted>");
+    }
+
+    [Fact]
+    public void ModelDownloadClient_DoesNotDisposeInjectedHttpClient()
+    {
+        using var handler = new RecordingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler);
+        using (var downloadClient = new ModelDownloadClient(httpClient))
+        {
+        }
+
+        var act = () => httpClient.DefaultRequestHeaders.Add("X-Test", "still-alive");
+
+        act.Should().NotThrow();
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
@@ -162,6 +162,40 @@ public class OcrServiceFactoryTests
         PpOcrV6ModelCatalog.Get(PpOcrV6ModelCatalog.TinyId).Languages.Should().NotContain("ja");
     }
 
+    [Fact]
+    public void PpOcrV6Catalog_ArtifactsMaintainStructuralInvariants()
+    {
+        foreach (var model in PpOcrV6ModelCatalog.Models)
+        {
+            model.DownloadSizeBytes.Should().Be(model.Artifacts.Sum(artifact => artifact.SizeBytes));
+            model.Languages.Should().NotBeEmpty();
+            model.Artifacts.Should().OnlyContain(artifact =>
+                artifact.SizeBytes > 0
+                && artifact.Sha256.Length == 64
+                && artifact.Sha256.All(Uri.IsHexDigit));
+        }
+    }
+
+    [Fact]
+    public void PpOcrV6ModelStore_InvalidateCompletion_IgnoresMissingDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Easydict", "ppocrv6-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new PpOcrV6ModelStore(root);
+            var act = () => store.InvalidateCompletion(PpOcrV6ModelCatalog.TinyId);
+
+            act.Should().NotThrow();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
     [Theory]
     [InlineData("zh", true)]
     [InlineData("zh-Hans", true)]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrServiceFactoryTests.cs
@@ -1,4 +1,5 @@
 using Easydict.TranslationService.Services;
+using Easydict.SidecarClient.Protocol;
 using Easydict.WinUI.Models;
 using Easydict.WinUI.Services;
 using Easydict.WinUI.Services.Workers;
@@ -23,6 +24,7 @@ public class OcrServiceFactoryTests
     [InlineData(OcrEngineType.WindowsNative, typeof(OcrWorkerClient))]
     [InlineData(OcrEngineType.Ollama, typeof(OllamaOcrService))]
     [InlineData(OcrEngineType.CustomApi, typeof(CustomApiOcrService))]
+    [InlineData(OcrEngineType.PpOcrV6, typeof(OcrWorkerClient))]
     public void Create_ReturnsImplementationMatchingSelectedEngine(
         OcrEngineType engine, System.Type expected)
     {
@@ -87,6 +89,7 @@ public class OcrServiceFactoryTests
     [InlineData(OcrEngineType.WindowsNative, typeof(OcrWorkerClient))]
     [InlineData(OcrEngineType.Ollama, typeof(OllamaOcrService))]
     [InlineData(OcrEngineType.CustomApi, typeof(CustomApiOcrService))]
+    [InlineData(OcrEngineType.PpOcrV6, typeof(OcrWorkerClient))]
     public void Create_WithOptions_UsesProvidedEngineIndependentOfSavedSetting(
         OcrEngineType engine, System.Type expected)
     {
@@ -135,6 +138,25 @@ public class OcrServiceFactoryTests
 
         options.Endpoint.Should().Be(OpenAIService.DefaultEndpoint);
         options.Model.Should().Be(OpenAIService.DefaultModel);
+    }
+
+    [Fact]
+    public void OcrServiceOptions_DefaultsToSmallPpOcrV6Model()
+    {
+        var options = new OcrServiceOptions(OcrEngineType.PpOcrV6, null, null, null, null);
+
+        options.Endpoint.Should().BeEmpty();
+        options.Model.Should().Be(PpOcrV6ModelCatalog.SmallId);
+    }
+
+    [Fact]
+    public void PpOcrV6Catalog_ContainsOfficialTiersAndSizes()
+    {
+        PpOcrV6ModelCatalog.Models.Should().ContainSingle(model => model.Id == PpOcrV6ModelCatalog.TinyId);
+        PpOcrV6ModelCatalog.Models.Should().ContainSingle(model => model.Id == PpOcrV6ModelCatalog.SmallId);
+        PpOcrV6ModelCatalog.Models.Should().ContainSingle(model => model.Id == PpOcrV6ModelCatalog.MediumId);
+        PpOcrV6ModelCatalog.Get(PpOcrV6ModelCatalog.MediumId).DownloadSizeBytes.Should().Be(138_739_282);
+        PpOcrV6ModelCatalog.Get(PpOcrV6ModelCatalog.TinyId).Languages.Should().NotContain("ja");
     }
 
     [Fact]

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrWorkerClientFallbackTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrWorkerClientFallbackTests.cs
@@ -60,6 +60,13 @@ public sealed class OcrWorkerClientFallbackTests
             .Should().BeTrue();
     }
 
+    [Fact]
+    public void CanFallbackToInProc_ReturnsTrue_WhenWorkerTimesOut()
+    {
+        OcrWorkerClient.CanFallbackToInProc(new SidecarTimeoutException("req-1"))
+            .Should().BeTrue();
+    }
+
     // Regression for issue #176: the worker used to naively join words with spaces, so CJK text
     // came back as "你 好 世 界". MapResult must re-merge per-word data with the same CJK-aware
     // merger as the in-process WindowsOcrService (no space between adjacent CJK characters).

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/OcrWorkerClientFallbackTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/OcrWorkerClientFallbackTests.cs
@@ -13,6 +13,24 @@ namespace Easydict.WinUI.Tests.Services;
 public sealed class OcrWorkerClientFallbackTests
 {
     [Fact]
+    public async Task DisposeAsync_MakesWorkerClientRejectNewRequests()
+    {
+        await using var client = new OcrWorkerClient(
+            SettingsService.Instance,
+            new FakeOcrService(),
+            _ => throw new InvalidOperationException("worker should not start after disposal"));
+
+        await client.DisposeAsync();
+
+        var act = () => client.RecognizeAsync(
+            new byte[] { 0, 0, 0, 255 },
+            pixelWidth: 1,
+            pixelHeight: 1);
+
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
     public async Task RecognizeAsync_ThrowsArgumentException_WhenBufferShorterThanExpected()
     {
         var fallback = new FakeOcrService();
@@ -65,6 +83,42 @@ public sealed class OcrWorkerClientFallbackTests
     {
         OcrWorkerClient.CanFallbackToInProc(new SidecarTimeoutException("req-1"))
             .Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanFallback_ReturnsTrue_WhenLanguageIsUnsupportedAndFallbackEnabled()
+    {
+        using var client = new OcrWorkerClient(
+            SettingsService.Instance,
+            new FakeOcrService(),
+            OcrEngineType.PpOcrV6,
+            PpOcrV6ModelCatalog.SmallId,
+            allowFallback: true);
+        var error = new SidecarErrorException(new IpcError
+        {
+            Code = WorkerErrorCodes.UnsupportedLanguage,
+            Message = "unsupported"
+        });
+
+        client.CanFallback(error).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanFallback_ReturnsFalse_WhenLanguageIsUnsupportedAndFallbackDisabled()
+    {
+        using var client = new OcrWorkerClient(
+            SettingsService.Instance,
+            new FakeOcrService(),
+            OcrEngineType.PpOcrV6,
+            PpOcrV6ModelCatalog.SmallId,
+            allowFallback: false);
+        var error = new SidecarErrorException(new IpcError
+        {
+            Code = WorkerErrorCodes.UnsupportedLanguage,
+            Message = "unsupported"
+        });
+
+        client.CanFallback(error).Should().BeFalse();
     }
 
     // Regression for issue #176: the worker used to naively join words with spaces, so CJK text

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/SettingsServiceTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/SettingsServiceTests.cs
@@ -1,3 +1,4 @@
+using Easydict.SidecarClient.Protocol;
 using Easydict.TranslationService;
 using Easydict.WindowsAI;
 using Easydict.WinUI.Models;
@@ -949,6 +950,7 @@ public class SettingsServiceTests
         var originalEngine = _settings.OcrEngine;
         var originalEndpoint = _settings.OcrEndpoint;
         var originalModel = _settings.OcrModel;
+        var originalPpModel = _settings.PpOcrV6ModelId;
         var originalPrompt = _settings.OcrSystemPrompt;
         var originalEnableThinking = _settings.OcrEnableThinking;
 
@@ -957,6 +959,7 @@ public class SettingsServiceTests
             _settings.OcrEngine = OcrEngineType.Ollama;
             _settings.OcrEndpoint = "http://test.local/ocr";
             _settings.OcrModel = "test-model";
+            _settings.PpOcrV6ModelId = PpOcrV6ModelCatalog.MediumId;
             _settings.OcrSystemPrompt = "Extract test text.";
             _settings.OcrEnableThinking = true;
             _settings.Save();
@@ -964,6 +967,7 @@ public class SettingsServiceTests
             _settings.OcrEngine.Should().Be(OcrEngineType.Ollama);
             _settings.OcrEndpoint.Should().Be("http://test.local/ocr");
             _settings.OcrModel.Should().Be("test-model");
+            _settings.PpOcrV6ModelId.Should().Be(PpOcrV6ModelCatalog.MediumId);
             _settings.OcrSystemPrompt.Should().Be("Extract test text.");
             _settings.OcrEnableThinking.Should().BeTrue();
         }
@@ -972,6 +976,7 @@ public class SettingsServiceTests
             _settings.OcrEngine = originalEngine;
             _settings.OcrEndpoint = originalEndpoint;
             _settings.OcrModel = originalModel;
+            _settings.PpOcrV6ModelId = originalPpModel;
             _settings.OcrSystemPrompt = originalPrompt;
             _settings.OcrEnableThinking = originalEnableThinking;
             _settings.Save();

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/WorkerPackagingTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/WorkerPackagingTests.cs
@@ -23,8 +23,9 @@ public sealed class WorkerPackagingTests
         workflow.Should().Contain("Easydict.Workers.LongDoc");
         workflow.Should().Contain("Easydict.Workers.LocalAi");
         workflow.Should().Contain("Easydict.Workers.Ocr");
-        workflow.Should().Contain("./publish/${{ matrix.platform }}/workers/ocr");
         workflow.Should().Contain("./publish-msix/${{ matrix.platform }}/workers/ocr");
+        workflow.Should().Contain("PublishWorkerOutputs");
+        workflow.Should().Contain("Verify portable workers present");
         workflow.Should().Contain("Dedupe-WorkerSharedFiles.ps1");
     }
 
@@ -54,17 +55,32 @@ public sealed class WorkerPackagingTests
         makefile.Should().Contain("Easydict.Workers.LongDoc");
         makefile.Should().Contain("Easydict.Workers.LocalAi");
         makefile.Should().Contain("Easydict.Workers.Ocr");
-        makefile.Should().Contain("./publish/x64/workers/ocr");
-        makefile.Should().Contain("./publish/arm64/workers/ocr");
         makefile.Should().Contain("./publish-msix/x64/workers/ocr");
         makefile.Should().Contain("./publish-msix/arm64/workers/ocr");
         makefile.Should().Contain("./publish-msix/x64 -p:BuildWorkerOutputs=false");
+        makefile.Should().Contain("-p:PublishWorkerOutputs=false");
         makefile.Should().Contain("./publish-msix/arm64 -p:BuildWorkerOutputs=false");
+        makefile.Should().Contain("PublishWorkerOutputs");
+        makefile.Should().Contain("Workers are auto-published");
         makefile.Should().Contain("winapp package ./publish-msix/x64");
         makefile.Should().Contain("<Identity[^>]* Version=");
         makefile.Should().Contain("Dedupe-WorkerSharedFiles.ps1");
         makefile.Should().Contain("Worker settings default");
         makefile.Should().NotContain("UseLocalAiWorker default false");
+    }
+
+    [Fact]
+    public void WinuiCsproj_AutoPublishesWorkersOnPublishTarget()
+    {
+        var csprojPath = Path.Combine(ProjectRoot, "src", "Easydict.WinUI", "Easydict.WinUI.csproj");
+        var csproj = File.ReadAllText(csprojPath);
+
+        csproj.Should().Contain("PublishWorkerOutputs");
+        csproj.Should().Contain("Target Name=\"PublishWorkerOutputs\"");
+        csproj.Should().Contain("AfterTargets=\"Publish\"");
+        csproj.Should().Contain("Target Name=\"ValidateWorkerPublish\"");
+        csproj.Should().Contain("workers\\ocr\\Easydict.Workers.Ocr.exe");
+        csproj.Should().Contain("WorkerPublishSelfContained");
     }
 
     [Fact]


### PR DESCRIPTION
# PP-OCRv6 local OCR integration

## Summary
Adds **PP-OCRv6 as a local OCR engine** alongside the existing Windows Native OCR. Includes end-to-end model lifecycle (download / validate / remove / cancel), a reusable OCR worker process, engine-aware settings UI, and localized strings. No breaking changes to the existing translation/OCR flow.

Closes the local OCR gap for offline usage and reduces per-request overhead by reusing the worker process.

## What changed
**Core engine & worker**
- `PpOcrV6Pipeline` + `Program.cs` (worker): PP-OCRv6 inference pipeline and worker host.
- `OcrWorkerClient`: reusable worker client with `PP-OCRv6` / `WindowsNative` engine switching, fallback policy, and proper `IAsyncDisposable` lifecycle (`App.xaml.cs` now awaits `CleanupServicesAsync`).

**Model catalog & distribution**
- `PpOcrV6ModelCatalog` / `PpOcrV6ModelStore` / `PpOcrV6ModelDownloadService`: model definitions, on-disk state by size (no SHA/hash verification — simplified per reliability request), staged download with atomic publish / rollback, progress + cancellation.
- `OcrProtocol` / `WorkerProtocol`: PP-OCRv6 params and result mapping (incl. `Confidence`).

**App & settings**
- `OcrEngineType` now includes `PpOcrV6`.
- `SettingsService`, `OcrServiceFactory`, `OcrServiceOptions`, `OcrTranslateService`: engine-aware creation, validation, and persistence for `PpOcrV6ModelId` / thread count / GPU / fallback.
- `SettingsPage.PpOcrV6.cs` + `SettingsPage.xaml` / `SettingsPage.xaml.cs`: dedicated PP-OCRv6 panel (model picker, status, download/remove/cancel, progress, test button), guarded save/validation flow.
- 14 locales updated (`ar-SA`, `da-DK`, `de-DE`, `en-US`, `fr-FR`, `hi-IN`, `id-ID`, `it-IT`, `ja-JP`, `ko-KR`, `ms-MY`, `th-TH`, `vi-VN`, `zh-CN`, `zh-TW`).

**Tests & CI stability**
- New: `OcrServiceFactoryTests`, `OcrWorkerClientFallbackTests`, `SettingsServiceTests` extensions for PP-OCRv6 paths.
- Fix: `UITestHelper.FindInputTextBox` hardened against transient UIA `COMException`/`TimeoutException` that caused flaky `Memory Gate / PR Memory Gate` runs (now retries via `FindByAutomationIdOrName` + `IsOnScreenOrUnknown`).

**Diff**
- 40 files changed, +2607 / -156 vs `master` (full stat in Files changed).

## Commits on this branch
```
f2daee1 feat: integrate PP-OCRv6 local OCR
a8c02cb perf: reuse PP-OCRv6 worker between OCR requests
4acf74a fix: address PP-OCRv6 review findings
74a55b6 feat: add PP-OCRv6 model cancel and remove states
6ae11d4 chore: polish PP-OCRv6 model safeguards
e0aafe5 fix: validate PP-OCRv6 model settings
2b9b99c fix: simplify PP-OCRv6 model integrity checks
37434c0 fix: harden Memory Gate UIAutomation helper against transient COM timeouts
```

## Validation
- Manual verification: app launches, PP-OCRv6 model download/cancel/remove works from Settings, OCR via PP-OCRv6 and Windows Native both functional (user confirmed: "el programa funciona bien").
- `dotnet build` for `Easydict.UIAutomation.Tests` (Release/x64): **0 warnings, 0 errors**.
- CI on `Asura7170/easydict_win32#2` (same head): `CI`, `Performance Benchmarks`, `UI Automation Tests` green; `Memory Gate` was flaky due to UIA timeout — addressed by the `UITestHelper` fix in this PR.
- `git diff --check` clean.

## Risk & compatibility
- No DB/config migration; new settings keys default safely when absent.
- Existing `WindowsNative` path unchanged; `OcrWorkerClient` reuses the worker only for PP-OCRv6, keeps previous fallback semantics for `WindowsNative`.
- `upstream/master` is up to date with this branch (7/0 ahead/behind at PR creation).

## How to test
1. Build `dotnet/src/Easydict.WinUI` (x64).
2. Open Settings → OCR Engine → `PP-OCRv6 (Local)` → pick model → Download.
3. Use OCR (screen capture) and verify text is recognized; toggle GPU / thread count and re-test.
4. Remove model and confirm state returns to "Not downloaded" and fallback (if enabled) works.

## Checklist
- [x] Tested locally
- [x] No `git diff --check` issues
- [x] Strings localized
- [x] Worker and services dispose correctly
