### PR TITLE
Fix mini/fixed window hotkey not closing window and slow first show

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -141,8 +141,8 @@ make run
   - `Ctrl+Alt+D` - Translate clipboard content
   - `Ctrl+Alt+S` - OCR screenshot translate (capture → recognize → translate)
   - `Ctrl+Alt+Shift+S` - Silent OCR (capture → recognize → copy to clipboard)
-  - `Ctrl+Alt+M` - Show mini window with selection
-  - `Ctrl+Alt+F` - Show fixed window
+  - `Ctrl+Alt+M` - Show/hide mini window (shows with selection; hides when foreground)
+  - `Ctrl+Alt+F` - Show/hide fixed window (shows with selection; hides when foreground)
   - `Ctrl+Alt+Shift+M` - Toggle mini window
   - `Ctrl+Alt+Shift+F` - Toggle fixed window
 - **Mouse Selection Translate**: Select text in any app (drag, double-click, triple-click) → floating icon appears → click to translate in Mini Window (uses `WH_MOUSE_LL` + `WH_KEYBOARD_LL` global hooks)

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ While the feature set is not yet complete compared to the macOS version, this po
 - **Global Hotkeys**
   - `Ctrl+Alt+T` - Show/hide main window
   - `Ctrl+Alt+D` - Translate clipboard content
-  - `Ctrl+Alt+M` - Show mini window (copies selection and translates when available)
-  - `Ctrl+Alt+F` - Show fixed window
+  - `Ctrl+Alt+M` - Show/hide mini window (copies selection and translates when available)
+  - `Ctrl+Alt+F` - Show/hide fixed window
   - `Ctrl+Alt+S` - OCR screenshot translate
   - `Ctrl+Alt+Shift+S` - Silent OCR (copy recognized text to clipboard)
   - `Ctrl+Alt+Shift+M` - Toggle mini window visibility

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -92,8 +92,8 @@ Easydict 支持 **Copilot+ PC 增强型本地 AI 翻译**：在搭载 40+ TOPS N
 - **全局快捷键**
   - `Ctrl+Alt+T` - 显示/隐藏主窗口
   - `Ctrl+Alt+D` - 翻译剪贴板内容
-  - `Ctrl+Alt+M` - 显示迷你窗口（自动复制选中文本并翻译）
-  - `Ctrl+Alt+F` - 显示固定窗口
+  - `Ctrl+Alt+M` - 显示/隐藏迷你窗口（自动复制选中文本并翻译）
+  - `Ctrl+Alt+F` - 显示/隐藏固定窗口
   - `Ctrl+Alt+S` - OCR 截图翻译
   - `Ctrl+Alt+Shift+S` - 静默 OCR（复制识别文字到剪贴板）
   - `Ctrl+Alt+Shift+M` - 切换迷你窗口可见性

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -522,6 +522,24 @@ namespace Easydict.WinUI
         {
             try
             {
+                // Toggle behavior (issue #194): like the main window hotkey (#123),
+                // pressing the hotkey while the mini window is foreground hides it.
+                // Checked before the selection-capture delay so closing is instant.
+                // WM_HOTKEY is dispatched on the UI thread, so it is safe to touch
+                // the window services directly here.
+                var mini = MiniWindowService.Instance;
+                if (mini.IsVisible && mini.IsForeground)
+                {
+                    mini.Hide();
+                    return;
+                }
+
+                // Create the window (hidden) on a separate dispatcher work item so
+                // first-show XAML inflation overlaps the selection-capture wait
+                // below instead of adding to it (issue #194: mini window slower
+                // to appear than the main window).
+                _window?.DispatcherQueue.TryEnqueue(() => MiniWindowService.Instance.EnsureCreated());
+
                 await Task.Delay(150);
 
                 TextInsertionService.CaptureSourceWindow();
@@ -546,6 +564,20 @@ namespace Easydict.WinUI
         {
             try
             {
+                // Toggle behavior (issue #194): like the main window hotkey (#123),
+                // pressing the hotkey while the fixed window is foreground hides it.
+                // Checked before the selection-capture delay so closing is instant.
+                var fixedWindow = FixedWindowService.Instance;
+                if (fixedWindow.IsVisible && fixedWindow.IsForeground)
+                {
+                    fixedWindow.Hide();
+                    return;
+                }
+
+                // Create the window (hidden) on a separate dispatcher work item so
+                // first-show XAML inflation overlaps the selection-capture wait.
+                _window?.DispatcherQueue.TryEnqueue(() => FixedWindowService.Instance.EnsureCreated());
+
                 await Task.Delay(150);
 
                 TextInsertionService.CaptureSourceWindow();

--- a/dotnet/src/Easydict.WinUI/App.xaml.cs
+++ b/dotnet/src/Easydict.WinUI/App.xaml.cs
@@ -70,6 +70,8 @@ namespace Easydict.WinUI
         private Task? _shutdownCleanupTask;
         private bool _shutdownCleanupCompleted;
         private static int _pendingRedirectedOcrTranslate;
+        private int _miniWindowShowGeneration;
+        private int _fixedWindowShowGeneration;
 
         // IPC: named event for context menu --ocr-translate signaling
         private EventWaitHandle? _ocrSignalEvent;
@@ -520,6 +522,7 @@ namespace Easydict.WinUI
 
         private async void OnShowMiniWindowHotkey()
         {
+            var requestGeneration = HotkeyShowRequestTracker.Begin(ref _miniWindowShowGeneration);
             try
             {
                 // Toggle behavior (issue #194): like the main window hotkey (#123),
@@ -538,16 +541,43 @@ namespace Easydict.WinUI
                 // first-show XAML inflation overlaps the selection-capture wait
                 // below instead of adding to it (issue #194: mini window slower
                 // to appear than the main window).
-                _window?.DispatcherQueue.TryEnqueue(() => MiniWindowService.Instance.EnsureCreated());
+                _window?.DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (HotkeyShowRequestTracker.IsCurrent(
+                        ref _miniWindowShowGeneration,
+                        requestGeneration))
+                    {
+                        MiniWindowService.Instance.EnsureCreated();
+                    }
+                });
 
                 await Task.Delay(150);
+                if (!HotkeyShowRequestTracker.IsCurrent(
+                    ref _miniWindowShowGeneration,
+                    requestGeneration))
+                {
+                    return;
+                }
 
                 TextInsertionService.CaptureSourceWindow();
 
                 var text = await TextSelectionService.GetSelectedTextAsync();
+                if (!HotkeyShowRequestTracker.IsCurrent(
+                    ref _miniWindowShowGeneration,
+                    requestGeneration))
+                {
+                    return;
+                }
 
                 _window?.DispatcherQueue.TryEnqueue(() =>
                 {
+                    if (!HotkeyShowRequestTracker.IsCurrent(
+                        ref _miniWindowShowGeneration,
+                        requestGeneration))
+                    {
+                        return;
+                    }
+
                     if (!string.IsNullOrWhiteSpace(text))
                         MiniWindowService.Instance.ShowWithText(text);
                     else
@@ -562,6 +592,7 @@ namespace Easydict.WinUI
 
         private async void OnShowFixedWindowHotkey()
         {
+            var requestGeneration = HotkeyShowRequestTracker.Begin(ref _fixedWindowShowGeneration);
             try
             {
                 // Toggle behavior (issue #194): like the main window hotkey (#123),
@@ -576,16 +607,43 @@ namespace Easydict.WinUI
 
                 // Create the window (hidden) on a separate dispatcher work item so
                 // first-show XAML inflation overlaps the selection-capture wait.
-                _window?.DispatcherQueue.TryEnqueue(() => FixedWindowService.Instance.EnsureCreated());
+                _window?.DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (HotkeyShowRequestTracker.IsCurrent(
+                        ref _fixedWindowShowGeneration,
+                        requestGeneration))
+                    {
+                        FixedWindowService.Instance.EnsureCreated();
+                    }
+                });
 
                 await Task.Delay(150);
+                if (!HotkeyShowRequestTracker.IsCurrent(
+                    ref _fixedWindowShowGeneration,
+                    requestGeneration))
+                {
+                    return;
+                }
 
                 TextInsertionService.CaptureSourceWindow();
 
                 var text = await TextSelectionService.GetSelectedTextAsync();
+                if (!HotkeyShowRequestTracker.IsCurrent(
+                    ref _fixedWindowShowGeneration,
+                    requestGeneration))
+                {
+                    return;
+                }
 
                 _window?.DispatcherQueue.TryEnqueue(() =>
                 {
+                    if (!HotkeyShowRequestTracker.IsCurrent(
+                        ref _fixedWindowShowGeneration,
+                        requestGeneration))
+                    {
+                        return;
+                    }
+
                     if (!string.IsNullOrWhiteSpace(text))
                         FixedWindowService.Instance.ShowWithText(text);
                     else

--- a/dotnet/src/Easydict.WinUI/Services/FixedWindowService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/FixedWindowService.cs
@@ -73,6 +73,16 @@ public sealed class FixedWindowService : IDisposable
     }
 
     /// <summary>
+    /// Ensure the fixed window instance exists without showing it.
+    /// Lets callers pay the window-creation cost ahead of time (e.g. while
+    /// selection capture is still running) so the first Show is instant.
+    /// </summary>
+    public void EnsureCreated()
+    {
+        EnsureWindowCreated();
+    }
+
+    /// <summary>
     /// Show the fixed window, creating it if necessary.
     /// </summary>
     public void Show()

--- a/dotnet/src/Easydict.WinUI/Services/ForegroundWindowHelper.cs
+++ b/dotnet/src/Easydict.WinUI/Services/ForegroundWindowHelper.cs
@@ -20,6 +20,9 @@ internal static class ForegroundWindowHelper
     [DllImport("user32.dll")]
     private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
 
+    [DllImport("user32.dll")]
+    private static extern short GetAsyncKeyState(int vKey);
+
     [DllImport("user32.dll", SetLastError = true)]
     private static extern bool AllowSetForegroundWindow(uint dwProcessId);
 
@@ -54,8 +57,16 @@ internal static class ForegroundWindowHelper
 
     private static void PrimeForegroundActivationContext(string owner)
     {
+        if (!ShouldPrimeForegroundActivation(GetAsyncKeyState(VkMenu)))
+        {
+            Debug.WriteLine($"[{owner}] Skipped foreground priming because ALT is physically held");
+            return;
+        }
+
         keybd_event(VkMenu, 0, KeyeventfExtendedkey, UIntPtr.Zero);
         keybd_event(VkMenu, 0, KeyeventfExtendedkey | KeyeventfKeyup, UIntPtr.Zero);
         Debug.WriteLine($"[{owner}] Primed foreground activation with keybd_event(VK_MENU)");
     }
+
+    internal static bool ShouldPrimeForegroundActivation(short altKeyState) => altKeyState >= 0;
 }

--- a/dotnet/src/Easydict.WinUI/Services/HotkeyShowRequestTracker.cs
+++ b/dotnet/src/Easydict.WinUI/Services/HotkeyShowRequestTracker.cs
@@ -1,0 +1,10 @@
+namespace Easydict.WinUI.Services;
+
+internal static class HotkeyShowRequestTracker
+{
+    internal static int Begin(ref int generation)
+        => Interlocked.Increment(ref generation);
+
+    internal static bool IsCurrent(ref int generation, int requestGeneration)
+        => Volatile.Read(ref generation) == requestGeneration;
+}

--- a/dotnet/src/Easydict.WinUI/Services/MiniWindowService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/MiniWindowService.cs
@@ -94,6 +94,16 @@ public sealed class MiniWindowService : IDisposable
     }
 
     /// <summary>
+    /// Ensure the mini window instance exists without showing it.
+    /// Lets callers pay the window-creation cost ahead of time (e.g. while
+    /// selection capture is still running) so the first Show is instant.
+    /// </summary>
+    public void EnsureCreated()
+    {
+        EnsureWindowCreated();
+    }
+
+    /// <summary>
     /// Show the mini window, creating it if necessary.
     /// </summary>
     public void Show()

--- a/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
+++ b/dotnet/src/Easydict.WinUI/Services/TextSelectionService.cs
@@ -26,6 +26,9 @@ public static class TextSelectionService
     private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
     [DllImport("user32.dll")]
+    private static extern short GetAsyncKeyState(int vKey);
+
+    [DllImport("user32.dll")]
     private static extern bool SetForegroundWindow(IntPtr hWnd);
 
     [DllImport("kernel32.dll")]
@@ -37,24 +40,24 @@ public static class TextSelectionService
     [DllImport("user32.dll")]
     private static extern uint GetClipboardSequenceNumber();
 
-    // INPUT struct must be 40 bytes on 64-bit Windows
-    // The union must be at offset 8 for proper alignment
+    // INPUT struct must be 40 bytes on 64-bit Windows.
+    // Internal visibility lets pure sequence tests inspect generated key events.
     [StructLayout(LayoutKind.Explicit, Size = 40)]
-    private struct INPUT
+    internal struct INPUT
     {
         [FieldOffset(0)] public uint type;
         [FieldOffset(8)] public InputUnion U;
     }
 
-    // Union must be 32 bytes (size of MOUSEINPUT, the largest member)
+    // Union must be 32 bytes (size of MOUSEINPUT, the largest member).
     [StructLayout(LayoutKind.Explicit, Size = 32)]
-    private struct InputUnion
+    internal struct InputUnion
     {
         [FieldOffset(0)] public KEYBDINPUT ki;
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct KEYBDINPUT
+    internal struct KEYBDINPUT
     {
         public ushort wVk;
         public ushort wScan;
@@ -63,12 +66,31 @@ public static class TextSelectionService
         public IntPtr dwExtraInfo;
     }
 
+    [Flags]
+    internal enum HeldModifierKeys
+    {
+        None = 0,
+        LeftControl = 1 << 0,
+        RightControl = 1 << 1,
+        LeftAlt = 1 << 2,
+        RightAlt = 1 << 3,
+        LeftShift = 1 << 4,
+        RightShift = 1 << 5,
+        LeftWin = 1 << 6,
+        RightWin = 1 << 7,
+    }
+
     private const uint INPUT_KEYBOARD = 1;
+    private const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
     private const uint KEYEVENTF_KEYUP = 0x0002;
     private const ushort VK_CONTROL = 0x11;
     private const ushort VK_C = 0x43;
-    private const ushort VK_SHIFT = 0x10;
-    private const ushort VK_MENU = 0x12; // Alt
+    private const ushort VK_LSHIFT = 0xA0;
+    private const ushort VK_RSHIFT = 0xA1;
+    private const ushort VK_LCONTROL = 0xA2;
+    private const ushort VK_RCONTROL = 0xA3;
+    private const ushort VK_LMENU = 0xA4;
+    private const ushort VK_RMENU = 0xA5;
     private const ushort VK_LWIN = 0x5B;
     private const ushort VK_RWIN = 0x5C;
 
@@ -889,95 +911,13 @@ public static class TextSelectionService
     private sealed record ClipboardProbe(bool HasText, string? Text, int AvailableFormatCount);
 
     /// <summary>
-    /// Sends Ctrl+C keystroke to copy selected text using SendInput API.
-    /// Flushes physical modifier keys before sending Ctrl+C to avoid modifier bleed.
+    /// Sends Ctrl+C keystrokes while preserving the physical state of every modifier side.
     /// </summary>
     private static void SendCtrlC()
     {
         Debug.WriteLine("[TextSelectionService] SendCtrlC() called");
 
-        var inputs = new List<INPUT>();
-
-        // 1. Flush physical modifier keys (KEYUP) to avoid modifier bleed
-        // This ensures the target app sees a pure "Ctrl+C" even if user is holding Alt/Shift/Win.
-        ushort[] modifiersToFlush = { VK_MENU, VK_SHIFT, VK_LWIN, VK_RWIN };
-        foreach (var vk in modifiersToFlush)
-        {
-            inputs.Add(new INPUT
-            {
-                type = INPUT_KEYBOARD,
-                U = new InputUnion
-                {
-                    ki = new KEYBDINPUT
-                    {
-                        wVk = vk,
-                        dwFlags = KEYEVENTF_KEYUP,
-                        dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY
-                    }
-                }
-            });
-        }
-
-        // 2. Send Ctrl+C sequence
-        // Ctrl down
-        inputs.Add(new INPUT
-        {
-            type = INPUT_KEYBOARD,
-            U = new InputUnion
-            {
-                ki = new KEYBDINPUT
-                {
-                    wVk = VK_CONTROL,
-                    dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY
-                }
-            }
-        });
-
-        // C down
-        inputs.Add(new INPUT
-        {
-            type = INPUT_KEYBOARD,
-            U = new InputUnion
-            {
-                ki = new KEYBDINPUT
-                {
-                    wVk = VK_C,
-                    dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY
-                }
-            }
-        });
-
-        // C up
-        inputs.Add(new INPUT
-        {
-            type = INPUT_KEYBOARD,
-            U = new InputUnion
-            {
-                ki = new KEYBDINPUT
-                {
-                    wVk = VK_C,
-                    dwFlags = KEYEVENTF_KEYUP,
-                    dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY
-                }
-            }
-        });
-
-        // Ctrl up
-        inputs.Add(new INPUT
-        {
-            type = INPUT_KEYBOARD,
-            U = new InputUnion
-            {
-                ki = new KEYBDINPUT
-                {
-                    wVk = VK_CONTROL,
-                    dwFlags = KEYEVENTF_KEYUP,
-                    dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY
-                }
-            }
-        });
-
-        var inputArray = inputs.ToArray();
+        var inputArray = BuildCtrlCInputs(GetHeldModifierKeys());
         var inputSize = Marshal.SizeOf<INPUT>();
         uint result = SendInput((uint)inputArray.Length, inputArray, inputSize);
 
@@ -988,6 +928,96 @@ public static class TextSelectionService
             var error = Marshal.GetLastWin32Error();
             Debug.WriteLine($"[TextSelectionService] SendInput error code: {error}");
         }
+    }
+
+    private static HeldModifierKeys GetHeldModifierKeys()
+    {
+        var heldModifiers = HeldModifierKeys.None;
+
+        if (GetAsyncKeyState(VK_LCONTROL) < 0) heldModifiers |= HeldModifierKeys.LeftControl;
+        if (GetAsyncKeyState(VK_RCONTROL) < 0) heldModifiers |= HeldModifierKeys.RightControl;
+        if (GetAsyncKeyState(VK_LMENU) < 0) heldModifiers |= HeldModifierKeys.LeftAlt;
+        if (GetAsyncKeyState(VK_RMENU) < 0) heldModifiers |= HeldModifierKeys.RightAlt;
+        if (GetAsyncKeyState(VK_LSHIFT) < 0) heldModifiers |= HeldModifierKeys.LeftShift;
+        if (GetAsyncKeyState(VK_RSHIFT) < 0) heldModifiers |= HeldModifierKeys.RightShift;
+        if (GetAsyncKeyState(VK_LWIN) < 0) heldModifiers |= HeldModifierKeys.LeftWin;
+        if (GetAsyncKeyState(VK_RWIN) < 0) heldModifiers |= HeldModifierKeys.RightWin;
+
+        return heldModifiers;
+    }
+
+    internal static INPUT[] BuildCtrlCInputs(HeldModifierKeys heldModifiers)
+    {
+        var inputs = new List<INPUT>(12);
+
+        // Temporarily release only the held non-Ctrl modifiers so the target receives pure Ctrl+C.
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.LeftAlt, VK_LMENU, isKeyUp: true);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.RightAlt, VK_RMENU, isKeyUp: true);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.LeftShift, VK_LSHIFT, isKeyUp: true);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.RightShift, VK_RSHIFT, isKeyUp: true);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.LeftWin, VK_LWIN, isKeyUp: true);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.RightWin, VK_RWIN, isKeyUp: true);
+
+        var isControlHeld = (heldModifiers &
+            (HeldModifierKeys.LeftControl | HeldModifierKeys.RightControl)) != 0;
+        if (!isControlHeld)
+        {
+            inputs.Add(CreateKeyboardInput(VK_CONTROL, isKeyUp: false));
+        }
+
+        inputs.Add(CreateKeyboardInput(VK_C, isKeyUp: false));
+        inputs.Add(CreateKeyboardInput(VK_C, isKeyUp: true));
+
+        if (!isControlHeld)
+        {
+            inputs.Add(CreateKeyboardInput(VK_CONTROL, isKeyUp: true));
+        }
+
+        // Restore each released side exactly; AltGr therefore restores Right Alt, not Left Alt.
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.LeftAlt, VK_LMENU, isKeyUp: false);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.RightAlt, VK_RMENU, isKeyUp: false);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.LeftShift, VK_LSHIFT, isKeyUp: false);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.RightShift, VK_RSHIFT, isKeyUp: false);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.LeftWin, VK_LWIN, isKeyUp: false);
+        AddModifierInputIfHeld(inputs, heldModifiers, HeldModifierKeys.RightWin, VK_RWIN, isKeyUp: false);
+
+        return inputs.ToArray();
+    }
+
+    private static void AddModifierInputIfHeld(
+        List<INPUT> inputs,
+        HeldModifierKeys heldModifiers,
+        HeldModifierKeys modifier,
+        ushort virtualKey,
+        bool isKeyUp)
+    {
+        if ((heldModifiers & modifier) != 0)
+        {
+            inputs.Add(CreateKeyboardInput(virtualKey, isKeyUp));
+        }
+    }
+
+    private static INPUT CreateKeyboardInput(ushort virtualKey, bool isKeyUp)
+    {
+        var flags = virtualKey is VK_RCONTROL or VK_RMENU ? KEYEVENTF_EXTENDEDKEY : 0;
+        if (isKeyUp)
+        {
+            flags |= KEYEVENTF_KEYUP;
+        }
+
+        return new INPUT
+        {
+            type = INPUT_KEYBOARD,
+            U = new InputUnion
+            {
+                ki = new KEYBDINPUT
+                {
+                    wVk = virtualKey,
+                    dwFlags = flags,
+                    dwExtraInfo = MouseHookService.EASYDICT_SYNTHETIC_KEY
+                }
+            }
+        };
     }
 
     // ---- Adaptive suppression bookkeeping ----

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/ForegroundWindowHelperTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/ForegroundWindowHelperTests.cs
@@ -1,0 +1,31 @@
+using Easydict.WinUI.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+[Trait("Category", "WinUI")]
+public class ForegroundWindowHelperTests
+{
+    [Theory]
+    [InlineData(unchecked((short)0x8000))]
+    [InlineData(unchecked((short)0x8001))]
+    public void ShouldPrimeForegroundActivation_WhileAltIsDown_ReturnsFalse(short altKeyState)
+    {
+        var shouldPrime = ForegroundWindowHelper.ShouldPrimeForegroundActivation(altKeyState);
+
+        shouldPrime.Should().BeFalse(
+            "a synthetic Alt key-up would clear the modifier while the user is still holding it");
+    }
+
+    [Theory]
+    [InlineData((short)0)]
+    [InlineData((short)1)]
+    public void ShouldPrimeForegroundActivation_WhileAltIsUp_ReturnsTrue(short altKeyState)
+    {
+        var shouldPrime = ForegroundWindowHelper.ShouldPrimeForegroundActivation(altKeyState);
+
+        shouldPrime.Should().BeTrue(
+            "the foreground activation workaround is still needed when Alt is not held");
+    }
+}

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/HotkeyShowRequestTrackerTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/HotkeyShowRequestTrackerTests.cs
@@ -1,0 +1,20 @@
+using Easydict.WinUI.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+public class HotkeyShowRequestTrackerTests
+{
+    [Fact]
+    public void Begin_InvalidatesPreviousRequest()
+    {
+        var generation = 0;
+
+        var firstRequest = HotkeyShowRequestTracker.Begin(ref generation);
+        var secondRequest = HotkeyShowRequestTracker.Begin(ref generation);
+
+        HotkeyShowRequestTracker.IsCurrent(ref generation, firstRequest).Should().BeFalse();
+        HotkeyShowRequestTracker.IsCurrent(ref generation, secondRequest).Should().BeTrue();
+    }
+}

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/KanbanTodoUxRegressionTests.cs
@@ -451,7 +451,7 @@ public class KanbanTodoUxRegressionTests
         AssertContainsInOrder(
             miniHotkeySnippet,
             "TextSelectionService.GetSelectedTextAsync();",
-            "_window?.DispatcherQueue.TryEnqueue",
+            "MiniWindowService.Instance.ShowWithText(text)",
             "the Mini Window hotkey must read selected text before dispatching the window show");
         miniHotkeySnippet.Should().Contain("await Task.Delay(150);",
             "the Mini Window hotkey should preserve its existing delayed selection flow");
@@ -459,6 +459,23 @@ public class KanbanTodoUxRegressionTests
         miniHotkeySnippet.Should().Contain("MiniWindowService.Instance.Show()");
         miniHotkeySnippet.Should().NotContain("FixedWindowService.Instance.ShowWithText(text)");
         miniHotkeySnippet.Should().NotContain("FixedWindowService.Instance.Show()");
+
+        // Toggle behavior (issue #194): the Mini Window hotkey must hide the
+        // window when it is already in the foreground, and must decide that
+        // before the selection-capture delay so closing is instant.
+        miniHotkeySnippet.Should().Contain("if (mini.IsVisible && mini.IsForeground)",
+            "the Mini Window hotkey should hide the foreground window on repeated press");
+        miniHotkeySnippet.Should().Contain("mini.Hide();",
+            "the toggle path should hide the mini window instead of re-showing it");
+        AssertContainsInOrder(
+            miniHotkeySnippet,
+            "mini.Hide();",
+            "await Task.Delay(150);",
+            "hiding the mini window must not wait for the selection-capture delay");
+        miniHotkeySnippet.Should().Contain("MiniWindowService.Instance.EnsureCreated()",
+            "first show should pre-create the mini window so XAML inflation overlaps the selection-capture wait");
+        miniServiceCode.Should().Contain("public void EnsureCreated()",
+            "the mini window service should expose hidden pre-creation for the hotkey warm-up");
 
         AssertContainsInOrder(
             fixedHotkeySnippet,
@@ -468,7 +485,7 @@ public class KanbanTodoUxRegressionTests
         AssertContainsInOrder(
             fixedHotkeySnippet,
             "TextSelectionService.GetSelectedTextAsync();",
-            "_window?.DispatcherQueue.TryEnqueue",
+            "FixedWindowService.Instance.ShowWithText(text)",
             "the Fixed Window hotkey must read selected text before dispatching the window show");
         fixedHotkeySnippet.Should().Contain("await Task.Delay(150);",
             "the Fixed Window hotkey should preserve its existing delayed selection flow");
@@ -476,6 +493,22 @@ public class KanbanTodoUxRegressionTests
         fixedHotkeySnippet.Should().Contain("FixedWindowService.Instance.Show()");
         fixedHotkeySnippet.Should().NotContain("MiniWindowService.Instance.ShowWithText(text)");
         fixedHotkeySnippet.Should().NotContain("MiniWindowService.Instance.Show()");
+
+        // Toggle behavior (issue #194) for the Fixed Window hotkey, mirroring the
+        // mini window contract above.
+        fixedHotkeySnippet.Should().Contain("if (fixedWindow.IsVisible && fixedWindow.IsForeground)",
+            "the Fixed Window hotkey should hide the foreground window on repeated press");
+        fixedHotkeySnippet.Should().Contain("fixedWindow.Hide();",
+            "the toggle path should hide the fixed window instead of re-showing it");
+        AssertContainsInOrder(
+            fixedHotkeySnippet,
+            "fixedWindow.Hide();",
+            "await Task.Delay(150);",
+            "hiding the fixed window must not wait for the selection-capture delay");
+        fixedHotkeySnippet.Should().Contain("FixedWindowService.Instance.EnsureCreated()",
+            "first show should pre-create the fixed window so XAML inflation overlaps the selection-capture wait");
+        fixedServiceCode.Should().Contain("public void EnsureCreated()",
+            "the fixed window service should expose hidden pre-creation for the hotkey warm-up");
     }
 
     private static string FindProjectRoot()

--- a/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceInputTests.cs
+++ b/dotnet/tests/Easydict.WinUI.Tests/Services/TextSelectionServiceInputTests.cs
@@ -1,0 +1,53 @@
+using Easydict.WinUI.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Easydict.WinUI.Tests.Services;
+
+[Trait("Category", "WinUI")]
+public class TextSelectionServiceInputTests
+{
+    private const uint KeyeventfExtendedkey = 0x0001;
+    private const uint KeyeventfKeyup = 0x0002;
+    private const ushort VkControl = 0x11;
+    private const ushort VkC = 0x43;
+    private const ushort VkRShift = 0xA1;
+    private const ushort VkRControl = 0xA3;
+    private const ushort VkRMenu = 0xA5;
+
+    [Fact]
+    public void BuildCtrlCInputs_WithRightSideModifiers_PreservesExactSides()
+    {
+        var heldModifiers =
+            TextSelectionService.HeldModifierKeys.RightControl |
+            TextSelectionService.HeldModifierKeys.RightAlt |
+            TextSelectionService.HeldModifierKeys.RightShift;
+
+        var inputs = TextSelectionService.BuildCtrlCInputs(heldModifiers);
+
+        inputs.Select(input => (input.U.ki.wVk, input.U.ki.dwFlags)).Should().Equal(
+            (VkRMenu, KeyeventfExtendedkey | KeyeventfKeyup),
+            (VkRShift, KeyeventfKeyup),
+            (VkC, 0u),
+            (VkC, KeyeventfKeyup),
+            (VkRMenu, KeyeventfExtendedkey),
+            (VkRShift, 0u));
+        inputs.Should().NotContain(input => input.U.ki.wVk == VkRControl,
+            "a physically held Ctrl side must not receive synthetic down/up events");
+    }
+
+    [Fact]
+    public void BuildCtrlCInputs_WithoutHeldControl_SynthesizesCtrlAroundC()
+    {
+        var inputs = TextSelectionService.BuildCtrlCInputs(
+            TextSelectionService.HeldModifierKeys.RightAlt);
+
+        inputs.Select(input => (input.U.ki.wVk, input.U.ki.dwFlags)).Should().Equal(
+            (VkRMenu, KeyeventfExtendedkey | KeyeventfKeyup),
+            (VkControl, 0u),
+            (VkC, 0u),
+            (VkC, KeyeventfKeyup),
+            (VkControl, KeyeventfKeyup),
+            (VkRMenu, KeyeventfExtendedkey));
+    }
+}


### PR DESCRIPTION
The Ctrl+Alt+M / Ctrl+Alt+F hotkeys could only bring up the mini/fixed window but never close it, unlike the main window hotkey which toggles (issue #123). Pressing the hotkey while the window is foreground now hides it, and the check happens before the 150ms selection-capture delay so closing is instant.

Also pre-create the (hidden) window on a separate dispatcher work item so first-show XAML inflation overlaps the selection-capture wait instead of adding to it, reducing the perceived slowness compared to the main window hotkey.

Fixes #194


Claude-Session: https://claude.ai/code/session_01VXvvTJMLoXwo2Qc5abBDB2